### PR TITLE
Add ad hoc planning path and delivery rules

### DIFF
--- a/agents/documentation.md
+++ b/agents/documentation.md
@@ -83,3 +83,25 @@ A feature or system area is not fully complete if:
 - but the durable documentation remains missing or stale
 
 Documentation completion is part of the delivery contract, not optional polish.
+
+## Durable Planning Note
+
+When work is proceeding on the ad hoc path instead of the feature/specification
+path, documentation still needs a durable project-facing record.
+
+That record should live under:
+
+```text
+project/adhoc/
+```
+
+Ad hoc documentation should capture the developer/project perspective on:
+
+* what changed
+* why it changed
+* what boundaries the change intentionally did not cross
+* how the change was verified
+
+Ad hoc notes are not public feature docs. They are the lightweight durable
+planning/implementation record for bounded work that is not using the full
+feature path.

--- a/agents/git-and-github.md
+++ b/agents/git-and-github.md
@@ -10,8 +10,9 @@ No code changes should be made directly on `main`.
 
 No implementation changes should be made without one of these durable planning anchors:
 
-* an issue, or
+* an issue
 * a specification
+* an ad hoc work document
 
 Implementation work must happen on one of these branch types:
 
@@ -19,6 +20,30 @@ Implementation work must happen on one of these branch types:
 * a feature branch
 
 Documentation-only changes may follow the same rule when they are part of implementation work or PR preparation.
+
+Before implementation begins, the path should be explicit:
+
+* feature path
+* ad hoc path
+
+If the user has not specified which path to use, agents should ask a short
+disambiguating question before proceeding with implementation.
+
+---
+
+## Workspace Repository Policy
+
+For this workspace, active work should happen on a feature branch.
+
+The working rule is:
+
+* do not work directly on `main`
+* create or switch to a feature branch before making changes
+* keep that feature branch focused on one named unit of work
+
+If a bug fix is small enough that the team would otherwise use a bug-fix branch,
+this workspace still prefers a feature branch unless the user explicitly asks
+for a different branch shape.
 
 ---
 
@@ -62,7 +87,7 @@ Issue work must not remain only in GitHub issue text and code history.
 
 Use a feature branch when the work is implementing a new capability, significant enhancement, or planned structural addition.
 
-Feature branches must have an associated specification.
+Feature-path work on a feature branch must have an associated specification.
 
 That specification is the durable record of:
 
@@ -82,6 +107,25 @@ Example:
 feature/voice-session-realization
 ```
 
+## Ad Hoc Work On Feature Branches
+
+This workspace still prefers feature branches for active implementation work,
+including ad hoc work.
+
+When the work is on the ad hoc path rather than the feature path, the feature
+branch should be anchored by an ad hoc work document under:
+
+```text
+project/adhoc/
+```
+
+That document is the durable record of:
+
+* the bounded unit of work
+* why it is being done on the ad hoc path
+* the intended scope
+* expected verification
+
 ---
 
 ## Pull Requests
@@ -96,15 +140,79 @@ For the current team shape:
 
 This keeps branch history, issue or spec linkage, and merge boundaries visible without adding unnecessary process overhead.
 
-For this workspace, "deliver the work" means the full merge path is complete:
+---
 
-1. commit the intended change set on the feature or bug-fix branch
-2. push that branch to the remote
-3. create a pull request
-4. merge the pull request
+## Commit Cadence
 
-Agents should not treat implementation as delivered while it exists only as
-local unpushed commits or as an open unmerged pull request.
+Commit frequently enough to protect meaningful progress.
+
+The goal is not:
+
+* hundreds of tiny noise commits
+
+The goal is also not:
+
+* waiting so long that significant work exists only in the working tree
+
+Preferred cadence:
+
+* commit on reasonable units of work
+* commit when a meaningful sub-part is stable
+* commit earlier when the user explicitly asks for it
+
+---
+
+## Push Cadence
+
+Push when a reasonable unit of work has been completed.
+
+Push earlier when the user explicitly asks for it.
+
+Agents should not leave completed work stranded only in local commits longer
+than necessary.
+
+---
+
+## Pull Request Cadence
+
+When asked to create a pull request, agents should:
+
+1. ensure the intended unit of work is committed
+2. push the branch
+3. create the pull request
+
+Agents should not merge the pull request unless the user explicitly asks for
+that merge.
+
+---
+
+## Merge Cadence
+
+Merge pull requests when the user explicitly asks for the merge.
+
+Merging a pull request is the completion of a feature branch for that unit of
+work.
+
+Until the pull request is merged, the work should be treated as branch work in
+progress, not finished repository integration.
+
+---
+
+## Delivery Meaning
+
+To deliver a named group of work means to follow the repository policy to
+completion for that unit of work.
+
+That means:
+
+1. perform the work on a feature branch
+2. commit it in reasonable units
+3. push the branch when the unit is ready
+4. create the pull request when asked
+5. merge the pull request when asked
+
+Agents should not describe work as delivered if it exists only as uncommitted
+changes, only as local commits, or only as an open unmerged pull request.
 
 ---
 
@@ -113,20 +221,21 @@ local unpushed commits or as an open unmerged pull request.
 Before making code changes, agents should ensure that:
 
 1. the current branch is not `main`
-2. the branch is clearly a bug-fix branch or a feature branch
-3. the work is anchored by either an issue or a specification
+2. the branch is clearly a feature branch for this workspace unless the user explicitly directs otherwise
+3. the work is anchored by an issue, a specification, or an ad hoc work document
 4. bug-fix work links to an issue
-5. feature work links to a specification
-6. issue-driven work is back-referenced into the architecture/specification tree
+5. feature-path work links to a specification
+6. ad-hoc-path work links to an ad hoc work document
+7. issue-driven work is back-referenced into the architecture/specification tree when appropriate
 
 If those conditions are not met, agents should stop and create or switch to the correct branching context before proceeding with code changes.
 
 When the user asks to "deliver" work, agents should also ensure that:
 
-7. the intended change set is committed
-8. the branch is pushed
-9. a pull request is created
-10. the pull request is merged
+8. the intended change set is committed in reasonable units
+9. the branch is pushed
+10. a pull request is created when requested
+11. the pull request is merged when requested
 
 ---
 
@@ -135,6 +244,7 @@ When the user asks to "deliver" work, agents should also ensure that:
 Use branches and pull requests to keep implementation intent visible.
 
 Issues define fixes.
-Specifications define features.
-Architecture/specification documents preserve durable project truth.
+Specifications define feature-path work.
+Ad hoc documents define bounded ad-hoc-path work.
+Architecture/specification/adhoc documents preserve durable project truth.
 Pull requests define merge boundaries.

--- a/agents/index.md
+++ b/agents/index.md
@@ -56,6 +56,7 @@ project/
   ui/
   product-definition.md
   architecture/
+  adhoc/
   specifications/
   test-specifications/
   planning/
@@ -88,8 +89,9 @@ When beginning work:
 5. review relevant UI definitions
 6. review `ui-ux-invariants.md` for interface work
 7. review relevant architecture
-8. follow the workflow defined in `workflow.md`
-9. if using sub-agents, review `delegation.md` before assigning work
+8. determine whether the work is following the feature path or the ad hoc path
+9. follow the workflow defined in `workflow.md`
+10. if using sub-agents, review `delegation.md` before assigning work
 
 ---
 

--- a/agents/workflow.md
+++ b/agents/workflow.md
@@ -26,6 +26,15 @@ project/agents/
 
 Agents should consult that folder before substantial work begins and keep project-specific operating rules there rather than scattering them through transient discussion.
 
+Project ad hoc planning documents live in:
+
+```text
+project/adhoc/
+```
+
+That folder is the lightweight durable-planning path for bounded work that does
+not need full feature-branch specification refinement first.
+
 Repository-wide branching and pull request rules are defined in:
 
 ```text
@@ -34,13 +43,15 @@ agents/git-and-github.md
 
 Agents should satisfy those branch and PR requirements before making code changes.
 
-When a user asks for delivery rather than only local implementation, the work is
-not complete until the repository workflow has also been finished:
+For this workspace, repository delivery should be understood as a staged flow:
 
-* commit the intended change set
-* push the branch
-* create a pull request
-* merge the pull request
+* work on a feature branch, not `main`
+* commit in reasonable units as progress stabilizes
+* push when a unit of work is complete or when explicitly asked
+* create a pull request when explicitly asked
+* merge the pull request when explicitly asked
+
+Merging the pull request is the completion of that feature branch's work.
 
 When work is executed through sub-agents, the delegation model, ownership boundaries, waiting rules, and review requirements are defined in:
 
@@ -52,6 +63,7 @@ Implementation work must not begin without a durable planning anchor:
 
 * an issue for bug-fix work, or
 * a specification for feature work
+* an ad hoc work document for ad-hoc-path work
 
 UI definition guidance is defined in:
 
@@ -94,6 +106,14 @@ Project test specification documents should live in:
 ```text
 project/test-specifications/
 ```
+
+Before implementation begins, the user should specify which path is being used:
+
+* feature path
+* ad hoc path
+
+If the user does not specify, agents should ask a short disambiguating question
+before implementation begins.
 
 ---
 
@@ -257,6 +277,37 @@ Agents should expect to:
 * create child specifications where needed
 * review those children in later rounds
 * continue refining downward until the tree consists of implementation-sized final leaves
+
+---
+
+## Ad Hoc Path
+
+The ad hoc path exists for small, real implementation work that should still
+gain durable project-facing documentation without being blocked on heavy feature
+spec refinement.
+
+Use the ad hoc path when:
+
+* the work is bounded and concrete
+* the work needs more durable context than chat history
+* the work does not justify full architecture-to-specification expansion first
+
+Ad hoc work should be recorded under:
+
+```text
+project/adhoc/
+```
+
+Each ad hoc document should describe:
+
+* what is changing
+* why it is changing
+* the scope boundary
+* expected verification
+* any maintenance or usage notes that matter later
+
+Ad hoc work is not a substitute for the feature path when the change truly
+needs architecture/specification refinement.
 
 The intended result is a specification tree, not a flat one-pass list.
 

--- a/project/README.md
+++ b/project/README.md
@@ -12,6 +12,7 @@ and developer-facing product documentation.
 - [Future Features](future-features.md)
 - [Planning](planning/README.md)
 - [Architecture](architecture/README.md)
+- [Ad Hoc Work](adhoc/README.md)
 - [Specifications](specifications/README.md)
 - [Research](research/)
 - [Issues](issues/)

--- a/project/adhoc/2026-04-24-agent-repo-path-and-delivery-rules.md
+++ b/project/adhoc/2026-04-24-agent-repo-path-and-delivery-rules.md
@@ -1,0 +1,56 @@
+# Agent Repo Path And Delivery Rules
+
+- Date: 2026-04-24
+- Status: delivered through repo workflow
+- Path: ad hoc
+
+## Summary
+
+This ad hoc work adds a lightweight planning path alongside feature/spec work
+and tightens the repository delivery rules so agents follow the same workflow
+the project expects.
+
+## Scope
+
+This work covers:
+
+- adding `project/adhoc/` as a durable planning space
+- defining the required choice between feature-path work and ad-hoc-path work
+- clarifying branch, commit, push, PR, merge, and delivery behavior in the
+  agent docs
+
+This work does not create a new feature architecture branch or a new feature
+specification tree.
+
+## Implementation Notes
+
+The rule updates are carried in:
+
+- `agents/git-and-github.md`
+- `agents/workflow.md`
+- `agents/index.md`
+- `agents/documentation.md`
+- `project/agents/index.md`
+- `project/README.md`
+- `project/adhoc/README.md`
+
+The intended operating model is:
+
+- active implementation happens on a feature branch
+- the planning anchor is either a specification or an ad hoc work document
+- the user must choose feature path or ad hoc path before implementation begins
+- if the user does not choose, the agent should ask
+
+## Verification Notes
+
+Validation for this doc/rule change is the repository documentation rules test:
+
+```bash
+./.venv/bin/pytest tests/test_documentation_rules.py -q
+```
+
+## Related Documents
+
+- `agents/git-and-github.md`
+- `agents/workflow.md`
+- `project/adhoc/README.md`

--- a/project/adhoc/README.md
+++ b/project/adhoc/README.md
@@ -1,0 +1,71 @@
+# Ad Hoc Work
+
+This folder is the durable planning space for small, named work that should not
+be blocked on heavy feature-spec refinement.
+
+It exists alongside:
+
+- `project/specifications/`
+- `project/test-specifications/`
+- `project/planning/`
+
+Use `project/adhoc/` when the work is real implementation work that still needs
+developer/project-facing documentation, but does not justify a full
+architecture-to-specification branch first.
+
+Examples:
+
+- a new example program
+- a documentation-driven showcase addition
+- a small developer-facing tool or helper
+- a bounded cleanup or structural adjustment that is too large for chat-only
+  context but too small for full feature-tree refinement
+
+## Purpose
+
+An ad hoc document should preserve:
+
+1. what changed
+2. why the change exists
+3. the intended scope boundary
+4. any important usage or maintenance notes
+5. what tests or verification are expected
+
+The goal is to avoid leaving meaningful work justified only by transient chat
+history while still keeping lightweight work lightweight.
+
+## What Ad Hoc Is Not
+
+Ad hoc work is not:
+
+- a replacement for architecture when architecture is actually needed
+- a way to skip feature/test specification work for substantial product changes
+- a place for vague notes with no implementation boundary
+
+If the work changes durable system behavior in a way that needs branching
+architecture or future refinement, it should stay on the feature path.
+
+## Minimum Document Shape
+
+Each ad hoc work item should be its own markdown file under `project/adhoc/`.
+
+Recommended contents:
+
+- title
+- date
+- status
+- summary
+- scope
+- implementation notes
+- verification notes
+- related files or related documents
+
+## Agent Rule
+
+Before implementation begins, the work should be classified as exactly one of:
+
+- feature-path work
+- ad-hoc-path work
+
+If the user has not specified which path to use, agents should ask a short
+disambiguating question before proceeding with implementation.

--- a/project/agents/index.md
+++ b/project/agents/index.md
@@ -20,3 +20,9 @@ Current project-specific rules:
 - [session-handoff.md](session-handoff.md)
   - end-of-work handoff phrase
   - when the agent should explicitly signal that deeper re-engagement is required
+
+Project planning spaces also include:
+
+- [../adhoc/README.md](../adhoc/README.md)
+  - lightweight durable planning for bounded ad hoc work
+  - required choice between feature-path work and ad-hoc-path work before implementation


### PR DESCRIPTION
## Summary
- add a lightweight `project/adhoc/` planning path for bounded ad hoc work
- require an explicit choice between feature-path work and ad-hoc-path work before implementation
- clarify repository delivery, branch, commit, push, PR, and merge rules in the agent docs

## Validation
- ./.venv/bin/pytest tests/test_documentation_rules.py -q