### PR TITLE
Implement 0.1.0.a Feature Spec 01A

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ library, the tools, and the examples.
 - [Mesh Analysis Tools](modeling/mesh-tools.md) - explicit mesh QA and plane-section tools retained for analysis and repair workflows.
 - [Paths](modeling/paths.md) - polyline/spline utilities for sweeps and visualization.
 - [Path3D](modeling/path3d.md) - true-curve 3D paths (line/arc/bezier).
+- [B-Spline Curves](modeling/bspline.md) - first-class authored 2D and 3D B-spline curve ownership.
 - [2D Drawing](modeling/drawing2d.md) - profile and path primitives for vector-style modeling.
 - [Topology](modeling/topology.md) - shared planar loop/region/section helpers used across modeling features.
 - [Loft](modeling/loft.md) - surface-first lofting, explicit station planning, ambiguity diagnostics, and public loft handoff APIs.

--- a/docs/modeling/bspline.md
+++ b/docs/modeling/bspline.md
@@ -1,0 +1,69 @@
+# Modeling — B-Spline Curves
+
+Impression now has first-class B-spline curve primitives for authored 2D and
+3D curve ownership.
+
+```python
+from impression.modeling import BSpline2D, BSpline3D
+```
+
+## Posture
+
+These primitives own authored curve truth:
+
+- control points
+- degree
+- knot vector
+- explicit closure policy
+
+They do not own fitting policy. Parameterization and knot-selection decisions
+for inferred or fitted curves belong to the fit-policy lane, not to the
+primitive object itself.
+
+## BSpline2D
+
+Use `BSpline2D(...)` when the curve is authored in a planar 2D domain.
+
+```python
+curve = BSpline2D(
+    control_points=[(0.0, 0.0), (0.3, 0.8), (0.8, 0.2), (1.0, 0.0)],
+    degree=3,
+    knots=(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0),
+    closure="open",
+)
+```
+
+## BSpline3D
+
+Use `BSpline3D(...)` when the authored curve lives directly in 3D space.
+
+```python
+curve = BSpline3D(
+    control_points=[
+        (0.0, 0.0, 0.0),
+        (0.2, 0.3, 0.5),
+        (0.8, -0.1, 1.0),
+        (1.0, 0.0, 1.2),
+    ],
+    degree=3,
+    knots=(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0),
+    closure="periodic",
+)
+```
+
+## Closure Policy
+
+Closure is explicit and must be one of:
+
+- `"open"`
+- `"closed"`
+- `"periodic"`
+
+Impression does not infer closure from repeated endpoints alone.
+
+## Current Scope
+
+This initial primitive layer is about durable authored ownership.
+
+Evaluation, derivative access, and deterministic sampling are defined in the
+next B-spline execution layer.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -50,6 +50,7 @@ from .loft import (
     loft_endcaps,
 )
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
+from .bspline import BSpline2D, BSpline3D
 from .csg import (
     BooleanOperationError,
     SurfaceBooleanCutCurve,
@@ -205,6 +206,8 @@ __all__ = [
     "Arc3D",
     "Bezier3D",
     "Path3D",
+    "BSpline2D",
+    "BSpline3D",
     "Loft",
     "loft",
     "loft_profiles",

--- a/src/impression/modeling/bspline.py
+++ b/src/impression/modeling/bspline.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+ClosurePolicy = Literal["open", "closed", "periodic"]
+
+
+def _require_point(value: Sequence[float], *, dim: int, label: str) -> np.ndarray:
+    try:
+        arr = np.asarray(value, dtype=float).reshape(dim)
+    except Exception as exc:
+        raise ValueError(f"{label} must be a {dim}D coordinate.") from exc
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{label} must be finite.")
+    return arr
+
+
+def _normalize_control_points(
+    values: Sequence[Sequence[float]],
+    *,
+    dim: int,
+) -> tuple[np.ndarray, ...]:
+    points = tuple(_require_point(value, dim=dim, label="control point") for value in values)
+    if len(points) < 2:
+        raise ValueError("B-spline curves require at least two control points.")
+    return points
+
+
+def _normalize_degree(value: int) -> int:
+    degree = int(value)
+    if degree < 1:
+        raise ValueError("degree must be >= 1.")
+    return degree
+
+
+def _normalize_knots(values: Sequence[float]) -> tuple[float, ...]:
+    knots = tuple(float(v) for v in values)
+    if len(knots) < 4:
+        raise ValueError("knot vector is too short.")
+    if not all(np.isfinite(v) for v in knots):
+        raise ValueError("knot vector values must be finite.")
+    if any(b < a for a, b in zip(knots, knots[1:])):
+        raise ValueError("knot vector must be nondecreasing.")
+    return knots
+
+
+def _normalize_closure(value: str) -> ClosurePolicy:
+    allowed: set[str] = {"open", "closed", "periodic"}
+    closure = str(value)
+    if closure not in allowed:
+        raise ValueError("closure must be one of: open, closed, periodic.")
+    return closure  # type: ignore[return-value]
+
+
+def _validate_shape(
+    control_points: tuple[np.ndarray, ...],
+    degree: int,
+    knots: tuple[float, ...],
+) -> None:
+    if len(control_points) <= degree:
+        raise ValueError("control point count must be greater than degree.")
+    expected = len(control_points) + degree + 1
+    if len(knots) != expected:
+        raise ValueError(
+            "knot vector length must equal control_point_count + degree + 1."
+        )
+
+
+@dataclass(frozen=True)
+class BSpline2D:
+    control_points: tuple[np.ndarray, ...]
+    degree: int
+    knots: tuple[float, ...]
+    closure: ClosurePolicy = "open"
+
+    def __init__(
+        self,
+        control_points: Sequence[Sequence[float]],
+        degree: int,
+        knots: Sequence[float],
+        closure: ClosurePolicy = "open",
+    ) -> None:
+        points = _normalize_control_points(control_points, dim=2)
+        deg = _normalize_degree(degree)
+        knot_vector = _normalize_knots(knots)
+        close = _normalize_closure(closure)
+        _validate_shape(points, deg, knot_vector)
+        object.__setattr__(self, "control_points", points)
+        object.__setattr__(self, "degree", deg)
+        object.__setattr__(self, "knots", knot_vector)
+        object.__setattr__(self, "closure", close)
+
+
+@dataclass(frozen=True)
+class BSpline3D:
+    control_points: tuple[np.ndarray, ...]
+    degree: int
+    knots: tuple[float, ...]
+    closure: ClosurePolicy = "open"
+
+    def __init__(
+        self,
+        control_points: Sequence[Sequence[float]],
+        degree: int,
+        knots: Sequence[float],
+        closure: ClosurePolicy = "open",
+    ) -> None:
+        points = _normalize_control_points(control_points, dim=3)
+        deg = _normalize_degree(degree)
+        knot_vector = _normalize_knots(knots)
+        close = _normalize_closure(closure)
+        _validate_shape(points, deg, knot_vector)
+        object.__setattr__(self, "control_points", points)
+        object.__setattr__(self, "degree", deg)
+        object.__setattr__(self, "knots", knot_vector)
+        object.__setattr__(self, "closure", close)
+
+
+__all__ = ["BSpline2D", "BSpline3D", "ClosurePolicy"]

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from impression.modeling import BSpline2D, BSpline3D
+
+
+def test_bspline2d_owns_explicit_curve_fields():
+    curve = BSpline2D(
+        control_points=[(0.0, 0.0), (0.4, 0.8), (0.8, 0.2), (1.0, 0.0)],
+        degree=3,
+        knots=(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0),
+        closure="closed",
+    )
+
+    assert curve.degree == 3
+    assert curve.closure == "closed"
+    assert curve.knots == (0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0)
+    assert len(curve.control_points) == 4
+    assert np.allclose(curve.control_points[1], [0.4, 0.8])
+
+
+def test_bspline3d_owns_explicit_curve_fields():
+    curve = BSpline3D(
+        control_points=[
+            (0.0, 0.0, 0.0),
+            (0.2, 0.3, 0.5),
+            (0.8, -0.1, 1.0),
+            (1.0, 0.0, 1.2),
+        ],
+        degree=3,
+        knots=(0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0),
+        closure="periodic",
+    )
+
+    assert curve.degree == 3
+    assert curve.closure == "periodic"
+    assert len(curve.control_points) == 4
+    assert np.allclose(curve.control_points[-1], [1.0, 0.0, 1.2])
+
+
+def test_bspline_rejects_missing_owned_knot_vector():
+    with pytest.raises(ValueError):
+        BSpline2D(
+            control_points=[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)],
+            degree=2,
+            knots=(0.0, 0.0, 0.0, 1.0),
+        )
+
+
+def test_bspline_requires_explicit_closure_policy_value():
+    with pytest.raises(ValueError):
+        BSpline3D(
+            control_points=[
+                (0.0, 0.0, 0.0),
+                (0.5, 0.5, 0.5),
+                (1.0, 0.0, 1.0),
+            ],
+            degree=2,
+            knots=(0.0, 0.0, 0.0, 1.0, 1.0, 1.0),
+            closure="auto",
+        )


### PR DESCRIPTION
## Summary
- add first-class `BSpline2D` and `BSpline3D` primitives with explicit control-point, degree, knot-vector, and closure ownership
- export the new primitives from `impression.modeling`
- add targeted primitive-ownership tests and a small modeling doc page

## Verification
- `./.venv/bin/pytest tests/test_bspline.py -q`
- `./.venv/bin/pytest tests/test_path3d.py -q`
