### PR TITLE
Implement 0.1.0.a Feature Spec 02A1

### DIFF
--- a/docs/modeling/bspline.md
+++ b/docs/modeling/bspline.md
@@ -76,3 +76,27 @@ Closure handling is explicit:
 - `"closed"` closes sampled output without guessing closure from repeated
   endpoints alone
 - `"periodic"` wraps parameter evaluation through the authored domain
+
+## Fit Policy Records
+
+Fit-backed workflows should keep parameterization policy explicit rather than
+burying it in helper behavior.
+
+```python
+from impression.modeling import ParameterizationPolicyRecord
+
+policy = ParameterizationPolicyRecord(
+    method="chord_length",
+    domain_start=0.0,
+    domain_end=1.0,
+)
+```
+
+Current initial scope:
+
+- `"uniform"`
+- `"chord_length"`
+- `"centripetal"`
+
+These policy records assign replayable parameter values to ordered evidence
+before later knot and fit-configuration stages run.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -51,6 +51,7 @@ from .loft import (
 )
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 from .bspline import BSpline2D, BSpline3D
+from .fit_records import ParameterizationPolicyRecord
 from .csg import (
     BooleanOperationError,
     SurfaceBooleanCutCurve,
@@ -208,6 +209,7 @@ __all__ = [
     "Path3D",
     "BSpline2D",
     "BSpline3D",
+    "ParameterizationPolicyRecord",
     "Loft",
     "loft",
     "loft_profiles",

--- a/src/impression/modeling/fit_records.py
+++ b/src/impression/modeling/fit_records.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+ParameterizationMethod = Literal["uniform", "chord_length", "centripetal"]
+
+
+def _require_ordered_points(points: Sequence[Sequence[float]]) -> np.ndarray:
+    if len(points) < 2:
+        raise ValueError("parameter assignment requires at least two ordered samples.")
+    arr = np.asarray(points, dtype=float)
+    if arr.ndim != 2 or arr.shape[1] not in (2, 3):
+        raise ValueError("sample points must be a sequence of 2D or 3D coordinates.")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("sample points must be finite.")
+    return arr
+
+
+def _normalize_domain_start(value: float) -> float:
+    start = float(value)
+    if not np.isfinite(start):
+        raise ValueError("domain_start must be finite.")
+    return start
+
+
+def _normalize_domain_end(value: float, *, start: float) -> float:
+    end = float(value)
+    if not np.isfinite(end):
+        raise ValueError("domain_end must be finite.")
+    if end <= start:
+        raise ValueError("domain_end must be greater than domain_start.")
+    return end
+
+
+def _normalize_method(value: str) -> ParameterizationMethod:
+    allowed: set[str] = {"uniform", "chord_length", "centripetal"}
+    method = str(value)
+    if method not in allowed:
+        raise ValueError("method must be one of: uniform, chord_length, centripetal.")
+    return method  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class ParameterizationPolicyRecord:
+    method: ParameterizationMethod = "chord_length"
+    domain_start: float = 0.0
+    domain_end: float = 1.0
+
+    def __init__(
+        self,
+        method: ParameterizationMethod = "chord_length",
+        domain_start: float = 0.0,
+        domain_end: float = 1.0,
+    ) -> None:
+        normalized_method = _normalize_method(method)
+        start = _normalize_domain_start(domain_start)
+        end = _normalize_domain_end(domain_end, start=start)
+        object.__setattr__(self, "method", normalized_method)
+        object.__setattr__(self, "domain_start", start)
+        object.__setattr__(self, "domain_end", end)
+
+    def assign_parameters(self, samples: Sequence[Sequence[float]]) -> np.ndarray:
+        points = _require_ordered_points(samples)
+        base = self._base_parameters(points)
+        return self.domain_start + (self.domain_end - self.domain_start) * base
+
+    def _base_parameters(self, points: np.ndarray) -> np.ndarray:
+        if self.method == "uniform":
+            return np.linspace(0.0, 1.0, len(points), dtype=float)
+
+        deltas = np.linalg.norm(np.diff(points, axis=0), axis=1)
+        if self.method == "centripetal":
+            deltas = np.sqrt(deltas)
+
+        cumulative = np.concatenate([[0.0], np.cumsum(deltas)])
+        total = float(cumulative[-1])
+        if total == 0.0:
+            return np.linspace(0.0, 1.0, len(points), dtype=float)
+        return cumulative / total
+
+
+__all__ = ["ParameterizationMethod", "ParameterizationPolicyRecord"]

--- a/tests/test_fit_records.py
+++ b/tests/test_fit_records.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import numpy as np
+
+from impression.modeling import ParameterizationPolicyRecord
+
+
+def test_parameterization_policy_record_accepts_explicit_initial_scope_choices():
+    policy = ParameterizationPolicyRecord(
+        method="centripetal",
+        domain_start=2.0,
+        domain_end=5.0,
+    )
+
+    assert policy.method == "centripetal"
+    assert policy.domain_start == 2.0
+    assert policy.domain_end == 5.0
+
+
+def test_identical_evidence_and_policy_reproduce_identical_parameter_assignments():
+    policy = ParameterizationPolicyRecord(
+        method="chord_length",
+        domain_start=0.0,
+        domain_end=1.0,
+    )
+    points = [(0.0, 0.0), (0.3, 0.4), (0.9, 0.9), (1.2, 1.0)]
+
+    first = policy.assign_parameters(points)
+    second = policy.assign_parameters(points)
+
+    assert np.allclose(first, second)
+
+
+def test_parameterization_policy_is_durable_for_replay():
+    policy = ParameterizationPolicyRecord(
+        method="uniform",
+        domain_start=-1.0,
+        domain_end=1.0,
+    )
+    values = policy.assign_parameters([(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)])
+
+    assert np.allclose(values, [-1.0, 0.0, 1.0])
+
+
+def test_parameterization_policy_choices_are_visible_to_fit_consumers():
+    policy = ParameterizationPolicyRecord(
+        method="chord_length",
+        domain_start=10.0,
+        domain_end=20.0,
+    )
+
+    assert policy.method == "chord_length"
+    assert policy.domain_start == 10.0
+    assert policy.domain_end == 20.0


### PR DESCRIPTION
## Summary
- add a first-class `ParameterizationPolicyRecord` for replayable parameter assignment
- support explicit uniform, chord-length, and centripetal methods with explicit domain bounds
- add targeted tests and docs for the initial fit-policy scope

## Verification
- `./.venv/bin/pytest tests/test_fit_records.py -q`
- `./.venv/bin/pytest tests/test_bspline.py -q`
