### PR TITLE
Implement 0.1.0.a Feature Spec 02A2

### DIFF
--- a/docs/modeling/bspline.md
+++ b/docs/modeling/bspline.md
@@ -100,3 +100,18 @@ Current initial scope:
 
 These policy records assign replayable parameter values to ordered evidence
 before later knot and fit-configuration stages run.
+
+Knot policy is also explicit:
+
+```python
+from impression.modeling import KnotCountPolicyRecord, KnotPlacementPolicyRecord
+
+count_policy = KnotCountPolicyRecord(strategy="fixed", control_point_count=6)
+placement_policy = KnotPlacementPolicyRecord(placement_method="average_parameter")
+```
+
+Initial knot-policy scope:
+
+- fixed control-point count selection
+- uniform internal knot placement
+- average-parameter knot placement

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -51,7 +51,11 @@ from .loft import (
 )
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 from .bspline import BSpline2D, BSpline3D
-from .fit_records import ParameterizationPolicyRecord
+from .fit_records import (
+    KnotCountPolicyRecord,
+    KnotPlacementPolicyRecord,
+    ParameterizationPolicyRecord,
+)
 from .csg import (
     BooleanOperationError,
     SurfaceBooleanCutCurve,
@@ -209,6 +213,8 @@ __all__ = [
     "Path3D",
     "BSpline2D",
     "BSpline3D",
+    "KnotCountPolicyRecord",
+    "KnotPlacementPolicyRecord",
     "ParameterizationPolicyRecord",
     "Loft",
     "loft",

--- a/src/impression/modeling/fit_records.py
+++ b/src/impression/modeling/fit_records.py
@@ -6,6 +6,8 @@ from typing import Literal, Sequence
 import numpy as np
 
 ParameterizationMethod = Literal["uniform", "chord_length", "centripetal"]
+KnotCountStrategy = Literal["fixed"]
+KnotPlacementMethod = Literal["uniform_internal", "average_parameter"]
 
 
 def _require_ordered_points(points: Sequence[Sequence[float]]) -> np.ndarray:
@@ -40,6 +42,29 @@ def _normalize_method(value: str) -> ParameterizationMethod:
     method = str(value)
     if method not in allowed:
         raise ValueError("method must be one of: uniform, chord_length, centripetal.")
+    return method  # type: ignore[return-value]
+
+
+def _normalize_knot_count_strategy(value: str) -> KnotCountStrategy:
+    allowed: set[str] = {"fixed"}
+    strategy = str(value)
+    if strategy not in allowed:
+        raise ValueError("strategy must be one of: fixed.")
+    return strategy  # type: ignore[return-value]
+
+
+def _normalize_positive_int(value: int, *, label: str) -> int:
+    normalized = int(value)
+    if normalized < 1:
+        raise ValueError(f"{label} must be >= 1.")
+    return normalized
+
+
+def _normalize_knot_placement_method(value: str) -> KnotPlacementMethod:
+    allowed: set[str] = {"uniform_internal", "average_parameter"}
+    method = str(value)
+    if method not in allowed:
+        raise ValueError("placement_method must be one of: uniform_internal, average_parameter.")
     return method  # type: ignore[return-value]
 
 
@@ -82,4 +107,101 @@ class ParameterizationPolicyRecord:
         return cumulative / total
 
 
-__all__ = ["ParameterizationMethod", "ParameterizationPolicyRecord"]
+@dataclass(frozen=True)
+class KnotCountPolicyRecord:
+    strategy: KnotCountStrategy = "fixed"
+    control_point_count: int = 4
+
+    def __init__(
+        self,
+        strategy: KnotCountStrategy = "fixed",
+        control_point_count: int = 4,
+    ) -> None:
+        normalized_strategy = _normalize_knot_count_strategy(strategy)
+        normalized_count = _normalize_positive_int(
+            control_point_count,
+            label="control_point_count",
+        )
+        object.__setattr__(self, "strategy", normalized_strategy)
+        object.__setattr__(self, "control_point_count", normalized_count)
+
+    def resolve_control_point_count(self, *, sample_count: int, degree: int) -> int:
+        sample_total = _normalize_positive_int(sample_count, label="sample_count")
+        deg = _normalize_positive_int(degree, label="degree")
+        if self.control_point_count <= deg:
+            raise ValueError("control_point_count must be greater than degree.")
+        if self.control_point_count > sample_total:
+            raise ValueError("control_point_count must not exceed sample_count.")
+        return self.control_point_count
+
+
+@dataclass(frozen=True)
+class KnotPlacementPolicyRecord:
+    placement_method: KnotPlacementMethod = "uniform_internal"
+
+    def __init__(self, placement_method: KnotPlacementMethod = "uniform_internal") -> None:
+        object.__setattr__(
+            self,
+            "placement_method",
+            _normalize_knot_placement_method(placement_method),
+        )
+
+    def build_knot_vector(
+        self,
+        parameters: Sequence[float],
+        *,
+        control_point_count: int,
+        degree: int,
+    ) -> tuple[float, ...]:
+        params = np.asarray(parameters, dtype=float).reshape(-1)
+        if params.size < 2:
+            raise ValueError("parameters must contain at least two values.")
+        if not np.all(np.isfinite(params)):
+            raise ValueError("parameters must be finite.")
+        if np.any(np.diff(params) < 0):
+            raise ValueError("parameters must be nondecreasing.")
+
+        ctrl_count = _normalize_positive_int(control_point_count, label="control_point_count")
+        deg = _normalize_positive_int(degree, label="degree")
+        if ctrl_count <= deg:
+            raise ValueError("control_point_count must be greater than degree.")
+
+        expected_knots = ctrl_count + deg + 1
+        internal_count = expected_knots - 2 * (deg + 1)
+        start = float(params[0])
+        end = float(params[-1])
+        if end <= start:
+            raise ValueError("parameter domain must be increasing.")
+
+        internal: np.ndarray
+        if internal_count <= 0:
+            internal = np.zeros((0,), dtype=float)
+        elif self.placement_method == "uniform_internal":
+            internal = np.linspace(start, end, internal_count + 2, dtype=float)[1:-1]
+        else:
+            internal = np.array(
+                [
+                    float(np.mean(params[j + 1 : j + deg + 1]))
+                    for j in range(internal_count)
+                ],
+                dtype=float,
+            )
+
+        knots = np.concatenate(
+            [
+                np.full(deg + 1, start, dtype=float),
+                internal,
+                np.full(deg + 1, end, dtype=float),
+            ]
+        )
+        return tuple(float(v) for v in knots)
+
+
+__all__ = [
+    "KnotCountPolicyRecord",
+    "KnotCountStrategy",
+    "KnotPlacementMethod",
+    "KnotPlacementPolicyRecord",
+    "ParameterizationMethod",
+    "ParameterizationPolicyRecord",
+]

--- a/tests/test_fit_records.py
+++ b/tests/test_fit_records.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from impression.modeling import ParameterizationPolicyRecord
+from impression.modeling import (
+    KnotCountPolicyRecord,
+    KnotPlacementPolicyRecord,
+    ParameterizationPolicyRecord,
+)
 
 
 def test_parameterization_policy_record_accepts_explicit_initial_scope_choices():
@@ -52,3 +56,37 @@ def test_parameterization_policy_choices_are_visible_to_fit_consumers():
     assert policy.method == "chord_length"
     assert policy.domain_start == 10.0
     assert policy.domain_end == 20.0
+
+
+def test_knot_count_policy_record_accepts_explicit_initial_scope_choices():
+    policy = KnotCountPolicyRecord(strategy="fixed", control_point_count=6)
+
+    assert policy.strategy == "fixed"
+    assert policy.control_point_count == 6
+    assert policy.resolve_control_point_count(sample_count=10, degree=3) == 6
+
+
+def test_knot_placement_policy_record_is_inspectable_for_later_fit_inputs():
+    policy = KnotPlacementPolicyRecord(placement_method="average_parameter")
+
+    assert policy.placement_method == "average_parameter"
+
+
+def test_knot_count_policy_is_durable_and_replayable():
+    policy = KnotCountPolicyRecord(strategy="fixed", control_point_count=5)
+
+    first = policy.resolve_control_point_count(sample_count=9, degree=3)
+    second = policy.resolve_control_point_count(sample_count=9, degree=3)
+
+    assert first == second == 5
+
+
+def test_knot_placement_policy_is_durable_and_replayable():
+    policy = KnotPlacementPolicyRecord(placement_method="uniform_internal")
+    parameters = (0.0, 0.2, 0.6, 1.0)
+
+    first = policy.build_knot_vector(parameters, control_point_count=4, degree=2)
+    second = policy.build_knot_vector(parameters, control_point_count=4, degree=2)
+
+    assert first == second
+    assert first == (0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0)


### PR DESCRIPTION
## Summary
- add explicit knot-count and knot-placement policy record types
- add deterministic initial helpers for fixed control-point count selection and initial knot-vector construction
- extend fit-policy tests and docs for the new knot-policy layer

## Verification
- `./.venv/bin/pytest tests/test_fit_records.py -q`
- `./.venv/bin/pytest tests/test_bspline.py -q`
