### PR TITLE
Implement 0.1.0.a Feature Spec 02A3

### DIFF
--- a/docs/modeling/bspline.md
+++ b/docs/modeling/bspline.md
@@ -115,3 +115,26 @@ Initial knot-policy scope:
 - fixed control-point count selection
 - uniform internal knot placement
 - average-parameter knot placement
+
+Fit configuration is bundled explicitly too:
+
+```python
+from impression.modeling import (
+    FitConfigurationRecord,
+    KnotCountPolicyRecord,
+    KnotPlacementPolicyRecord,
+    ParameterizationPolicyRecord,
+)
+
+fit_config = FitConfigurationRecord(
+    parameterization_policy=ParameterizationPolicyRecord(method="chord_length"),
+    knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=6),
+    knot_placement_policy=KnotPlacementPolicyRecord(
+        placement_method="average_parameter"
+    ),
+)
+```
+
+`FitConfigurationRecord` gives later inference and diagnostics branches one
+durable object and one stable identity to point back to when they need to say
+exactly which fit-policy bundle produced a candidate curve.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -52,6 +52,7 @@ from .loft import (
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
+    FitConfigurationRecord,
     KnotCountPolicyRecord,
     KnotPlacementPolicyRecord,
     ParameterizationPolicyRecord,
@@ -213,6 +214,7 @@ __all__ = [
     "Path3D",
     "BSpline2D",
     "BSpline3D",
+    "FitConfigurationRecord",
     "KnotCountPolicyRecord",
     "KnotPlacementPolicyRecord",
     "ParameterizationPolicyRecord",

--- a/src/impression/modeling/fit_records.py
+++ b/src/impression/modeling/fit_records.py
@@ -197,7 +197,35 @@ class KnotPlacementPolicyRecord:
         return tuple(float(v) for v in knots)
 
 
+@dataclass(frozen=True)
+class FitConfigurationRecord:
+    parameterization_policy: ParameterizationPolicyRecord
+    knot_count_policy: KnotCountPolicyRecord
+    knot_placement_policy: KnotPlacementPolicyRecord
+
+    def __init__(
+        self,
+        *,
+        parameterization_policy: ParameterizationPolicyRecord,
+        knot_count_policy: KnotCountPolicyRecord,
+        knot_placement_policy: KnotPlacementPolicyRecord,
+    ) -> None:
+        object.__setattr__(self, "parameterization_policy", parameterization_policy)
+        object.__setattr__(self, "knot_count_policy", knot_count_policy)
+        object.__setattr__(self, "knot_placement_policy", knot_placement_policy)
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "fit_configuration",
+            self.parameterization_policy,
+            self.knot_count_policy,
+            self.knot_placement_policy,
+        )
+
+
 __all__ = [
+    "FitConfigurationRecord",
     "KnotCountPolicyRecord",
     "KnotCountStrategy",
     "KnotPlacementMethod",

--- a/tests/test_fit_records.py
+++ b/tests/test_fit_records.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from impression.modeling import (
+    FitConfigurationRecord,
     KnotCountPolicyRecord,
     KnotPlacementPolicyRecord,
     ParameterizationPolicyRecord,
@@ -90,3 +91,84 @@ def test_knot_placement_policy_is_durable_and_replayable():
 
     assert first == second
     assert first == (0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0)
+
+
+def test_fit_configuration_record_references_parameterization_and_knot_policies():
+    parameterization = ParameterizationPolicyRecord(method="centripetal")
+    knot_count = KnotCountPolicyRecord(strategy="fixed", control_point_count=6)
+    knot_placement = KnotPlacementPolicyRecord(placement_method="average_parameter")
+
+    config = FitConfigurationRecord(
+        parameterization_policy=parameterization,
+        knot_count_policy=knot_count,
+        knot_placement_policy=knot_placement,
+    )
+
+    assert config.parameterization_policy is parameterization
+    assert config.knot_count_policy is knot_count
+    assert config.knot_placement_policy is knot_placement
+
+
+def test_fit_configuration_identity_is_inspectable_from_later_fit_results():
+    config = FitConfigurationRecord(
+        parameterization_policy=ParameterizationPolicyRecord(method="uniform"),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=5),
+        knot_placement_policy=KnotPlacementPolicyRecord(
+            placement_method="uniform_internal"
+        ),
+    )
+    later_fit_result = {"fit_configuration_identity": config.identity}
+
+    assert later_fit_result["fit_configuration_identity"] == config.identity
+
+
+def test_fit_configuration_is_durable_and_replayable():
+    config = FitConfigurationRecord(
+        parameterization_policy=ParameterizationPolicyRecord(
+            method="chord_length",
+            domain_start=2.0,
+            domain_end=3.0,
+        ),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=7),
+        knot_placement_policy=KnotPlacementPolicyRecord(
+            placement_method="average_parameter"
+        ),
+    )
+
+    first = config.identity
+    second = config.identity
+
+    assert first == second
+
+
+def test_later_inference_branches_can_link_to_the_exact_fit_configuration_used():
+    config = FitConfigurationRecord(
+        parameterization_policy=ParameterizationPolicyRecord(method="centripetal"),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=4),
+        knot_placement_policy=KnotPlacementPolicyRecord(
+            placement_method="uniform_internal"
+        ),
+    )
+    inference_branch_record = {
+        "fit_configuration": config,
+        "fit_configuration_identity": config.identity,
+    }
+
+    assert inference_branch_record["fit_configuration"] == config
+    assert inference_branch_record["fit_configuration_identity"] == config.identity
+
+
+def test_fit_configuration_comparison_remains_stable_across_identical_inputs():
+    kwargs = dict(
+        parameterization_policy=ParameterizationPolicyRecord(method="uniform"),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=5),
+        knot_placement_policy=KnotPlacementPolicyRecord(
+            placement_method="average_parameter"
+        ),
+    )
+
+    first = FitConfigurationRecord(**kwargs)
+    second = FitConfigurationRecord(**kwargs)
+
+    assert first == second
+    assert first.identity == second.identity


### PR DESCRIPTION
## Summary
- add a durable fit configuration record that bundles parameterization and knot policies
- expose a stable configuration identity for replay, diagnostics, and later inference linkage
- extend fit-record tests and B-spline docs for the new configuration contract

## Testing
- ./.venv/bin/pytest tests/test_fit_records.py -q
- ./.venv/bin/pytest tests/test_bspline.py -q
