### PR TITLE
Implement 0.1.0.a Feature Spec 08A

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ library, the tools, and the examples.
 - [Paths](modeling/paths.md) - polyline/spline utilities for sweeps and visualization.
 - [Path3D](modeling/path3d.md) - true-curve 3D paths (line/arc/bezier).
 - [B-Spline Curves](modeling/bspline.md) - first-class authored 2D and 3D B-spline curve ownership.
+- [Progression](modeling/progression.md) - path-backed loft travel semantics with explicit provenance.
 - [2D Drawing](modeling/drawing2d.md) - profile and path primitives for vector-style modeling.
 - [Topology](modeling/topology.md) - shared planar loop/region/section helpers used across modeling features.
 - [Loft](modeling/loft.md) - surface-first lofting, explicit station planning, ambiguity diagnostics, and public loft handoff APIs.

--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -1,0 +1,42 @@
+# Modeling — Progression
+
+`PathBackedProgression` is the first `0.1.0.a` step toward treating progression
+as a semantic object built on `Path3D`, rather than as loose scalar arrays.
+
+```python
+from impression.modeling import Path3D, PathBackedProgression
+
+path = Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.0, 1.0), (0.4, 0.1, 2.0)])
+progression = PathBackedProgression(path=path)
+```
+
+## Ownership
+
+The progression object owns:
+
+- the underlying `Path3D` spine reference
+- the parameter domain for travel along that spine
+- explicit-vs-inferred provenance
+
+It does **not** replace `Path3D`. The path remains the geometric carrier; the
+progression object owns the loft-travel semantics around that carrier.
+
+## Provenance
+
+Use `ProgressionProvenanceRecord` to keep authored and inferred progression
+explicit and inspectable:
+
+```python
+from impression.modeling import ProgressionProvenanceRecord
+
+provenance = ProgressionProvenanceRecord(
+    kind="inferred",
+    source="dense_station_inference",
+)
+```
+
+This first milestone keeps the contract intentionally small:
+
+- progression identity is stable and replayable
+- progression is distinct from the raw path primitive
+- later station-attachment and transport semantics can build on this object

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -50,6 +50,11 @@ from .loft import (
     loft_endcaps,
 )
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
+from .progression import (
+    PathBackedProgression,
+    ProgressionProvenanceKind,
+    ProgressionProvenanceRecord,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -216,6 +221,9 @@ __all__ = [
     "Arc3D",
     "Bezier3D",
     "Path3D",
+    "PathBackedProgression",
+    "ProgressionProvenanceKind",
+    "ProgressionProvenanceRecord",
     "BSpline2D",
     "BSpline3D",
     "FitApproximationPosture",

--- a/src/impression/modeling/progression.py
+++ b/src/impression/modeling/progression.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .path3d import Arc3D, Bezier3D, Line3D, Path3D
+
+ProgressionProvenanceKind = Literal["explicit", "inferred"]
+
+
+def _normalize_progression_provenance_kind(value: str) -> ProgressionProvenanceKind:
+    allowed: set[str] = {"explicit", "inferred"}
+    kind = str(value)
+    if kind not in allowed:
+        raise ValueError("kind must be one of: explicit, inferred.")
+    return kind  # type: ignore[return-value]
+
+
+def _segment_signature(segment: Line3D | Arc3D | Bezier3D) -> tuple[object, ...]:
+    if isinstance(segment, Line3D):
+        return (
+            "line",
+            tuple(float(v) for v in segment.start),
+            tuple(float(v) for v in segment.end),
+        )
+    if isinstance(segment, Arc3D):
+        return (
+            "arc",
+            tuple(float(v) for v in segment.center),
+            float(segment.radius),
+            float(segment.start_angle_deg),
+            float(segment.end_angle_deg),
+            tuple(float(v) for v in segment.normal),
+            bool(segment.clockwise),
+        )
+    return (
+        "bezier",
+        tuple(float(v) for v in segment.p0),
+        tuple(float(v) for v in segment.p1),
+        tuple(float(v) for v in segment.p2),
+        tuple(float(v) for v in segment.p3),
+    )
+
+
+@dataclass(frozen=True)
+class ProgressionProvenanceRecord:
+    kind: ProgressionProvenanceKind = "explicit"
+    source: str = "authored_path"
+
+    def __init__(
+        self,
+        kind: ProgressionProvenanceKind = "explicit",
+        source: str = "authored_path",
+    ) -> None:
+        normalized_kind = _normalize_progression_provenance_kind(kind)
+        normalized_source = str(source).strip()
+        if not normalized_source:
+            raise ValueError("source must be non-empty.")
+        object.__setattr__(self, "kind", normalized_kind)
+        object.__setattr__(self, "source", normalized_source)
+
+
+@dataclass(frozen=True)
+class PathBackedProgression:
+    path: Path3D
+    domain_start: float = 0.0
+    domain_end: float = 1.0
+    provenance: ProgressionProvenanceRecord = ProgressionProvenanceRecord()
+
+    def __init__(
+        self,
+        *,
+        path: Path3D,
+        domain_start: float = 0.0,
+        domain_end: float = 1.0,
+        provenance: ProgressionProvenanceRecord | None = None,
+    ) -> None:
+        if not isinstance(path, Path3D):
+            raise ValueError("path must be a Path3D.")
+        start = float(domain_start)
+        end = float(domain_end)
+        if not np.isfinite(start):
+            raise ValueError("domain_start must be finite.")
+        if not np.isfinite(end):
+            raise ValueError("domain_end must be finite.")
+        if end <= start:
+            raise ValueError("domain_end must be greater than domain_start.")
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "domain_start", start)
+        object.__setattr__(self, "domain_end", end)
+        object.__setattr__(
+            self,
+            "provenance",
+            provenance if provenance is not None else ProgressionProvenanceRecord(),
+        )
+
+    @property
+    def parameter_domain(self) -> tuple[float, float]:
+        return (self.domain_start, self.domain_end)
+
+    @property
+    def path_signature(self) -> tuple[object, ...]:
+        return (
+            "path3d",
+            bool(self.path.closed),
+            tuple(_segment_signature(segment) for segment in self.path.segments),
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "path_backed_progression",
+            self.path_signature,
+            self.parameter_domain,
+            self.provenance,
+        )
+
+
+__all__ = [
+    "PathBackedProgression",
+    "ProgressionProvenanceKind",
+    "ProgressionProvenanceRecord",
+]

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    Line3D,
+    Path3D,
+    PathBackedProgression,
+    ProgressionProvenanceRecord,
+)
+
+
+def test_progression_objects_reference_an_underlying_path_explicitly() -> None:
+    path = Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)])
+    progression = PathBackedProgression(path=path)
+
+    assert progression.path is path
+    assert progression.parameter_domain == (0.0, 1.0)
+
+
+def test_explicit_vs_inferred_provenance_remains_inspectable() -> None:
+    explicit = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]),
+        provenance=ProgressionProvenanceRecord(kind="explicit", source="authored_path"),
+    )
+    inferred = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.5, 0.2, 1.0)]),
+        provenance=ProgressionProvenanceRecord(
+            kind="inferred",
+            source="dense_station_inference",
+        ),
+    )
+
+    assert explicit.provenance.kind == "explicit"
+    assert inferred.provenance.kind == "inferred"
+    assert inferred.provenance.source == "dense_station_inference"
+
+
+def test_progression_remains_distinct_from_the_raw_path_primitive() -> None:
+    path = Path3D(segments=[Line3D((0.0, 0.0, 0.0), (0.0, 0.0, 1.0))])
+    progression = PathBackedProgression(path=path)
+
+    assert isinstance(path, Path3D)
+    assert isinstance(progression, PathBackedProgression)
+    assert progression != path
+
+
+def test_provenance_remains_durable_and_replayable() -> None:
+    provenance = ProgressionProvenanceRecord(
+        kind="inferred",
+        source="shared_trajectory_fit",
+    )
+
+    first = provenance
+    second = ProgressionProvenanceRecord(
+        kind="inferred",
+        source="shared_trajectory_fit",
+    )
+
+    assert first == second
+
+
+def test_progression_identity_is_stable_enough_for_later_diagnostics() -> None:
+    path = Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.1, 1.0)])
+    first = PathBackedProgression(
+        path=path,
+        domain_start=2.0,
+        domain_end=4.0,
+        provenance=ProgressionProvenanceRecord(kind="explicit", source="authored_path"),
+    )
+    second = PathBackedProgression(
+        path=path,
+        domain_start=2.0,
+        domain_end=4.0,
+        provenance=ProgressionProvenanceRecord(kind="explicit", source="authored_path"),
+    )
+
+    assert first.identity == second.identity


### PR DESCRIPTION
## Summary
- add a first-class path-backed progression object with explicit provenance and stable identity
- export progression records from impression.modeling and document the new modeling surface
- add focused progression tests and a loft smoke verification slice

## Testing
- ./.venv/bin/pytest tests/test_progression.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
