### PR TITLE
Implement 0.1.0.a Feature Spec 08B1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -40,3 +40,33 @@ This first milestone keeps the contract intentionally small:
 - progression identity is stable and replayable
 - progression is distinct from the raw path primitive
 - later station-attachment and transport semantics can build on this object
+
+## Station Attachment
+
+Stations can now attach to progression explicitly instead of only living beside
+parallel scalar progression arrays:
+
+```python
+from impression.modeling import ProgressionStationAttachment, Station, as_section
+from impression.modeling.drawing2d import make_rect
+
+station = Station(
+    t=0.5,
+    section=as_section(make_rect(size=(1.0, 1.0))),
+    origin=(0.0, 0.0, 0.5),
+    u=(1.0, 0.0, 0.0),
+    v=(0.0, 1.0, 0.0),
+    n=(0.0, 0.0, 1.0),
+)
+attachment = ProgressionStationAttachment.from_station(
+    progression=progression,
+    station=station,
+    station_index=0,
+)
+```
+
+That attachment contract keeps:
+
+- progression identity explicit
+- attachment ordering durable
+- station-owned topology truth intact

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -52,6 +52,7 @@ from .loft import (
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 from .progression import (
     PathBackedProgression,
+    ProgressionStationAttachment,
     ProgressionProvenanceKind,
     ProgressionProvenanceRecord,
 )
@@ -222,6 +223,7 @@ __all__ = [
     "Bezier3D",
     "Path3D",
     "PathBackedProgression",
+    "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
     "BSpline2D",

--- a/src/impression/modeling/progression.py
+++ b/src/impression/modeling/progression.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Protocol
 
 import numpy as np
 
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 
 ProgressionProvenanceKind = Literal["explicit", "inferred"]
+
+
+class _StationLike(Protocol):
+    @property
+    def progression(self) -> float: ...
+
+    @property
+    def topology_state(self) -> object | None: ...
+
+    @property
+    def placement_frame(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: ...
+
+    @property
+    def directional_correspondence(self) -> tuple[dict[str, frozenset[str]], ...]: ...
 
 
 def _normalize_progression_provenance_kind(value: str) -> ProgressionProvenanceKind:
@@ -117,9 +131,73 @@ class PathBackedProgression:
             self.provenance,
         )
 
+    def attach_stations(
+        self,
+        stations: list[_StationLike] | tuple[_StationLike, ...],
+    ) -> tuple["ProgressionStationAttachment", ...]:
+        attachments: list[ProgressionStationAttachment] = []
+        last_progression: float | None = None
+        for station_index, station in enumerate(stations):
+            attachment = ProgressionStationAttachment.from_station(
+                progression=self,
+                station=station,
+                station_index=station_index,
+            )
+            if last_progression is not None and attachment.progression_value < last_progression:
+                raise ValueError("station attachments must remain ordered by progression value.")
+            attachments.append(attachment)
+            last_progression = attachment.progression_value
+        return tuple(attachments)
+
+
+@dataclass(frozen=True)
+class ProgressionStationAttachment:
+    progression_identity: tuple[object, ...]
+    station_index: int
+    progression_value: float
+    topology_state: object | None
+    placement_frame: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    directional_correspondence: tuple[dict[str, frozenset[str]], ...]
+
+    @classmethod
+    def from_station(
+        cls,
+        *,
+        progression: PathBackedProgression,
+        station: _StationLike,
+        station_index: int,
+    ) -> "ProgressionStationAttachment":
+        progression_value = float(station.progression)
+        if not np.isfinite(progression_value):
+            raise ValueError("station progression value must be finite.")
+        if not progression.domain_start <= progression_value <= progression.domain_end:
+            raise ValueError("station progression value must lie within the progression domain.")
+        placement_frame = tuple(
+            np.asarray(component, dtype=float).reshape(3)
+            for component in station.placement_frame
+        )
+        return cls(
+            progression_identity=progression.identity,
+            station_index=int(station_index),
+            progression_value=progression_value,
+            topology_state=station.topology_state,
+            placement_frame=placement_frame,
+            directional_correspondence=station.directional_correspondence,
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "progression_station_attachment",
+            self.progression_identity,
+            self.station_index,
+            self.progression_value,
+        )
+
 
 __all__ = [
     "PathBackedProgression",
+    "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
 ]

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -4,8 +4,12 @@ from impression.modeling import (
     Line3D,
     Path3D,
     PathBackedProgression,
+    ProgressionStationAttachment,
     ProgressionProvenanceRecord,
+    Station,
+    as_section,
 )
+from impression.modeling.drawing2d import make_rect
 
 
 def test_progression_objects_reference_an_underlying_path_explicitly() -> None:
@@ -71,6 +75,140 @@ def test_progression_identity_is_stable_enough_for_later_diagnostics() -> None:
         domain_start=2.0,
         domain_end=4.0,
         provenance=ProgressionProvenanceRecord(kind="explicit", source="authored_path"),
+    )
+
+    assert first.identity == second.identity
+
+
+def test_stations_attach_to_progression_explicitly_rather_than_via_loose_scalar_arrays() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+    station = Station(
+        t=0.25,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, 0.0),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
+
+    attachment = ProgressionStationAttachment.from_station(
+        progression=progression,
+        station=station,
+        station_index=0,
+    )
+
+    assert attachment.progression_identity == progression.identity
+    assert attachment.progression_value == 0.25
+
+
+def test_attachment_ordering_and_identity_remain_inspectable() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 2.0)]),
+    )
+    stations = [
+        Station(
+            t=0.0,
+            section=as_section(make_rect(size=(1.0, 1.0))),
+            origin=(0.0, 0.0, 0.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=1.0,
+            section=as_section(make_rect(size=(0.8, 1.2))),
+            origin=(0.0, 0.0, 1.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+    ]
+
+    attachments = progression.attach_stations(stations)
+
+    assert [attachment.station_index for attachment in attachments] == [0, 1]
+    assert attachments[0].identity != attachments[1].identity
+
+
+def test_topology_owned_station_truth_remains_intact_after_attachment() -> None:
+    section = as_section(make_rect(size=(1.0, 0.6)))
+    station = Station(
+        t=0.5,
+        section=section,
+        origin=(0.0, 0.0, 0.5),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+
+    attachment = ProgressionStationAttachment.from_station(
+        progression=progression,
+        station=station,
+        station_index=0,
+    )
+
+    assert attachment.topology_state is station.topology_state
+    assert attachment.directional_correspondence == station.directional_correspondence
+
+
+def test_attachment_ordering_remains_deterministic() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 2.0)]),
+    )
+    stations = [
+        Station(
+            t=0.25,
+            section=as_section(make_rect(size=(1.0, 1.0))),
+            origin=(0.0, 0.0, 0.5),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=0.75,
+            section=as_section(make_rect(size=(0.8, 0.8))),
+            origin=(0.0, 0.0, 1.5),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+    ]
+
+    first = progression.attach_stations(stations)
+    second = progression.attach_stations(stations)
+
+    assert tuple(attachment.identity for attachment in first) == tuple(
+        attachment.identity for attachment in second
+    )
+
+
+def test_station_attachment_remains_durable_enough_for_replay() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+    station = Station(
+        t=0.5,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, 0.5),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
+
+    first = ProgressionStationAttachment.from_station(
+        progression=progression,
+        station=station,
+        station_index=0,
+    )
+    second = ProgressionStationAttachment.from_station(
+        progression=progression,
+        station=station,
+        station_index=0,
     )
 
     assert first.identity == second.identity


### PR DESCRIPTION
## Summary
- add explicit progression station-attachment records and ordered attachment helpers
- keep topology-owned station truth and attachment identity durable for replay
- extend progression docs and tests around attachment behavior

## Testing
- ./.venv/bin/pytest tests/test_progression.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
