### PR TITLE
Implement 0.1.0.a Feature Spec 08B2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -70,3 +70,23 @@ That attachment contract keeps:
 - progression identity explicit
 - attachment ordering durable
 - station-owned topology truth intact
+
+## Transport Semantics
+
+Transport semantics now live explicitly on the progression object too:
+
+```python
+from impression.modeling import ProgressionTransportPolicy
+
+progression = PathBackedProgression(
+    path=path,
+    transport_policy=ProgressionTransportPolicy(kind="parallel_transport"),
+)
+contract = progression.loft_transport_contract
+```
+
+In this milestone:
+
+- transport ownership is explicit on progression
+- loft-facing consumption is represented by an inspectable contract object
+- transport policy stays separate from later twist and scale semantic slots

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -55,6 +55,9 @@ from .progression import (
     ProgressionStationAttachment,
     ProgressionProvenanceKind,
     ProgressionProvenanceRecord,
+    ProgressionTransportContract,
+    ProgressionTransportKind,
+    ProgressionTransportPolicy,
 )
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
@@ -226,6 +229,9 @@ __all__ = [
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
+    "ProgressionTransportContract",
+    "ProgressionTransportKind",
+    "ProgressionTransportPolicy",
     "BSpline2D",
     "BSpline3D",
     "FitApproximationPosture",

--- a/src/impression/modeling/progression.py
+++ b/src/impression/modeling/progression.py
@@ -8,6 +8,7 @@ import numpy as np
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 
 ProgressionProvenanceKind = Literal["explicit", "inferred"]
+ProgressionTransportKind = Literal["parallel_transport"]
 
 
 class _StationLike(Protocol):
@@ -29,6 +30,14 @@ def _normalize_progression_provenance_kind(value: str) -> ProgressionProvenanceK
     kind = str(value)
     if kind not in allowed:
         raise ValueError("kind must be one of: explicit, inferred.")
+    return kind  # type: ignore[return-value]
+
+
+def _normalize_progression_transport_kind(value: str) -> ProgressionTransportKind:
+    allowed: set[str] = {"parallel_transport"}
+    kind = str(value)
+    if kind not in allowed:
+        raise ValueError("kind must be one of: parallel_transport.")
     return kind  # type: ignore[return-value]
 
 
@@ -77,11 +86,26 @@ class ProgressionProvenanceRecord:
 
 
 @dataclass(frozen=True)
+class ProgressionTransportPolicy:
+    kind: ProgressionTransportKind = "parallel_transport"
+
+    def __init__(self, kind: ProgressionTransportKind = "parallel_transport") -> None:
+        object.__setattr__(self, "kind", _normalize_progression_transport_kind(kind))
+
+
+@dataclass(frozen=True)
+class ProgressionTransportContract:
+    progression_identity: tuple[object, ...]
+    transport_policy: ProgressionTransportPolicy
+
+
+@dataclass(frozen=True)
 class PathBackedProgression:
     path: Path3D
     domain_start: float = 0.0
     domain_end: float = 1.0
     provenance: ProgressionProvenanceRecord = ProgressionProvenanceRecord()
+    transport_policy: ProgressionTransportPolicy = ProgressionTransportPolicy()
 
     def __init__(
         self,
@@ -90,6 +114,7 @@ class PathBackedProgression:
         domain_start: float = 0.0,
         domain_end: float = 1.0,
         provenance: ProgressionProvenanceRecord | None = None,
+        transport_policy: ProgressionTransportPolicy | None = None,
     ) -> None:
         if not isinstance(path, Path3D):
             raise ValueError("path must be a Path3D.")
@@ -108,6 +133,11 @@ class PathBackedProgression:
             self,
             "provenance",
             provenance if provenance is not None else ProgressionProvenanceRecord(),
+        )
+        object.__setattr__(
+            self,
+            "transport_policy",
+            transport_policy if transport_policy is not None else ProgressionTransportPolicy(),
         )
 
     @property
@@ -129,6 +159,13 @@ class PathBackedProgression:
             self.path_signature,
             self.parameter_domain,
             self.provenance,
+        )
+
+    @property
+    def loft_transport_contract(self) -> ProgressionTransportContract:
+        return ProgressionTransportContract(
+            progression_identity=self.identity,
+            transport_policy=self.transport_policy,
         )
 
     def attach_stations(
@@ -200,4 +237,7 @@ __all__ = [
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
+    "ProgressionTransportContract",
+    "ProgressionTransportKind",
+    "ProgressionTransportPolicy",
 ]

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -6,6 +6,7 @@ from impression.modeling import (
     PathBackedProgression,
     ProgressionStationAttachment,
     ProgressionProvenanceRecord,
+    ProgressionTransportPolicy,
     Station,
     as_section,
 )
@@ -212,3 +213,56 @@ def test_station_attachment_remains_durable_enough_for_replay() -> None:
     )
 
     assert first.identity == second.identity
+
+
+def test_progression_records_expose_explicit_transport_semantics() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+        transport_policy=ProgressionTransportPolicy(kind="parallel_transport"),
+    )
+
+    assert progression.transport_policy.kind == "parallel_transport"
+
+
+def test_loft_consumes_transport_semantics_through_an_inspectable_contract() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.0, 1.0)]),
+    )
+    contract = progression.loft_transport_contract
+
+    assert contract.progression_identity == progression.identity
+    assert contract.transport_policy == progression.transport_policy
+
+
+def test_transport_semantics_remain_deterministic_for_identical_inputs() -> None:
+    kwargs = dict(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.0, 1.0)]),
+        transport_policy=ProgressionTransportPolicy(kind="parallel_transport"),
+    )
+
+    first = PathBackedProgression(**kwargs)
+    second = PathBackedProgression(**kwargs)
+
+    assert first.loft_transport_contract == second.loft_transport_contract
+
+
+def test_transport_policy_remains_separate_from_twist_and_scale_semantic_slots() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+
+    assert progression.transport_policy.kind == "parallel_transport"
+    assert not hasattr(progression.transport_policy, "twist")
+    assert not hasattr(progression.transport_policy, "scale")
+
+
+def test_transport_ownership_is_durable_enough_for_replay_and_diagnostics() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.1, 1.0)]),
+        transport_policy=ProgressionTransportPolicy(kind="parallel_transport"),
+    )
+
+    first = progression.loft_transport_contract
+    second = progression.loft_transport_contract
+
+    assert first == second


### PR DESCRIPTION
## Summary
- add explicit transport-policy ownership to path-backed progression
- expose an inspectable loft-facing transport contract for deterministic consumption
- extend progression docs and tests around transport semantics

## Testing
- ./.venv/bin/pytest tests/test_progression.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
