### PR TITLE
Implement 0.1.0.a Feature Spec 08B3

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -90,3 +90,27 @@ In this milestone:
 - transport ownership is explicit on progression
 - loft-facing consumption is represented by an inspectable contract object
 - transport policy stays separate from later twist and scale semantic slots
+
+## Twist and Scale Slots
+
+Twist and scale semantics now have explicit owned slots on progression, even
+though first-milestone execution remains deferred:
+
+```python
+from impression.modeling import (
+    ProgressionScaleSemanticSlot,
+    ProgressionTwistSemanticSlot,
+)
+
+progression = PathBackedProgression(
+    path=path,
+    twist_semantics=ProgressionTwistSemanticSlot(status="deferred"),
+    scale_semantics=ProgressionScaleSemanticSlot(status="deferred"),
+)
+```
+
+That keeps the contract honest:
+
+- twist semantics are not hidden inside transport policy
+- scale semantics are not hidden inside transport policy
+- deferred execution does not erase the owned semantic slots

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -55,9 +55,12 @@ from .progression import (
     ProgressionStationAttachment,
     ProgressionProvenanceKind,
     ProgressionProvenanceRecord,
+    ProgressionScaleSemanticSlot,
+    ProgressionSemanticSlotStatus,
     ProgressionTransportContract,
     ProgressionTransportKind,
     ProgressionTransportPolicy,
+    ProgressionTwistSemanticSlot,
 )
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
@@ -229,9 +232,12 @@ __all__ = [
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
+    "ProgressionScaleSemanticSlot",
+    "ProgressionSemanticSlotStatus",
     "ProgressionTransportContract",
     "ProgressionTransportKind",
     "ProgressionTransportPolicy",
+    "ProgressionTwistSemanticSlot",
     "BSpline2D",
     "BSpline3D",
     "FitApproximationPosture",

--- a/src/impression/modeling/progression.py
+++ b/src/impression/modeling/progression.py
@@ -9,6 +9,7 @@ from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 
 ProgressionProvenanceKind = Literal["explicit", "inferred"]
 ProgressionTransportKind = Literal["parallel_transport"]
+ProgressionSemanticSlotStatus = Literal["deferred"]
 
 
 class _StationLike(Protocol):
@@ -39,6 +40,14 @@ def _normalize_progression_transport_kind(value: str) -> ProgressionTransportKin
     if kind not in allowed:
         raise ValueError("kind must be one of: parallel_transport.")
     return kind  # type: ignore[return-value]
+
+
+def _normalize_progression_semantic_slot_status(value: str) -> ProgressionSemanticSlotStatus:
+    allowed: set[str] = {"deferred"}
+    status = str(value)
+    if status not in allowed:
+        raise ValueError("status must be one of: deferred.")
+    return status  # type: ignore[return-value]
 
 
 def _segment_signature(segment: Line3D | Arc3D | Bezier3D) -> tuple[object, ...]:
@@ -100,12 +109,30 @@ class ProgressionTransportContract:
 
 
 @dataclass(frozen=True)
+class ProgressionTwistSemanticSlot:
+    status: ProgressionSemanticSlotStatus = "deferred"
+
+    def __init__(self, status: ProgressionSemanticSlotStatus = "deferred") -> None:
+        object.__setattr__(self, "status", _normalize_progression_semantic_slot_status(status))
+
+
+@dataclass(frozen=True)
+class ProgressionScaleSemanticSlot:
+    status: ProgressionSemanticSlotStatus = "deferred"
+
+    def __init__(self, status: ProgressionSemanticSlotStatus = "deferred") -> None:
+        object.__setattr__(self, "status", _normalize_progression_semantic_slot_status(status))
+
+
+@dataclass(frozen=True)
 class PathBackedProgression:
     path: Path3D
     domain_start: float = 0.0
     domain_end: float = 1.0
     provenance: ProgressionProvenanceRecord = ProgressionProvenanceRecord()
     transport_policy: ProgressionTransportPolicy = ProgressionTransportPolicy()
+    twist_semantics: ProgressionTwistSemanticSlot = ProgressionTwistSemanticSlot()
+    scale_semantics: ProgressionScaleSemanticSlot = ProgressionScaleSemanticSlot()
 
     def __init__(
         self,
@@ -115,6 +142,8 @@ class PathBackedProgression:
         domain_end: float = 1.0,
         provenance: ProgressionProvenanceRecord | None = None,
         transport_policy: ProgressionTransportPolicy | None = None,
+        twist_semantics: ProgressionTwistSemanticSlot | None = None,
+        scale_semantics: ProgressionScaleSemanticSlot | None = None,
     ) -> None:
         if not isinstance(path, Path3D):
             raise ValueError("path must be a Path3D.")
@@ -138,6 +167,16 @@ class PathBackedProgression:
             self,
             "transport_policy",
             transport_policy if transport_policy is not None else ProgressionTransportPolicy(),
+        )
+        object.__setattr__(
+            self,
+            "twist_semantics",
+            twist_semantics if twist_semantics is not None else ProgressionTwistSemanticSlot(),
+        )
+        object.__setattr__(
+            self,
+            "scale_semantics",
+            scale_semantics if scale_semantics is not None else ProgressionScaleSemanticSlot(),
         )
 
     @property
@@ -237,7 +276,10 @@ __all__ = [
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",
+    "ProgressionScaleSemanticSlot",
+    "ProgressionSemanticSlotStatus",
     "ProgressionTransportContract",
     "ProgressionTransportKind",
     "ProgressionTransportPolicy",
+    "ProgressionTwistSemanticSlot",
 ]

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -4,9 +4,12 @@ from impression.modeling import (
     Line3D,
     Path3D,
     PathBackedProgression,
+    ProgressionScaleSemanticSlot,
+    ProgressionSemanticSlotStatus,
     ProgressionStationAttachment,
     ProgressionProvenanceRecord,
     ProgressionTransportPolicy,
+    ProgressionTwistSemanticSlot,
     Station,
     as_section,
 )
@@ -266,3 +269,58 @@ def test_transport_ownership_is_durable_enough_for_replay_and_diagnostics() -> N
     second = progression.loft_transport_contract
 
     assert first == second
+
+
+def test_progression_records_expose_explicit_twist_and_scale_semantic_slots() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+        twist_semantics=ProgressionTwistSemanticSlot(status="deferred"),
+        scale_semantics=ProgressionScaleSemanticSlot(status="deferred"),
+    )
+
+    assert progression.twist_semantics.status == "deferred"
+    assert progression.scale_semantics.status == "deferred"
+
+
+def test_semantic_slots_remain_inspectable_even_when_some_execution_remains_deferred() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.2, 0.0, 1.0)]),
+    )
+
+    assert isinstance(progression.twist_semantics.status, str)
+    assert isinstance(progression.scale_semantics.status, str)
+
+
+def test_twist_semantics_are_not_hidden_inside_transport_policy() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+
+    assert progression.transport_policy.kind == "parallel_transport"
+    assert progression.twist_semantics.status == "deferred"
+    assert not hasattr(progression.transport_policy, "twist_semantics")
+
+
+def test_scale_semantics_are_not_hidden_inside_transport_policy() -> None:
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    )
+
+    assert progression.transport_policy.kind == "parallel_transport"
+    assert progression.scale_semantics.status == "deferred"
+    assert not hasattr(progression.transport_policy, "scale_semantics")
+
+
+def test_deferred_execution_does_not_erase_semantic_slot_ownership() -> None:
+    twist_slot = ProgressionTwistSemanticSlot(status="deferred")
+    scale_slot = ProgressionScaleSemanticSlot(status="deferred")
+    progression = PathBackedProgression(
+        path=Path3D.from_points([(0.0, 0.0, 0.0), (0.3, 0.1, 1.0)]),
+        twist_semantics=twist_slot,
+        scale_semantics=scale_slot,
+    )
+
+    assert progression.twist_semantics == twist_slot
+    assert progression.scale_semantics == scale_slot
+    assert progression.twist_semantics.status == "deferred"
+    assert progression.scale_semantics.status == "deferred"


### PR DESCRIPTION
## Summary
- add explicit twist and scale semantic slots to path-backed progression
- keep the first milestone honest by exposing deferred slots instead of hiding them in transport policy
- extend progression docs and tests around semantic-slot ownership

## Testing
- ./.venv/bin/pytest tests/test_progression.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
