### PR TITLE
Implement 0.1.0.a Feature Spec 04A

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -114,3 +114,28 @@ That keeps the contract honest:
 - twist semantics are not hidden inside transport policy
 - scale semantics are not hidden inside transport policy
 - deferred execution does not erase the owned semantic slots
+
+## Hidden Control Stations
+
+The planner can also carry hidden control stations as internal records without
+promoting them to public authored API:
+
+```python
+from impression.modeling import (
+    HiddenControlStationProvenanceRecord,
+    HiddenControlStationRecord,
+)
+
+record = HiddenControlStationRecord(
+    station_id="control-0",
+    origin=(0.0, 0.0, 0.5),
+    u=(1.0, 0.0, 0.0),
+    v=(0.0, 1.0, 0.0),
+    n=(0.0, 0.0, 1.0),
+    topology_reference=None,
+    provenance=HiddenControlStationProvenanceRecord(),
+)
+```
+
+These records are planner-owned and keep provenance explicit, but they are not
+the same thing as public topology stations.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -62,6 +62,11 @@ from .progression import (
     ProgressionTransportPolicy,
     ProgressionTwistSemanticSlot,
 )
+from .control_stations import (
+    HiddenControlStationProvenanceRecord,
+    HiddenControlStationRecord,
+    HiddenControlStationSource,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -229,6 +234,9 @@ __all__ = [
     "Bezier3D",
     "Path3D",
     "PathBackedProgression",
+    "HiddenControlStationProvenanceRecord",
+    "HiddenControlStationRecord",
+    "HiddenControlStationSource",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/control_stations.py
+++ b/src/impression/modeling/control_stations.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+import numpy as np
+
+HiddenControlStationSource = Literal["dense_station_fit", "shared_trajectory_fit"]
+
+
+class _StationLike(Protocol):
+    @property
+    def topology_state(self) -> object | None: ...
+
+    @property
+    def placement_frame(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: ...
+
+
+def _normalize_hidden_control_station_source(value: str) -> HiddenControlStationSource:
+    allowed: set[str] = {"dense_station_fit", "shared_trajectory_fit"}
+    source = str(value)
+    if source not in allowed:
+        raise ValueError("source must be one of: dense_station_fit, shared_trajectory_fit.")
+    return source  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class HiddenControlStationProvenanceRecord:
+    source: HiddenControlStationSource = "dense_station_fit"
+    evidence_reference: str = "fit_candidate"
+
+    def __init__(
+        self,
+        source: HiddenControlStationSource = "dense_station_fit",
+        evidence_reference: str = "fit_candidate",
+    ) -> None:
+        normalized_source = _normalize_hidden_control_station_source(source)
+        normalized_reference = str(evidence_reference).strip()
+        if not normalized_reference:
+            raise ValueError("evidence_reference must be non-empty.")
+        object.__setattr__(self, "source", normalized_source)
+        object.__setattr__(self, "evidence_reference", normalized_reference)
+
+
+@dataclass(frozen=True)
+class HiddenControlStationRecord:
+    station_id: str
+    origin: tuple[float, float, float]
+    u: tuple[float, float, float]
+    v: tuple[float, float, float]
+    n: tuple[float, float, float]
+    topology_reference: object | None
+    provenance: HiddenControlStationProvenanceRecord
+
+    def __init__(
+        self,
+        *,
+        station_id: str,
+        origin: tuple[float, float, float] | np.ndarray,
+        u: tuple[float, float, float] | np.ndarray,
+        v: tuple[float, float, float] | np.ndarray,
+        n: tuple[float, float, float] | np.ndarray,
+        topology_reference: object | None,
+        provenance: HiddenControlStationProvenanceRecord,
+    ) -> None:
+        normalized_station_id = str(station_id).strip()
+        if not normalized_station_id:
+            raise ValueError("station_id must be non-empty.")
+        object.__setattr__(self, "station_id", normalized_station_id)
+        object.__setattr__(self, "origin", tuple(float(value) for value in np.asarray(origin, dtype=float).reshape(3)))
+        object.__setattr__(self, "u", tuple(float(value) for value in np.asarray(u, dtype=float).reshape(3)))
+        object.__setattr__(self, "v", tuple(float(value) for value in np.asarray(v, dtype=float).reshape(3)))
+        object.__setattr__(self, "n", tuple(float(value) for value in np.asarray(n, dtype=float).reshape(3)))
+        object.__setattr__(self, "topology_reference", topology_reference)
+        object.__setattr__(self, "provenance", provenance)
+
+    @classmethod
+    def from_station(
+        cls,
+        *,
+        station_id: str,
+        station: _StationLike,
+        provenance: HiddenControlStationProvenanceRecord,
+    ) -> "HiddenControlStationRecord":
+        origin, u, v, n = station.placement_frame
+        return cls(
+            station_id=station_id,
+            origin=origin,
+            u=u,
+            v=v,
+            n=n,
+            topology_reference=station.topology_state,
+            provenance=provenance,
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "hidden_control_station",
+            self.station_id,
+            self.origin,
+            self.provenance,
+        )
+
+
+__all__ = [
+    "HiddenControlStationProvenanceRecord",
+    "HiddenControlStationRecord",
+    "HiddenControlStationSource",
+]

--- a/tests/test_control_stations.py
+++ b/tests/test_control_stations.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    HiddenControlStationProvenanceRecord,
+    HiddenControlStationRecord,
+    Station,
+    as_section,
+)
+from impression.modeling.drawing2d import make_rect
+
+
+def test_hidden_control_station_records_remain_distinct_from_topology_station_records() -> None:
+    station = Station(
+        t=0.5,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, 0.5),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
+    record = HiddenControlStationRecord.from_station(
+        station_id="control-0",
+        station=station,
+        provenance=HiddenControlStationProvenanceRecord(),
+    )
+
+    assert record is not station
+    assert record.topology_reference is station.topology_state
+
+
+def test_provenance_metadata_is_carried_with_retained_hidden_control_stations() -> None:
+    provenance = HiddenControlStationProvenanceRecord(
+        source="shared_trajectory_fit",
+        evidence_reference="trajectory_candidate_0",
+    )
+    station = Station(
+        t=0.5,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, 0.5),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
+
+    record = HiddenControlStationRecord.from_station(
+        station_id="control-1",
+        station=station,
+        provenance=provenance,
+    )
+
+    assert record.provenance == provenance
+
+
+def test_internal_representation_remains_planner_owned_and_non_user_facing() -> None:
+    record = HiddenControlStationRecord(
+        station_id="control-2",
+        origin=(0.0, 0.0, 0.5),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+        topology_reference=None,
+        provenance=HiddenControlStationProvenanceRecord(),
+    )
+
+    assert record.station_id == "control-2"
+    assert not hasattr(record, "t")
+
+
+def test_provenance_remains_durable_enough_for_later_diagnostics() -> None:
+    first = HiddenControlStationProvenanceRecord(
+        source="dense_station_fit",
+        evidence_reference="fit_candidate_2",
+    )
+    second = HiddenControlStationProvenanceRecord(
+        source="dense_station_fit",
+        evidence_reference="fit_candidate_2",
+    )
+
+    assert first == second
+
+
+def test_hidden_control_stations_do_not_collapse_into_stealth_public_authored_inputs() -> None:
+    record = HiddenControlStationRecord(
+        station_id="control-3",
+        origin=(0.0, 0.0, 1.0),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+        topology_reference=None,
+        provenance=HiddenControlStationProvenanceRecord(),
+    )
+
+    assert not hasattr(record, "section")
+    assert record.identity[0] == "hidden_control_station"


### PR DESCRIPTION
## Summary
- add planner-owned hidden control station records and provenance
- keep hidden control stations distinct from public topology station truth
- add focused control-station tests and doc coverage

## Testing
- ./.venv/bin/pytest tests/test_control_stations.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
