### PR TITLE
Implement 0.1.0.a Feature Spec 04B

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -139,3 +139,18 @@ record = HiddenControlStationRecord(
 
 These records are planner-owned and keep provenance explicit, but they are not
 the same thing as public topology stations.
+
+Planner consumption stays explicit too:
+
+```python
+from impression.modeling import HiddenControlStationPlannerConsumption
+
+consumption = HiddenControlStationPlannerConsumption(
+    planner_stage="fit_guidance",
+    topology_station_ids=("topo-0", "topo-1"),
+    hidden_control_station_ids=("control-0",),
+)
+```
+
+That contract keeps hidden control stations on the planner side of the boundary
+without letting them override topology truth or become public authored inputs.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -63,6 +63,8 @@ from .progression import (
     ProgressionTwistSemanticSlot,
 )
 from .control_stations import (
+    HiddenControlStationPlannerConsumption,
+    HiddenControlStationPlannerStage,
     HiddenControlStationProvenanceRecord,
     HiddenControlStationRecord,
     HiddenControlStationSource,
@@ -236,6 +238,8 @@ __all__ = [
     "PathBackedProgression",
     "HiddenControlStationProvenanceRecord",
     "HiddenControlStationRecord",
+    "HiddenControlStationPlannerConsumption",
+    "HiddenControlStationPlannerStage",
     "HiddenControlStationSource",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",

--- a/src/impression/modeling/control_stations.py
+++ b/src/impression/modeling/control_stations.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol
 import numpy as np
 
 HiddenControlStationSource = Literal["dense_station_fit", "shared_trajectory_fit"]
+HiddenControlStationPlannerStage = Literal["fit_guidance", "trajectory_guidance"]
 
 
 class _StationLike(Protocol):
@@ -22,6 +23,14 @@ def _normalize_hidden_control_station_source(value: str) -> HiddenControlStation
     if source not in allowed:
         raise ValueError("source must be one of: dense_station_fit, shared_trajectory_fit.")
     return source  # type: ignore[return-value]
+
+
+def _normalize_hidden_control_station_planner_stage(value: str) -> HiddenControlStationPlannerStage:
+    allowed: set[str] = {"fit_guidance", "trajectory_guidance"}
+    stage = str(value)
+    if stage not in allowed:
+        raise ValueError("planner_stage must be one of: fit_guidance, trajectory_guidance.")
+    return stage  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)
@@ -103,7 +112,50 @@ class HiddenControlStationRecord:
         )
 
 
+@dataclass(frozen=True)
+class HiddenControlStationPlannerConsumption:
+    planner_stage: HiddenControlStationPlannerStage
+    topology_station_ids: tuple[str, ...]
+    hidden_control_station_ids: tuple[str, ...]
+    public_authored_inputs_exposed: bool = False
+
+    def __init__(
+        self,
+        *,
+        planner_stage: HiddenControlStationPlannerStage,
+        topology_station_ids: tuple[str, ...] | list[str],
+        hidden_control_station_ids: tuple[str, ...] | list[str],
+        public_authored_inputs_exposed: bool = False,
+    ) -> None:
+        normalized_topology = tuple(str(value).strip() for value in topology_station_ids)
+        normalized_hidden = tuple(str(value).strip() for value in hidden_control_station_ids)
+        if any(not value for value in normalized_topology):
+            raise ValueError("topology_station_ids must be non-empty strings.")
+        if any(not value for value in normalized_hidden):
+            raise ValueError("hidden_control_station_ids must be non-empty strings.")
+        object.__setattr__(self, "planner_stage", _normalize_hidden_control_station_planner_stage(planner_stage))
+        object.__setattr__(self, "topology_station_ids", normalized_topology)
+        object.__setattr__(self, "hidden_control_station_ids", normalized_hidden)
+        object.__setattr__(self, "public_authored_inputs_exposed", bool(public_authored_inputs_exposed))
+        if self.public_authored_inputs_exposed:
+            raise ValueError("hidden control station consumption must remain non-user-facing.")
+        overlap = set(self.topology_station_ids) & set(self.hidden_control_station_ids)
+        if overlap:
+            raise ValueError("hidden control stations must not override topology station identity.")
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "hidden_control_station_planner_consumption",
+            self.planner_stage,
+            self.topology_station_ids,
+            self.hidden_control_station_ids,
+        )
+
+
 __all__ = [
+    "HiddenControlStationPlannerConsumption",
+    "HiddenControlStationPlannerStage",
     "HiddenControlStationProvenanceRecord",
     "HiddenControlStationRecord",
     "HiddenControlStationSource",

--- a/tests/test_control_stations.py
+++ b/tests/test_control_stations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from impression.modeling import (
+    HiddenControlStationPlannerConsumption,
     HiddenControlStationProvenanceRecord,
     HiddenControlStationRecord,
     Station,
@@ -92,3 +93,68 @@ def test_hidden_control_stations_do_not_collapse_into_stealth_public_authored_in
 
     assert not hasattr(record, "section")
     assert record.identity[0] == "hidden_control_station"
+
+
+def test_planner_stages_that_consume_hidden_control_stations_are_explicit_and_inspectable() -> None:
+    consumption = HiddenControlStationPlannerConsumption(
+        planner_stage="fit_guidance",
+        topology_station_ids=("topo-0", "topo-1"),
+        hidden_control_station_ids=("control-0",),
+    )
+
+    assert consumption.planner_stage == "fit_guidance"
+    assert consumption.hidden_control_station_ids == ("control-0",)
+
+
+def test_topology_owned_truth_remains_visible_alongside_hidden_control_consumption() -> None:
+    consumption = HiddenControlStationPlannerConsumption(
+        planner_stage="trajectory_guidance",
+        topology_station_ids=("topo-0", "topo-1"),
+        hidden_control_station_ids=("control-1", "control-2"),
+    )
+
+    assert consumption.topology_station_ids == ("topo-0", "topo-1")
+    assert consumption.hidden_control_station_ids == ("control-1", "control-2")
+
+
+def test_hidden_control_stations_do_not_override_topology_truth() -> None:
+    try:
+        HiddenControlStationPlannerConsumption(
+            planner_stage="fit_guidance",
+            topology_station_ids=("shared-id",),
+            hidden_control_station_ids=("shared-id",),
+        )
+    except ValueError as exc:
+        assert "must not override topology station identity" in str(exc)
+    else:
+        raise AssertionError("Expected overlapping topology/control identities to fail.")
+
+
+def test_planner_consumption_boundaries_remain_explicit_and_deterministic() -> None:
+    first = HiddenControlStationPlannerConsumption(
+        planner_stage="fit_guidance",
+        topology_station_ids=("topo-0", "topo-1"),
+        hidden_control_station_ids=("control-0",),
+    )
+    second = HiddenControlStationPlannerConsumption(
+        planner_stage="fit_guidance",
+        topology_station_ids=("topo-0", "topo-1"),
+        hidden_control_station_ids=("control-0",),
+    )
+
+    assert first == second
+    assert first.identity == second.identity
+
+
+def test_public_api_posture_remains_non_user_facing() -> None:
+    try:
+        HiddenControlStationPlannerConsumption(
+            planner_stage="fit_guidance",
+            topology_station_ids=("topo-0",),
+            hidden_control_station_ids=("control-0",),
+            public_authored_inputs_exposed=True,
+        )
+    except ValueError as exc:
+        assert "must remain non-user-facing" in str(exc)
+    else:
+        raise AssertionError("Expected public exposure flag to fail.")


### PR DESCRIPTION
## Summary
- add explicit planner-consumption boundary records for hidden control stations
- protect topology station identity and non-user-facing posture in the contract
- extend control-station tests and docs around planner usage boundaries

## Testing
- ./.venv/bin/pytest tests/test_control_stations.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
