### PR TITLE
Implement 0.1.0.a Feature Spec 03A

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -154,3 +154,20 @@ consumption = HiddenControlStationPlannerConsumption(
 
 That contract keeps hidden control stations on the planner side of the boundary
 without letting them override topology truth or become public authored inputs.
+
+## Dense Loft Descriptor Preparation
+
+Fit-backed loft analysis can prepare dense descriptor bands deterministically
+from ordered stations:
+
+```python
+from impression.modeling import prepare_dense_loft_fit_descriptors
+
+descriptor_band = prepare_dense_loft_fit_descriptors(stations)
+```
+
+The initial descriptor band keeps:
+
+- station ordering intact
+- simple structural meaning such as region counts
+- replayable records for later candidate-fit comparison

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -69,6 +69,11 @@ from .control_stations import (
     HiddenControlStationRecord,
     HiddenControlStationSource,
 )
+from .inference_descriptors import (
+    DenseLoftDescriptorBand,
+    DenseLoftStationDescriptor,
+    prepare_dense_loft_fit_descriptors,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -241,6 +246,9 @@ __all__ = [
     "HiddenControlStationPlannerConsumption",
     "HiddenControlStationPlannerStage",
     "HiddenControlStationSource",
+    "DenseLoftDescriptorBand",
+    "DenseLoftStationDescriptor",
+    "prepare_dense_loft_fit_descriptors",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/inference_descriptors.py
+++ b/src/impression/modeling/inference_descriptors.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+class _StationLike(Protocol):
+    @property
+    def progression(self) -> float: ...
+
+    @property
+    def topology_state(self) -> object | None: ...
+
+    @property
+    def placement_frame(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: ...
+
+    @property
+    def directional_correspondence(self) -> tuple[dict[str, frozenset[str]], ...]: ...
+
+
+@dataclass(frozen=True)
+class DenseLoftStationDescriptor:
+    station_index: int
+    progression_value: float
+    origin: tuple[float, float, float]
+    region_count: int
+    directional_correspondence_count: int
+
+    @classmethod
+    def from_station(
+        cls,
+        *,
+        station_index: int,
+        station: _StationLike,
+    ) -> "DenseLoftStationDescriptor":
+        origin, _, _, _ = station.placement_frame
+        topology_state = station.topology_state
+        region_count = 0 if topology_state is None else len(topology_state.regions)
+        return cls(
+            station_index=int(station_index),
+            progression_value=float(station.progression),
+            origin=tuple(float(value) for value in np.asarray(origin, dtype=float).reshape(3)),
+            region_count=int(region_count),
+            directional_correspondence_count=len(station.directional_correspondence),
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "dense_loft_station_descriptor",
+            self.station_index,
+            self.progression_value,
+            self.origin,
+            self.region_count,
+            self.directional_correspondence_count,
+        )
+
+
+@dataclass(frozen=True)
+class DenseLoftDescriptorBand:
+    descriptors: tuple[DenseLoftStationDescriptor, ...]
+
+    @property
+    def station_indices(self) -> tuple[int, ...]:
+        return tuple(descriptor.station_index for descriptor in self.descriptors)
+
+    @property
+    def progression_values(self) -> tuple[float, ...]:
+        return tuple(descriptor.progression_value for descriptor in self.descriptors)
+
+
+def prepare_dense_loft_fit_descriptors(
+    stations: list[_StationLike] | tuple[_StationLike, ...],
+) -> DenseLoftDescriptorBand:
+    descriptors = tuple(
+        DenseLoftStationDescriptor.from_station(
+            station_index=station_index,
+            station=station,
+        )
+        for station_index, station in enumerate(stations)
+    )
+    return DenseLoftDescriptorBand(descriptors=descriptors)
+
+
+__all__ = [
+    "DenseLoftDescriptorBand",
+    "DenseLoftStationDescriptor",
+    "prepare_dense_loft_fit_descriptors",
+]

--- a/tests/test_inference_descriptors.py
+++ b/tests/test_inference_descriptors.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from impression.modeling import Station, as_section, prepare_dense_loft_fit_descriptors
+from impression.modeling.drawing2d import make_circle, make_rect
+
+
+def _dense_fixture() -> list[Station]:
+    return [
+        Station(
+            t=0.0,
+            section=as_section(make_rect(size=(1.0, 1.0))),
+            origin=(0.0, 0.0, 0.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=0.5,
+            section=as_section(make_circle(radius=0.6)),
+            origin=(0.1, 0.0, 0.5),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=1.0,
+            section=as_section(make_rect(size=(0.8, 1.2))),
+            origin=(0.2, 0.0, 1.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+    ]
+
+
+def test_dense_loft_fixtures_emit_descriptor_records_in_deterministic_order() -> None:
+    band = prepare_dense_loft_fit_descriptors(_dense_fixture())
+
+    assert band.station_indices == (0, 1, 2)
+    assert band.progression_values == (0.0, 0.5, 1.0)
+
+
+def test_descriptor_normalization_preserves_station_ordering_and_correspondence_meaning() -> None:
+    band = prepare_dense_loft_fit_descriptors(_dense_fixture())
+
+    assert [descriptor.directional_correspondence_count for descriptor in band.descriptors] == [1, 1, 1]
+    assert [descriptor.region_count for descriptor in band.descriptors] == [1, 1, 1]
+
+
+def test_prepared_descriptor_bands_are_replayable_for_identical_inputs() -> None:
+    first = prepare_dense_loft_fit_descriptors(_dense_fixture())
+    second = prepare_dense_loft_fit_descriptors(_dense_fixture())
+
+    assert first == second
+
+
+def test_ordering_and_continuity_survive_descriptor_preparation() -> None:
+    band = prepare_dense_loft_fit_descriptors(_dense_fixture())
+
+    assert tuple(sorted(band.progression_values)) == band.progression_values
+    assert band.descriptors[0].origin[2] < band.descriptors[1].origin[2] < band.descriptors[2].origin[2]
+
+
+def test_prepared_evidence_is_consumable_by_later_candidate_fit_branches() -> None:
+    band = prepare_dense_loft_fit_descriptors(_dense_fixture())
+
+    assert all(descriptor.identity[0] == "dense_loft_station_descriptor" for descriptor in band.descriptors)


### PR DESCRIPTION
## Summary
- add deterministic dense-loft descriptor preparation for fit-backed analysis
- preserve station ordering and simple structural meaning in descriptor bands
- add focused descriptor tests and doc coverage

## Testing
- ./.venv/bin/pytest tests/test_inference_descriptors.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
