### PR TITLE
Implement 0.1.0.a Feature Spec 06A1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -171,3 +171,17 @@ The initial descriptor band keeps:
 - station ordering intact
 - simple structural meaning such as region counts
 - replayable records for later candidate-fit comparison
+
+Curve-intent inference then builds explicit descriptor families from that band:
+
+```python
+from impression.modeling import build_curve_intent_descriptor_families
+
+families = build_curve_intent_descriptor_families(descriptor_band)
+```
+
+The initial families are:
+
+- section descriptors
+- loop descriptors
+- correspondence-track descriptors

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -70,8 +70,13 @@ from .control_stations import (
     HiddenControlStationSource,
 )
 from .inference_descriptors import (
+    CorrespondenceTrackDescriptor,
+    CurveIntentDescriptorFamilies,
     DenseLoftDescriptorBand,
     DenseLoftStationDescriptor,
+    LoopCurveIntentDescriptor,
+    SectionCurveIntentDescriptor,
+    build_curve_intent_descriptor_families,
     prepare_dense_loft_fit_descriptors,
 )
 from .bspline import BSpline2D, BSpline3D
@@ -248,6 +253,11 @@ __all__ = [
     "HiddenControlStationSource",
     "DenseLoftDescriptorBand",
     "DenseLoftStationDescriptor",
+    "SectionCurveIntentDescriptor",
+    "LoopCurveIntentDescriptor",
+    "CorrespondenceTrackDescriptor",
+    "CurveIntentDescriptorFamilies",
+    "build_curve_intent_descriptor_families",
     "prepare_dense_loft_fit_descriptors",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",

--- a/src/impression/modeling/inference_descriptors.py
+++ b/src/impression/modeling/inference_descriptors.py
@@ -71,6 +71,32 @@ class DenseLoftDescriptorBand:
         return tuple(descriptor.progression_value for descriptor in self.descriptors)
 
 
+@dataclass(frozen=True)
+class SectionCurveIntentDescriptor:
+    station_index: int
+    progression_value: float
+    region_count: int
+
+
+@dataclass(frozen=True)
+class LoopCurveIntentDescriptor:
+    station_index: int
+    loop_count: int
+
+
+@dataclass(frozen=True)
+class CorrespondenceTrackDescriptor:
+    station_index: int
+    correspondence_track_count: int
+
+
+@dataclass(frozen=True)
+class CurveIntentDescriptorFamilies:
+    section_descriptors: tuple[SectionCurveIntentDescriptor, ...]
+    loop_descriptors: tuple[LoopCurveIntentDescriptor, ...]
+    correspondence_track_descriptors: tuple[CorrespondenceTrackDescriptor, ...]
+
+
 def prepare_dense_loft_fit_descriptors(
     stations: list[_StationLike] | tuple[_StationLike, ...],
 ) -> DenseLoftDescriptorBand:
@@ -84,8 +110,45 @@ def prepare_dense_loft_fit_descriptors(
     return DenseLoftDescriptorBand(descriptors=descriptors)
 
 
+def build_curve_intent_descriptor_families(
+    descriptor_band: DenseLoftDescriptorBand,
+) -> CurveIntentDescriptorFamilies:
+    section_descriptors = tuple(
+        SectionCurveIntentDescriptor(
+            station_index=descriptor.station_index,
+            progression_value=descriptor.progression_value,
+            region_count=descriptor.region_count,
+        )
+        for descriptor in descriptor_band.descriptors
+    )
+    loop_descriptors = tuple(
+        LoopCurveIntentDescriptor(
+            station_index=descriptor.station_index,
+            loop_count=descriptor.region_count,
+        )
+        for descriptor in descriptor_band.descriptors
+    )
+    correspondence_track_descriptors = tuple(
+        CorrespondenceTrackDescriptor(
+            station_index=descriptor.station_index,
+            correspondence_track_count=descriptor.directional_correspondence_count,
+        )
+        for descriptor in descriptor_band.descriptors
+    )
+    return CurveIntentDescriptorFamilies(
+        section_descriptors=section_descriptors,
+        loop_descriptors=loop_descriptors,
+        correspondence_track_descriptors=correspondence_track_descriptors,
+    )
+
+
 __all__ = [
+    "CorrespondenceTrackDescriptor",
+    "CurveIntentDescriptorFamilies",
     "DenseLoftDescriptorBand",
     "DenseLoftStationDescriptor",
+    "LoopCurveIntentDescriptor",
+    "SectionCurveIntentDescriptor",
+    "build_curve_intent_descriptor_families",
     "prepare_dense_loft_fit_descriptors",
 ]

--- a/tests/test_inference_descriptors.py
+++ b/tests/test_inference_descriptors.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from impression.modeling import Station, as_section, prepare_dense_loft_fit_descriptors
+from impression.modeling import (
+    Station,
+    as_section,
+    build_curve_intent_descriptor_families,
+    prepare_dense_loft_fit_descriptors,
+)
 from impression.modeling.drawing2d import make_circle, make_rect
 
 
@@ -65,3 +70,52 @@ def test_prepared_evidence_is_consumable_by_later_candidate_fit_branches() -> No
     band = prepare_dense_loft_fit_descriptors(_dense_fixture())
 
     assert all(descriptor.identity[0] == "dense_loft_station_descriptor" for descriptor in band.descriptors)
+
+
+def test_section_loop_and_correspondence_track_descriptor_records_emit_in_deterministic_order() -> None:
+    families = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    assert [descriptor.station_index for descriptor in families.section_descriptors] == [0, 1, 2]
+    assert [descriptor.station_index for descriptor in families.loop_descriptors] == [0, 1, 2]
+    assert [descriptor.station_index for descriptor in families.correspondence_track_descriptors] == [0, 1, 2]
+
+
+def test_family_level_descriptor_fields_remain_inspectable() -> None:
+    families = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    assert families.section_descriptors[1].progression_value == 0.5
+    assert families.loop_descriptors[1].loop_count == 1
+    assert families.correspondence_track_descriptors[1].correspondence_track_count == 1
+
+
+def test_descriptor_families_are_durable_enough_for_replay_and_comparison() -> None:
+    first = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+    second = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    assert first == second
+
+
+def test_family_boundaries_remain_stable_for_identical_inputs() -> None:
+    families = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    assert len(families.section_descriptors) == 3
+    assert len(families.loop_descriptors) == 3
+    assert len(families.correspondence_track_descriptors) == 3
+
+
+def test_descriptor_families_remain_reusable_by_later_evidence_assembly() -> None:
+    families = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    assert tuple(descriptor.station_index for descriptor in families.section_descriptors) == (0, 1, 2)


### PR DESCRIPTION
## Summary
- add section, loop, and correspondence-track descriptor families for curve-intent inference
- keep family fields deterministic and reusable from dense descriptor bands
- extend descriptor tests and docs around the family layer

## Testing
- ./.venv/bin/pytest tests/test_inference_descriptors.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
