### PR TITLE
Implement 0.1.0.a Feature Spec 06A2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -185,3 +185,14 @@ The initial families are:
 - section descriptors
 - loop descriptors
 - correspondence-track descriptors
+
+Span-local curve-intent evidence can then be assembled from those families:
+
+```python
+from impression.modeling import assemble_span_local_curve_intent_evidence
+
+evidence = assemble_span_local_curve_intent_evidence(families)
+```
+
+That assembled evidence keeps ordering explicit and gives later candidate
+classification a stable downstream shape to consume.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -76,6 +76,8 @@ from .inference_descriptors import (
     DenseLoftStationDescriptor,
     LoopCurveIntentDescriptor,
     SectionCurveIntentDescriptor,
+    SpanLocalCurveIntentEvidence,
+    assemble_span_local_curve_intent_evidence,
     build_curve_intent_descriptor_families,
     prepare_dense_loft_fit_descriptors,
 )
@@ -257,6 +259,8 @@ __all__ = [
     "LoopCurveIntentDescriptor",
     "CorrespondenceTrackDescriptor",
     "CurveIntentDescriptorFamilies",
+    "SpanLocalCurveIntentEvidence",
+    "assemble_span_local_curve_intent_evidence",
     "build_curve_intent_descriptor_families",
     "prepare_dense_loft_fit_descriptors",
     "ProgressionStationAttachment",

--- a/src/impression/modeling/inference_descriptors.py
+++ b/src/impression/modeling/inference_descriptors.py
@@ -97,6 +97,15 @@ class CurveIntentDescriptorFamilies:
     correspondence_track_descriptors: tuple[CorrespondenceTrackDescriptor, ...]
 
 
+@dataclass(frozen=True)
+class SpanLocalCurveIntentEvidence:
+    span_start_station_index: int
+    span_end_station_index: int
+    section_region_counts: tuple[int, ...]
+    loop_counts: tuple[int, ...]
+    correspondence_track_counts: tuple[int, ...]
+
+
 def prepare_dense_loft_fit_descriptors(
     stations: list[_StationLike] | tuple[_StationLike, ...],
 ) -> DenseLoftDescriptorBand:
@@ -142,6 +151,35 @@ def build_curve_intent_descriptor_families(
     )
 
 
+def assemble_span_local_curve_intent_evidence(
+    descriptor_families: CurveIntentDescriptorFamilies,
+) -> tuple[SpanLocalCurveIntentEvidence, ...]:
+    if not descriptor_families.section_descriptors:
+        return ()
+    evidence: list[SpanLocalCurveIntentEvidence] = []
+    for left, right in zip(
+        descriptor_families.section_descriptors,
+        descriptor_families.section_descriptors[1:],
+        strict=False,
+    ):
+        start_index = left.station_index
+        end_index = right.station_index
+        loop_slice = descriptor_families.loop_descriptors[start_index : end_index + 1]
+        track_slice = descriptor_families.correspondence_track_descriptors[start_index : end_index + 1]
+        evidence.append(
+            SpanLocalCurveIntentEvidence(
+                span_start_station_index=start_index,
+                span_end_station_index=end_index,
+                section_region_counts=(left.region_count, right.region_count),
+                loop_counts=tuple(descriptor.loop_count for descriptor in loop_slice),
+                correspondence_track_counts=tuple(
+                    descriptor.correspondence_track_count for descriptor in track_slice
+                ),
+            )
+        )
+    return tuple(evidence)
+
+
 __all__ = [
     "CorrespondenceTrackDescriptor",
     "CurveIntentDescriptorFamilies",
@@ -149,6 +187,8 @@ __all__ = [
     "DenseLoftStationDescriptor",
     "LoopCurveIntentDescriptor",
     "SectionCurveIntentDescriptor",
+    "SpanLocalCurveIntentEvidence",
+    "assemble_span_local_curve_intent_evidence",
     "build_curve_intent_descriptor_families",
     "prepare_dense_loft_fit_descriptors",
 ]

--- a/tests/test_inference_descriptors.py
+++ b/tests/test_inference_descriptors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from impression.modeling import (
     Station,
+    assemble_span_local_curve_intent_evidence,
     as_section,
     build_curve_intent_descriptor_families,
     prepare_dense_loft_fit_descriptors,
@@ -119,3 +120,58 @@ def test_descriptor_families_remain_reusable_by_later_evidence_assembly() -> Non
     )
 
     assert tuple(descriptor.station_index for descriptor in families.section_descriptors) == (0, 1, 2)
+
+
+def test_span_local_evidence_records_remain_inspectable() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+
+    assert evidence[0].span_start_station_index == 0
+    assert evidence[0].span_end_station_index == 1
+
+
+def test_identical_descriptor_inputs_produce_identical_evidence_ordering() -> None:
+    families = build_curve_intent_descriptor_families(
+        prepare_dense_loft_fit_descriptors(_dense_fixture())
+    )
+
+    first = assemble_span_local_curve_intent_evidence(families)
+    second = assemble_span_local_curve_intent_evidence(families)
+
+    assert first == second
+
+
+def test_span_local_evidence_shape_is_stable_for_identical_inputs() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+
+    assert len(evidence) == 2
+    assert evidence[0].section_region_counts == (1, 1)
+
+
+def test_normalization_and_ordering_remain_explicit() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+
+    assert tuple(item.span_start_station_index for item in evidence) == (0, 1)
+    assert tuple(item.span_end_station_index for item in evidence) == (1, 2)
+
+
+def test_later_candidate_classification_branches_can_consume_the_same_evidence_shape() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+
+    assert all(isinstance(item.loop_counts, tuple) for item in evidence)
+    assert all(isinstance(item.correspondence_track_counts, tuple) for item in evidence)


### PR DESCRIPTION
## Summary
- add span-local curve-intent evidence assembly from descriptor families
- preserve deterministic ordering and a stable downstream evidence shape
- extend descriptor tests and docs for the evidence layer

## Testing
- ./.venv/bin/pytest tests/test_inference_descriptors.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
