### PR TITLE
Implement 0.1.0.a Feature Spec 03B

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -196,3 +196,20 @@ evidence = assemble_span_local_curve_intent_evidence(families)
 
 That assembled evidence keeps ordering explicit and gives later candidate
 classification a stable downstream shape to consume.
+
+Station-derived candidate fits can then be generated and compared explicitly:
+
+```python
+from impression.modeling import (
+    compare_station_derived_curve_fit_candidates,
+    generate_station_derived_curve_fit_candidates,
+)
+
+candidates = generate_station_derived_curve_fit_candidates(descriptor_band)
+selected, assessment = compare_station_derived_curve_fit_candidates(candidates)
+```
+
+The comparison contract always returns either:
+
+- an accepted candidate with residual diagnostics
+- or an explicit refusal

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -81,6 +81,11 @@ from .inference_descriptors import (
     build_curve_intent_descriptor_families,
     prepare_dense_loft_fit_descriptors,
 )
+from .inference_candidates import (
+    StationDerivedCurveFitCandidate,
+    compare_station_derived_curve_fit_candidates,
+    generate_station_derived_curve_fit_candidates,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -263,6 +268,9 @@ __all__ = [
     "assemble_span_local_curve_intent_evidence",
     "build_curve_intent_descriptor_families",
     "prepare_dense_loft_fit_descriptors",
+    "StationDerivedCurveFitCandidate",
+    "generate_station_derived_curve_fit_candidates",
+    "compare_station_derived_curve_fit_candidates",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/inference_candidates.py
+++ b/src/impression/modeling/inference_candidates.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .bspline import BSpline3D
+from .fit_records import FitAssessmentReport, FitConfigurationRecord, FitResidualReport
+from .inference_descriptors import DenseLoftDescriptorBand
+
+
+def _open_uniform_knots(control_point_count: int, degree: int) -> tuple[float, ...]:
+    internal_count = control_point_count - degree - 1
+    if internal_count <= 0:
+        internal = ()
+    else:
+        internal = tuple(
+            float(value)
+            for value in np.linspace(0.0, 1.0, internal_count + 2, dtype=float)[1:-1]
+        )
+    return (
+        *((0.0,) * (degree + 1)),
+        *internal,
+        *((1.0,) * (degree + 1)),
+    )
+
+
+def _polyline_residual(points: np.ndarray) -> float:
+    if len(points) < 3:
+        return 0.0
+    start = points[0]
+    end = points[-1]
+    direction = end - start
+    norm = float(np.linalg.norm(direction))
+    if norm == 0.0:
+        return 0.0
+    unit = direction / norm
+    max_distance = 0.0
+    for point in points:
+        offset = point - start
+        projection = float(np.dot(offset, unit))
+        nearest = start + projection * unit
+        max_distance = max(max_distance, float(np.linalg.norm(point - nearest)))
+    return max_distance
+
+
+@dataclass(frozen=True)
+class StationDerivedCurveFitCandidate:
+    candidate_id: str
+    curve: BSpline3D
+    residual_report: FitResidualReport
+    fit_configuration_identity: tuple[object, ...] | None
+
+
+def generate_station_derived_curve_fit_candidates(
+    descriptor_band: DenseLoftDescriptorBand,
+    *,
+    fit_configuration: FitConfigurationRecord | None = None,
+    acceptance_threshold: float = 0.25,
+) -> tuple[StationDerivedCurveFitCandidate, ...]:
+    points = np.asarray([descriptor.origin for descriptor in descriptor_band.descriptors], dtype=float)
+    if points.shape[0] < 2:
+        return ()
+
+    exact_degree = 1
+    exact_curve = BSpline3D(
+        control_points=points,
+        degree=exact_degree,
+        knots=_open_uniform_knots(len(points), exact_degree),
+        closure="open",
+    )
+    exact_candidate = StationDerivedCurveFitCandidate(
+        candidate_id="station_polyline_exact",
+        curve=exact_curve,
+        residual_report=FitResidualReport(
+            metric_name="max_distance_to_station_polyline",
+            residual_value=0.0,
+            acceptance_threshold=acceptance_threshold,
+            approximation_posture="exact",
+            exact_threshold=0.0,
+        ),
+        fit_configuration_identity=None if fit_configuration is None else fit_configuration.identity,
+    )
+
+    approx_points = np.vstack([points[0], points[-1]])
+    approx_degree = 1
+    approx_curve = BSpline3D(
+        control_points=approx_points,
+        degree=approx_degree,
+        knots=_open_uniform_knots(len(approx_points), approx_degree),
+        closure="open",
+    )
+    approx_candidate = StationDerivedCurveFitCandidate(
+        candidate_id="station_endpoint_line",
+        curve=approx_curve,
+        residual_report=FitResidualReport(
+            metric_name="max_distance_to_station_line",
+            residual_value=_polyline_residual(points),
+            acceptance_threshold=acceptance_threshold,
+            approximation_posture="approximate",
+            exact_threshold=0.0,
+        ),
+        fit_configuration_identity=None if fit_configuration is None else fit_configuration.identity,
+    )
+    return (exact_candidate, approx_candidate)
+
+
+def compare_station_derived_curve_fit_candidates(
+    candidates: tuple[StationDerivedCurveFitCandidate, ...],
+) -> tuple[StationDerivedCurveFitCandidate | None, FitAssessmentReport]:
+    if not candidates:
+        refusal = FitResidualReport(
+            metric_name="missing_station_candidates",
+            residual_value=1.0,
+            acceptance_threshold=0.0,
+            approximation_posture="approximate",
+        )
+        return (
+            None,
+            FitAssessmentReport(
+                residual_report=refusal,
+                decision_outcome="refused",
+                decision_reason="no_station_derived_candidates",
+                fit_configuration_identity=None,
+            ),
+        )
+    best = min(candidates, key=lambda candidate: candidate.residual_report.residual_value)
+    assessment = FitAssessmentReport.from_residual(
+        best.residual_report,
+        fit_configuration_identity=best.fit_configuration_identity,
+    )
+    if assessment.decision_outcome == "refused":
+        return None, assessment
+    return best, assessment
+
+
+__all__ = [
+    "StationDerivedCurveFitCandidate",
+    "compare_station_derived_curve_fit_candidates",
+    "generate_station_derived_curve_fit_candidates",
+]

--- a/tests/test_inference_candidates.py
+++ b/tests/test_inference_candidates.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    FitAssessmentReport,
+    FitConfigurationRecord,
+    KnotCountPolicyRecord,
+    KnotPlacementPolicyRecord,
+    ParameterizationPolicyRecord,
+    compare_station_derived_curve_fit_candidates,
+    generate_station_derived_curve_fit_candidates,
+    prepare_dense_loft_fit_descriptors,
+)
+from impression.modeling.drawing2d import make_circle, make_rect
+from impression.modeling import Station, as_section
+
+
+def _dense_fixture() -> list[Station]:
+    return [
+        Station(
+            t=0.0,
+            section=as_section(make_rect(size=(1.0, 1.0))),
+            origin=(0.0, 0.0, 0.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=0.5,
+            section=as_section(make_circle(radius=0.6)),
+            origin=(0.3, 0.1, 0.5),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=1.0,
+            section=as_section(make_rect(size=(0.8, 1.2))),
+            origin=(1.0, 0.0, 1.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+    ]
+
+
+def _fit_config() -> FitConfigurationRecord:
+    return FitConfigurationRecord(
+        parameterization_policy=ParameterizationPolicyRecord(method="uniform"),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=3),
+        knot_placement_policy=KnotPlacementPolicyRecord(placement_method="uniform_internal"),
+    )
+
+
+def test_representative_dense_fixtures_produce_station_derived_candidate_fits() -> None:
+    candidates = generate_station_derived_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert len(candidates) == 2
+    assert candidates[0].candidate_id == "station_polyline_exact"
+
+
+def test_comparison_returns_either_an_accepted_candidate_or_an_explicit_refusal() -> None:
+    candidates = generate_station_derived_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    selected, assessment = compare_station_derived_curve_fit_candidates(candidates)
+
+    assert isinstance(assessment, FitAssessmentReport)
+    assert assessment.decision_outcome in {"accepted", "refused"}
+    if assessment.decision_outcome == "accepted":
+        assert selected is not None
+
+
+def test_candidate_comparison_references_explicit_residual_diagnostics() -> None:
+    candidates = generate_station_derived_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    _, assessment = compare_station_derived_curve_fit_candidates(candidates)
+
+    assert assessment.residual_report.metric_name.startswith("max_distance")
+
+
+def test_refusal_remains_explicit_when_no_station_derived_candidate_is_trustworthy() -> None:
+    candidates = generate_station_derived_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    weak_candidates = tuple(
+        type(candidate)(
+            candidate_id=candidate.candidate_id,
+            curve=candidate.curve,
+            residual_report=type(candidate.residual_report)(
+                metric_name=candidate.residual_report.metric_name,
+                residual_value=1.0,
+                acceptance_threshold=0.1,
+                approximation_posture="approximate",
+                exact_threshold=0.0,
+            ),
+            fit_configuration_identity=candidate.fit_configuration_identity,
+        )
+        for candidate in candidates
+    )
+
+    selected, assessment = compare_station_derived_curve_fit_candidates(weak_candidates)
+
+    assert selected is None
+    assert assessment.decision_outcome == "refused"
+
+
+def test_weak_candidates_are_not_silently_selected() -> None:
+    candidates = generate_station_derived_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    weak_candidates = tuple(
+        type(candidate)(
+            candidate_id=candidate.candidate_id,
+            curve=candidate.curve,
+            residual_report=type(candidate.residual_report)(
+                metric_name=candidate.residual_report.metric_name,
+                residual_value=0.5,
+                acceptance_threshold=0.1,
+                approximation_posture="approximate",
+                exact_threshold=0.0,
+            ),
+            fit_configuration_identity=candidate.fit_configuration_identity,
+        )
+        for candidate in candidates
+    )
+
+    selected, assessment = compare_station_derived_curve_fit_candidates(weak_candidates)
+
+    assert selected is None
+    assert assessment.decision_outcome == "refused"


### PR DESCRIPTION
## Summary
- add explicit station-derived candidate curve-fit generation and comparison
- report residual diagnostics and refusal instead of silently selecting weak candidates
- add focused candidate-fit tests and doc coverage

## Testing
- ./.venv/bin/pytest tests/test_inference_candidates.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
