### PR TITLE
Implement 0.1.0.a Feature Spec 03C

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -213,3 +213,18 @@ The comparison contract always returns either:
 
 - an accepted candidate with residual diagnostics
 - or an explicit refusal
+
+There is also a parallel shared-trajectory candidate lane:
+
+```python
+from impression.modeling import (
+    compare_shared_trajectory_curve_fit_candidates,
+    generate_shared_trajectory_curve_fit_candidates,
+)
+
+candidates = generate_shared_trajectory_curve_fit_candidates(descriptor_band)
+selected, assessment = compare_shared_trajectory_curve_fit_candidates(candidates)
+```
+
+This keeps the shared-trajectory fit path using the same explicit residual and
+refusal posture as the station-derived lane.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -82,6 +82,9 @@ from .inference_descriptors import (
     prepare_dense_loft_fit_descriptors,
 )
 from .inference_candidates import (
+    SharedTrajectoryCurveFitCandidate,
+    compare_shared_trajectory_curve_fit_candidates,
+    generate_shared_trajectory_curve_fit_candidates,
     StationDerivedCurveFitCandidate,
     compare_station_derived_curve_fit_candidates,
     generate_station_derived_curve_fit_candidates,
@@ -271,6 +274,9 @@ __all__ = [
     "StationDerivedCurveFitCandidate",
     "generate_station_derived_curve_fit_candidates",
     "compare_station_derived_curve_fit_candidates",
+    "SharedTrajectoryCurveFitCandidate",
+    "generate_shared_trajectory_curve_fit_candidates",
+    "compare_shared_trajectory_curve_fit_candidates",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/inference_candidates.py
+++ b/src/impression/modeling/inference_candidates.py
@@ -52,6 +52,14 @@ class StationDerivedCurveFitCandidate:
     fit_configuration_identity: tuple[object, ...] | None
 
 
+@dataclass(frozen=True)
+class SharedTrajectoryCurveFitCandidate:
+    candidate_id: str
+    curve: BSpline3D
+    residual_report: FitResidualReport
+    fit_configuration_identity: tuple[object, ...] | None
+
+
 def generate_station_derived_curve_fit_candidates(
     descriptor_band: DenseLoftDescriptorBand,
     *,
@@ -134,7 +142,87 @@ def compare_station_derived_curve_fit_candidates(
     return best, assessment
 
 
+def generate_shared_trajectory_curve_fit_candidates(
+    descriptor_band: DenseLoftDescriptorBand,
+    *,
+    fit_configuration: FitConfigurationRecord | None = None,
+    acceptance_threshold: float = 0.25,
+) -> tuple[SharedTrajectoryCurveFitCandidate, ...]:
+    points = np.asarray([descriptor.origin for descriptor in descriptor_band.descriptors], dtype=float)
+    if points.shape[0] < 2:
+        return ()
+    polyline_curve = BSpline3D(
+        control_points=points,
+        degree=1,
+        knots=_open_uniform_knots(len(points), 1),
+        closure="open",
+    )
+    polyline_candidate = SharedTrajectoryCurveFitCandidate(
+        candidate_id="shared_trajectory_polyline",
+        curve=polyline_curve,
+        residual_report=FitResidualReport(
+            metric_name="max_distance_to_shared_trajectory_polyline",
+            residual_value=0.0,
+            acceptance_threshold=acceptance_threshold,
+            approximation_posture="exact",
+            exact_threshold=0.0,
+        ),
+        fit_configuration_identity=None if fit_configuration is None else fit_configuration.identity,
+    )
+    endpoint_curve = BSpline3D(
+        control_points=np.vstack([points[0], points[-1]]),
+        degree=1,
+        knots=_open_uniform_knots(2, 1),
+        closure="open",
+    )
+    endpoint_candidate = SharedTrajectoryCurveFitCandidate(
+        candidate_id="shared_trajectory_endpoint_line",
+        curve=endpoint_curve,
+        residual_report=FitResidualReport(
+            metric_name="max_distance_to_shared_trajectory_line",
+            residual_value=_polyline_residual(points),
+            acceptance_threshold=acceptance_threshold,
+            approximation_posture="approximate",
+            exact_threshold=0.0,
+        ),
+        fit_configuration_identity=None if fit_configuration is None else fit_configuration.identity,
+    )
+    return (polyline_candidate, endpoint_candidate)
+
+
+def compare_shared_trajectory_curve_fit_candidates(
+    candidates: tuple[SharedTrajectoryCurveFitCandidate, ...],
+) -> tuple[SharedTrajectoryCurveFitCandidate | None, FitAssessmentReport]:
+    if not candidates:
+        refusal = FitResidualReport(
+            metric_name="missing_shared_trajectory_candidates",
+            residual_value=1.0,
+            acceptance_threshold=0.0,
+            approximation_posture="approximate",
+        )
+        return (
+            None,
+            FitAssessmentReport(
+                residual_report=refusal,
+                decision_outcome="refused",
+                decision_reason="no_shared_trajectory_candidates",
+                fit_configuration_identity=None,
+            ),
+        )
+    best = min(candidates, key=lambda candidate: candidate.residual_report.residual_value)
+    assessment = FitAssessmentReport.from_residual(
+        best.residual_report,
+        fit_configuration_identity=best.fit_configuration_identity,
+    )
+    if assessment.decision_outcome == "refused":
+        return None, assessment
+    return best, assessment
+
+
 __all__ = [
+    "SharedTrajectoryCurveFitCandidate",
+    "compare_shared_trajectory_curve_fit_candidates",
+    "generate_shared_trajectory_curve_fit_candidates",
     "StationDerivedCurveFitCandidate",
     "compare_station_derived_curve_fit_candidates",
     "generate_station_derived_curve_fit_candidates",

--- a/tests/test_inference_candidates.py
+++ b/tests/test_inference_candidates.py
@@ -6,7 +6,9 @@ from impression.modeling import (
     KnotCountPolicyRecord,
     KnotPlacementPolicyRecord,
     ParameterizationPolicyRecord,
+    compare_shared_trajectory_curve_fit_candidates,
     compare_station_derived_curve_fit_candidates,
+    generate_shared_trajectory_curve_fit_candidates,
     generate_station_derived_curve_fit_candidates,
     prepare_dense_loft_fit_descriptors,
 )
@@ -134,6 +136,94 @@ def test_weak_candidates_are_not_silently_selected() -> None:
     )
 
     selected, assessment = compare_station_derived_curve_fit_candidates(weak_candidates)
+
+    assert selected is None
+    assert assessment.decision_outcome == "refused"
+
+
+def test_representative_dense_fixtures_produce_shared_trajectory_candidate_fits() -> None:
+    candidates = generate_shared_trajectory_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert len(candidates) == 2
+    assert candidates[0].candidate_id == "shared_trajectory_polyline"
+
+
+def test_shared_trajectory_comparison_returns_either_an_accepted_candidate_or_an_explicit_refusal() -> None:
+    candidates = generate_shared_trajectory_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    selected, assessment = compare_shared_trajectory_curve_fit_candidates(candidates)
+
+    assert isinstance(assessment, FitAssessmentReport)
+    assert assessment.decision_outcome in {"accepted", "refused"}
+    if assessment.decision_outcome == "accepted":
+        assert selected is not None
+
+
+def test_shared_trajectory_comparison_references_explicit_residual_diagnostics() -> None:
+    candidates = generate_shared_trajectory_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    _, assessment = compare_shared_trajectory_curve_fit_candidates(candidates)
+
+    assert assessment.residual_report.metric_name.startswith("max_distance")
+
+
+def test_refusal_remains_explicit_when_no_shared_trajectory_candidate_is_trustworthy() -> None:
+    candidates = generate_shared_trajectory_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    weak_candidates = tuple(
+        type(candidate)(
+            candidate_id=candidate.candidate_id,
+            curve=candidate.curve,
+            residual_report=type(candidate.residual_report)(
+                metric_name=candidate.residual_report.metric_name,
+                residual_value=0.5,
+                acceptance_threshold=0.1,
+                approximation_posture="approximate",
+                exact_threshold=0.0,
+            ),
+            fit_configuration_identity=candidate.fit_configuration_identity,
+        )
+        for candidate in candidates
+    )
+
+    selected, assessment = compare_shared_trajectory_curve_fit_candidates(weak_candidates)
+
+    assert selected is None
+    assert assessment.decision_outcome == "refused"
+
+
+def test_weak_trajectory_fits_are_not_silently_promoted() -> None:
+    candidates = generate_shared_trajectory_curve_fit_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    weak_candidates = tuple(
+        type(candidate)(
+            candidate_id=candidate.candidate_id,
+            curve=candidate.curve,
+            residual_report=type(candidate.residual_report)(
+                metric_name=candidate.residual_report.metric_name,
+                residual_value=1.0,
+                acceptance_threshold=0.1,
+                approximation_posture="approximate",
+                exact_threshold=0.0,
+            ),
+            fit_configuration_identity=candidate.fit_configuration_identity,
+        )
+        for candidate in candidates
+    )
+
+    selected, assessment = compare_shared_trajectory_curve_fit_candidates(weak_candidates)
 
     assert selected is None
     assert assessment.decision_outcome == "refused"


### PR DESCRIPTION
## Summary
- add the shared-trajectory candidate curve-fit generation and comparison lane
- keep shared-trajectory residual diagnostics and refusal explicit
- extend candidate-fit tests and docs around the shared-trajectory path

## Testing
- ./.venv/bin/pytest tests/test_inference_candidates.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
