### PR TITLE
Implement 0.1.0.a Feature Spec 06B

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -197,6 +197,19 @@ evidence = assemble_span_local_curve_intent_evidence(families)
 That assembled evidence keeps ordering explicit and gives later candidate
 classification a stable downstream shape to consume.
 
+Curve-intent candidate posture can then be classified explicitly:
+
+```python
+from impression.modeling import classify_curve_intent_candidate
+
+report = classify_curve_intent_candidate(evidence)
+```
+
+The initial posture stays conservative:
+
+- strong evidence yields a candidate report
+- weak or conflicting evidence yields an explicit indeterminate posture
+
 Station-derived candidate fits can then be generated and compared explicitly:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -89,6 +89,11 @@ from .inference_candidates import (
     compare_station_derived_curve_fit_candidates,
     generate_station_derived_curve_fit_candidates,
 )
+from .curve_intent import (
+    CurveIntentCandidateReport,
+    CurveIntentPosture,
+    classify_curve_intent_candidate,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -277,6 +282,9 @@ __all__ = [
     "SharedTrajectoryCurveFitCandidate",
     "generate_shared_trajectory_curve_fit_candidates",
     "compare_shared_trajectory_curve_fit_candidates",
+    "CurveIntentCandidateReport",
+    "CurveIntentPosture",
+    "classify_curve_intent_candidate",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/curve_intent.py
+++ b/src/impression/modeling/curve_intent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .inference_descriptors import SpanLocalCurveIntentEvidence
+
+CurveIntentPosture = Literal["candidate", "indeterminate"]
+
+
+@dataclass(frozen=True)
+class CurveIntentCandidateReport:
+    candidate_kind: str
+    confidence: float
+    posture: CurveIntentPosture
+    evidence_count: int
+    reason: str
+
+
+def classify_curve_intent_candidate(
+    evidence: tuple[SpanLocalCurveIntentEvidence, ...],
+) -> CurveIntentCandidateReport:
+    if not evidence:
+        return CurveIntentCandidateReport(
+            candidate_kind="none",
+            confidence=0.0,
+            posture="indeterminate",
+            evidence_count=0,
+            reason="missing_span_local_evidence",
+        )
+    stable_regions = all(
+        len(set(item.section_region_counts)) == 1 for item in evidence
+    )
+    stable_tracks = all(
+        all(count > 0 for count in item.correspondence_track_counts) for item in evidence
+    )
+    if stable_regions and stable_tracks:
+        return CurveIntentCandidateReport(
+            candidate_kind="shared_curve",
+            confidence=1.0,
+            posture="candidate",
+            evidence_count=len(evidence),
+            reason="stable_region_and_track_evidence",
+        )
+    return CurveIntentCandidateReport(
+        candidate_kind="none",
+        confidence=0.0,
+        posture="indeterminate",
+        evidence_count=len(evidence),
+        reason="weak_or_conflicting_evidence",
+    )
+
+
+__all__ = [
+    "CurveIntentCandidateReport",
+    "CurveIntentPosture",
+    "classify_curve_intent_candidate",
+]

--- a/tests/test_inference_descriptors.py
+++ b/tests/test_inference_descriptors.py
@@ -5,6 +5,7 @@ from impression.modeling import (
     assemble_span_local_curve_intent_evidence,
     as_section,
     build_curve_intent_descriptor_families,
+    classify_curve_intent_candidate,
     prepare_dense_loft_fit_descriptors,
 )
 from impression.modeling.drawing2d import make_circle, make_rect
@@ -175,3 +176,67 @@ def test_later_candidate_classification_branches_can_consume_the_same_evidence_s
 
     assert all(isinstance(item.loop_counts, tuple) for item in evidence)
     assert all(isinstance(item.correspondence_track_counts, tuple) for item in evidence)
+
+
+def test_representative_evidence_produces_candidate_intent_reports_or_explicit_indeterminate_posture() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+
+    report = classify_curve_intent_candidate(evidence)
+
+    assert report.posture in {"candidate", "indeterminate"}
+
+
+def test_confidence_or_uncertainty_remains_inspectable() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+    report = classify_curve_intent_candidate(evidence)
+
+    assert isinstance(report.confidence, float)
+    assert isinstance(report.reason, str)
+
+
+def test_weak_evidence_is_not_overstated_as_strong_inferred_intent() -> None:
+    weak_evidence = (
+        type(
+            assemble_span_local_curve_intent_evidence(
+                build_curve_intent_descriptor_families(
+                    prepare_dense_loft_fit_descriptors(_dense_fixture())
+                )
+            )[0]
+        )(
+            span_start_station_index=0,
+            span_end_station_index=1,
+            section_region_counts=(1, 2),
+            loop_counts=(1, 2),
+            correspondence_track_counts=(0, 0),
+        ),
+    )
+
+    report = classify_curve_intent_candidate(weak_evidence)
+
+    assert report.posture == "indeterminate"
+
+
+def test_indeterminate_or_refusal_posture_remains_a_first_class_output() -> None:
+    report = classify_curve_intent_candidate(())
+
+    assert report.posture == "indeterminate"
+    assert report.reason == "missing_span_local_evidence"
+
+
+def test_candidate_reporting_stays_aligned_with_descriptor_evidence() -> None:
+    evidence = assemble_span_local_curve_intent_evidence(
+        build_curve_intent_descriptor_families(
+            prepare_dense_loft_fit_descriptors(_dense_fixture())
+        )
+    )
+    report = classify_curve_intent_candidate(evidence)
+
+    assert report.evidence_count == len(evidence)


### PR DESCRIPTION
## Summary
- add explicit curve-intent candidate reporting and indeterminate posture
- keep weak or conflicting evidence from being overstated as strong inferred intent
- extend descriptor tests and docs around the classification layer

## Testing
- ./.venv/bin/pytest tests/test_inference_descriptors.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
