### PR TITLE
Implement 0.1.0.a Feature Spec 07A1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -241,3 +241,18 @@ selected, assessment = compare_shared_trajectory_curve_fit_candidates(candidates
 
 This keeps the shared-trajectory fit path using the same explicit residual and
 refusal posture as the station-derived lane.
+
+That fitted shared-trajectory evidence can then be lifted into whole-loft
+trajectory candidates:
+
+```python
+from impression.modeling import generate_shared_whole_loft_trajectory_candidates
+
+whole_loft_candidates = generate_shared_whole_loft_trajectory_candidates(descriptor_band)
+```
+
+Those candidate records keep the boundary honest:
+
+- candidate scope remains limited to whole-loft shared trajectories
+- source fit candidate identity remains explicit
+- source residual evidence remains attached for later posture decisions

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -94,6 +94,10 @@ from .curve_intent import (
     CurveIntentPosture,
     classify_curve_intent_candidate,
 )
+from .shared_trajectory import (
+    SharedWholeLoftTrajectoryCandidate,
+    generate_shared_whole_loft_trajectory_candidates,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -285,6 +289,8 @@ __all__ = [
     "CurveIntentCandidateReport",
     "CurveIntentPosture",
     "classify_curve_intent_candidate",
+    "SharedWholeLoftTrajectoryCandidate",
+    "generate_shared_whole_loft_trajectory_candidates",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",
     "ProgressionProvenanceRecord",

--- a/src/impression/modeling/shared_trajectory.py
+++ b/src/impression/modeling/shared_trajectory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .bspline import BSpline3D
+from .fit_records import FitConfigurationRecord, FitResidualReport
+from .inference_candidates import (
+    SharedTrajectoryCurveFitCandidate,
+    generate_shared_trajectory_curve_fit_candidates,
+)
+from .inference_descriptors import DenseLoftDescriptorBand
+
+
+@dataclass(frozen=True)
+class SharedWholeLoftTrajectoryCandidate:
+    candidate_id: str
+    trajectory_curve: BSpline3D
+    source_fit_candidate_id: str
+    source_residual_report: FitResidualReport
+    fit_configuration_identity: tuple[object, ...] | None
+    evidence_lane: str = "shared_trajectory_curve_fit"
+
+
+def generate_shared_whole_loft_trajectory_candidates(
+    descriptor_band: DenseLoftDescriptorBand,
+    *,
+    fit_configuration: FitConfigurationRecord | None = None,
+) -> tuple[SharedWholeLoftTrajectoryCandidate, ...]:
+    fit_candidates = generate_shared_trajectory_curve_fit_candidates(
+        descriptor_band,
+        fit_configuration=fit_configuration,
+    )
+    return tuple(
+        SharedWholeLoftTrajectoryCandidate(
+            candidate_id=f"whole_loft_{candidate.candidate_id}",
+            trajectory_curve=candidate.curve,
+            source_fit_candidate_id=candidate.candidate_id,
+            source_residual_report=candidate.residual_report,
+            fit_configuration_identity=candidate.fit_configuration_identity,
+        )
+        for candidate in fit_candidates
+    )
+
+
+__all__ = [
+    "SharedWholeLoftTrajectoryCandidate",
+    "generate_shared_whole_loft_trajectory_candidates",
+]

--- a/tests/test_inference_candidates.py
+++ b/tests/test_inference_candidates.py
@@ -8,6 +8,7 @@ from impression.modeling import (
     ParameterizationPolicyRecord,
     compare_shared_trajectory_curve_fit_candidates,
     compare_station_derived_curve_fit_candidates,
+    generate_shared_whole_loft_trajectory_candidates,
     generate_shared_trajectory_curve_fit_candidates,
     generate_station_derived_curve_fit_candidates,
     prepare_dense_loft_fit_descriptors,
@@ -227,3 +228,64 @@ def test_weak_trajectory_fits_are_not_silently_promoted() -> None:
 
     assert selected is None
     assert assessment.decision_outcome == "refused"
+
+
+def test_representative_loft_evidence_produces_shared_whole_loft_trajectory_candidates() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert len(candidates) == 2
+    assert candidates[0].candidate_id.startswith("whole_loft_")
+
+
+def test_candidate_outputs_remain_inspectable_and_durable() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert candidates[0].source_fit_candidate_id == "shared_trajectory_polyline"
+    assert candidates[0].source_residual_report.metric_name.startswith("max_distance")
+    assert candidates[0].fit_configuration_identity == _fit_config().identity
+
+
+def test_generation_remains_limited_to_whole_loft_shared_trajectories() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert all(candidate.evidence_lane == "shared_trajectory_curve_fit" for candidate in candidates)
+
+
+def test_candidate_output_shape_remains_stable_for_identical_inputs() -> None:
+    first = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    second = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert tuple(candidate.candidate_id for candidate in first) == tuple(
+        candidate.candidate_id for candidate in second
+    )
+    assert tuple(candidate.source_fit_candidate_id for candidate in first) == tuple(
+        candidate.source_fit_candidate_id for candidate in second
+    )
+    assert tuple(candidate.fit_configuration_identity for candidate in first) == tuple(
+        candidate.fit_configuration_identity for candidate in second
+    )
+
+
+def test_fitted_curve_evidence_contribution_remains_explicit() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+
+    assert all(candidate.source_fit_candidate_id for candidate in candidates)
+    assert all(candidate.source_residual_report.metric_name for candidate in candidates)


### PR DESCRIPTION
## Summary
- add the shared whole-loft trajectory candidate lane on top of shared-trajectory fit outputs
- keep candidate scope limited to whole-loft shared trajectories while carrying source fit evidence forward
- document and test the candidate output contract

## Testing
- ./.venv/bin/pytest tests/test_inference_candidates.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
