### PR TITLE
Implement 0.1.0.a Feature Spec 07A2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -256,3 +256,17 @@ Those candidate records keep the boundary honest:
 - candidate scope remains limited to whole-loft shared trajectories
 - source fit candidate identity remains explicit
 - source residual evidence remains attached for later posture decisions
+
+Confidence and refusal are then handled by a separate posture layer:
+
+```python
+from impression.modeling import assess_shared_whole_loft_trajectory_candidates
+
+assessment = assess_shared_whole_loft_trajectory_candidates(whole_loft_candidates)
+```
+
+That assessment returns one of three explicit outcomes:
+
+- `accepted` when exact whole-loft shared trajectory evidence is within threshold
+- `uncertain` when only approximate-but-acceptable shared trajectory evidence remains
+- `refused` when no whole-loft shared trajectory candidate is trustworthy

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -95,7 +95,10 @@ from .curve_intent import (
     classify_curve_intent_candidate,
 )
 from .shared_trajectory import (
+    SharedWholeLoftTrajectoryAssessment,
     SharedWholeLoftTrajectoryCandidate,
+    SharedWholeLoftTrajectoryPosture,
+    assess_shared_whole_loft_trajectory_candidates,
     generate_shared_whole_loft_trajectory_candidates,
 )
 from .bspline import BSpline2D, BSpline3D
@@ -289,7 +292,10 @@ __all__ = [
     "CurveIntentCandidateReport",
     "CurveIntentPosture",
     "classify_curve_intent_candidate",
+    "SharedWholeLoftTrajectoryAssessment",
     "SharedWholeLoftTrajectoryCandidate",
+    "SharedWholeLoftTrajectoryPosture",
+    "assess_shared_whole_loft_trajectory_candidates",
     "generate_shared_whole_loft_trajectory_candidates",
     "ProgressionStationAttachment",
     "ProgressionProvenanceKind",

--- a/src/impression/modeling/shared_trajectory.py
+++ b/src/impression/modeling/shared_trajectory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from .bspline import BSpline3D
 from .fit_records import FitConfigurationRecord, FitResidualReport
@@ -10,6 +11,8 @@ from .inference_candidates import (
 )
 from .inference_descriptors import DenseLoftDescriptorBand
 
+SharedWholeLoftTrajectoryPosture = Literal["accepted", "uncertain", "refused"]
+
 
 @dataclass(frozen=True)
 class SharedWholeLoftTrajectoryCandidate:
@@ -18,6 +21,15 @@ class SharedWholeLoftTrajectoryCandidate:
     source_fit_candidate_id: str
     source_residual_report: FitResidualReport
     fit_configuration_identity: tuple[object, ...] | None
+    evidence_lane: str = "shared_trajectory_curve_fit"
+
+
+@dataclass(frozen=True)
+class SharedWholeLoftTrajectoryAssessment:
+    candidate: SharedWholeLoftTrajectoryCandidate | None
+    confidence: float
+    posture: SharedWholeLoftTrajectoryPosture
+    reason: str
     evidence_lane: str = "shared_trajectory_curve_fit"
 
 
@@ -42,7 +54,45 @@ def generate_shared_whole_loft_trajectory_candidates(
     )
 
 
+def assess_shared_whole_loft_trajectory_candidates(
+    candidates: tuple[SharedWholeLoftTrajectoryCandidate, ...],
+) -> SharedWholeLoftTrajectoryAssessment:
+    if not candidates:
+        return SharedWholeLoftTrajectoryAssessment(
+            candidate=None,
+            confidence=0.0,
+            posture="refused",
+            reason="missing_shared_whole_loft_trajectory_candidates",
+        )
+
+    best = min(candidates, key=lambda candidate: candidate.source_residual_report.residual_value)
+    residual_report = best.source_residual_report
+    if not residual_report.within_acceptance_threshold:
+        return SharedWholeLoftTrajectoryAssessment(
+            candidate=None,
+            confidence=0.0,
+            posture="refused",
+            reason="shared_whole_loft_trajectory_residual_above_threshold",
+        )
+    if residual_report.approximation_posture == "exact":
+        return SharedWholeLoftTrajectoryAssessment(
+            candidate=best,
+            confidence=1.0,
+            posture="accepted",
+            reason="shared_whole_loft_trajectory_exact_within_threshold",
+        )
+    return SharedWholeLoftTrajectoryAssessment(
+        candidate=best,
+        confidence=0.5,
+        posture="uncertain",
+        reason="shared_whole_loft_trajectory_approximate_within_threshold",
+    )
+
+
 __all__ = [
+    "SharedWholeLoftTrajectoryAssessment",
     "SharedWholeLoftTrajectoryCandidate",
+    "SharedWholeLoftTrajectoryPosture",
+    "assess_shared_whole_loft_trajectory_candidates",
     "generate_shared_whole_loft_trajectory_candidates",
 ]

--- a/tests/test_inference_candidates.py
+++ b/tests/test_inference_candidates.py
@@ -6,6 +6,7 @@ from impression.modeling import (
     KnotCountPolicyRecord,
     KnotPlacementPolicyRecord,
     ParameterizationPolicyRecord,
+    assess_shared_whole_loft_trajectory_candidates,
     compare_shared_trajectory_curve_fit_candidates,
     compare_station_derived_curve_fit_candidates,
     generate_shared_whole_loft_trajectory_candidates,
@@ -289,3 +290,78 @@ def test_fitted_curve_evidence_contribution_remains_explicit() -> None:
 
     assert all(candidate.source_fit_candidate_id for candidate in candidates)
     assert all(candidate.source_residual_report.metric_name for candidate in candidates)
+
+
+def test_weak_or_conflicting_evidence_produces_explicit_confidence_or_refusal_posture() -> None:
+    assessment = assess_shared_whole_loft_trajectory_candidates(
+        generate_shared_whole_loft_trajectory_candidates(
+            prepare_dense_loft_fit_descriptors(_dense_fixture()),
+            fit_configuration=_fit_config(),
+        )
+    )
+
+    assert assessment.posture in {"accepted", "uncertain", "refused"}
+    assert assessment.reason
+
+
+def test_confidence_posture_is_attached_to_generated_shared_trajectory_candidates() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    assessment = assess_shared_whole_loft_trajectory_candidates(candidates)
+
+    assert assessment.candidate is not None
+    assert assessment.candidate.candidate_id.startswith("whole_loft_")
+
+
+def test_weak_evidence_is_not_silently_promoted_to_accepted_trajectory_truth() -> None:
+    candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )
+    weak_candidates = tuple(
+        type(candidate)(
+            candidate_id=candidate.candidate_id,
+            trajectory_curve=candidate.trajectory_curve,
+            source_fit_candidate_id=candidate.source_fit_candidate_id,
+            source_residual_report=type(candidate.source_residual_report)(
+                metric_name=candidate.source_residual_report.metric_name,
+                residual_value=1.0,
+                acceptance_threshold=0.1,
+                approximation_posture="approximate",
+                exact_threshold=0.0,
+            ),
+            fit_configuration_identity=candidate.fit_configuration_identity,
+            evidence_lane=candidate.evidence_lane,
+        )
+        for candidate in candidates
+    )
+
+    assessment = assess_shared_whole_loft_trajectory_candidates(weak_candidates)
+
+    assert assessment.candidate is None
+    assert assessment.posture == "refused"
+
+
+def test_refusal_or_uncertainty_remain_first_class_outputs() -> None:
+    approximate_candidates = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[1:]
+
+    assessment = assess_shared_whole_loft_trajectory_candidates(approximate_candidates)
+
+    assert assessment.posture == "uncertain"
+    assert assessment.candidate is not None
+
+
+def test_scope_remains_limited_to_whole_loft_shared_trajectories() -> None:
+    assessment = assess_shared_whole_loft_trajectory_candidates(
+        generate_shared_whole_loft_trajectory_candidates(
+            prepare_dense_loft_fit_descriptors(_dense_fixture()),
+            fit_configuration=_fit_config(),
+        )
+    )
+
+    assert assessment.evidence_lane == "shared_trajectory_curve_fit"


### PR DESCRIPTION
## Summary
- add explicit assessment for whole-loft shared trajectory confidence, uncertainty, and refusal
- keep weak evidence from being silently promoted to accepted trajectory truth
- document and test the whole-loft trajectory posture layer

## Testing
- ./.venv/bin/pytest tests/test_inference_candidates.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
