### PR TITLE
Implement 0.1.0.a Feature Spec 07B1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -257,6 +257,25 @@ Those candidate records keep the boundary honest:
 - source fit candidate identity remains explicit
 - source residual evidence remains attached for later posture decisions
 
+Explicit shared guidance can then attach to a progression through a durable
+attachment record:
+
+```python
+from impression.modeling import ExplicitSharedGuidanceAttachmentRecord
+
+attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+    guidance_id="guidance-0",
+    progression=progression,
+    candidate=whole_loft_candidates[0],
+)
+```
+
+That first guidance milestone keeps:
+
+- attachment identity deterministic and inspectable
+- replay payload shape stable
+- attachment metadata durable for later diagnostics
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -101,6 +101,9 @@ from .shared_trajectory import (
     assess_shared_whole_loft_trajectory_candidates,
     generate_shared_whole_loft_trajectory_candidates,
 )
+from .shared_guidance import (
+    ExplicitSharedGuidanceAttachmentRecord,
+)
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
     FitApproximationPosture,
@@ -293,6 +296,7 @@ __all__ = [
     "CurveIntentPosture",
     "classify_curve_intent_candidate",
     "SharedWholeLoftTrajectoryAssessment",
+    "ExplicitSharedGuidanceAttachmentRecord",
     "SharedWholeLoftTrajectoryCandidate",
     "SharedWholeLoftTrajectoryPosture",
     "assess_shared_whole_loft_trajectory_candidates",

--- a/src/impression/modeling/shared_guidance.py
+++ b/src/impression/modeling/shared_guidance.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .progression import PathBackedProgression
+from .shared_trajectory import SharedWholeLoftTrajectoryCandidate
+
+
+def _normalize_metadata_entries(
+    metadata_entries: tuple[tuple[str, str], ...] | list[tuple[str, str]] | None,
+) -> tuple[tuple[str, str], ...]:
+    if metadata_entries is None:
+        return ()
+    normalized: list[tuple[str, str]] = []
+    for key, value in metadata_entries:
+        normalized_key = str(key).strip()
+        normalized_value = str(value).strip()
+        if not normalized_key:
+            raise ValueError("metadata keys must be non-empty.")
+        if not normalized_value:
+            raise ValueError("metadata values must be non-empty.")
+        normalized.append((normalized_key, normalized_value))
+    return tuple(normalized)
+
+
+@dataclass(frozen=True)
+class ExplicitSharedGuidanceAttachmentRecord:
+    guidance_id: str
+    progression_identity: tuple[object, ...]
+    trajectory_candidate_id: str
+    trajectory_evidence_lane: str
+    fit_configuration_identity: tuple[object, ...] | None
+    metadata_entries: tuple[tuple[str, str], ...] = ()
+
+    def __init__(
+        self,
+        *,
+        guidance_id: str,
+        progression_identity: tuple[object, ...],
+        trajectory_candidate_id: str,
+        trajectory_evidence_lane: str,
+        fit_configuration_identity: tuple[object, ...] | None,
+        metadata_entries: tuple[tuple[str, str], ...] | list[tuple[str, str]] | None = None,
+    ) -> None:
+        normalized_guidance_id = str(guidance_id).strip()
+        normalized_candidate_id = str(trajectory_candidate_id).strip()
+        normalized_lane = str(trajectory_evidence_lane).strip()
+        if not normalized_guidance_id:
+            raise ValueError("guidance_id must be non-empty.")
+        if not normalized_candidate_id:
+            raise ValueError("trajectory_candidate_id must be non-empty.")
+        if not normalized_lane:
+            raise ValueError("trajectory_evidence_lane must be non-empty.")
+        object.__setattr__(self, "guidance_id", normalized_guidance_id)
+        object.__setattr__(self, "progression_identity", progression_identity)
+        object.__setattr__(self, "trajectory_candidate_id", normalized_candidate_id)
+        object.__setattr__(self, "trajectory_evidence_lane", normalized_lane)
+        object.__setattr__(self, "fit_configuration_identity", fit_configuration_identity)
+        object.__setattr__(self, "metadata_entries", _normalize_metadata_entries(metadata_entries))
+
+    @classmethod
+    def from_candidate(
+        cls,
+        *,
+        guidance_id: str,
+        progression: PathBackedProgression,
+        candidate: SharedWholeLoftTrajectoryCandidate,
+        metadata_entries: tuple[tuple[str, str], ...] | list[tuple[str, str]] | None = None,
+    ) -> "ExplicitSharedGuidanceAttachmentRecord":
+        return cls(
+            guidance_id=guidance_id,
+            progression_identity=progression.identity,
+            trajectory_candidate_id=candidate.candidate_id,
+            trajectory_evidence_lane=candidate.evidence_lane,
+            fit_configuration_identity=candidate.fit_configuration_identity,
+            metadata_entries=metadata_entries,
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "explicit_shared_guidance_attachment",
+            self.guidance_id,
+            self.progression_identity,
+            self.trajectory_candidate_id,
+        )
+
+    @property
+    def replay_payload(self) -> tuple[object, ...]:
+        return (
+            "explicit_shared_guidance_attachment",
+            self.guidance_id,
+            self.progression_identity,
+            self.trajectory_candidate_id,
+            self.trajectory_evidence_lane,
+            self.fit_configuration_identity,
+            self.metadata_entries,
+        )
+
+
+__all__ = [
+    "ExplicitSharedGuidanceAttachmentRecord",
+]

--- a/tests/test_shared_guidance.py
+++ b/tests/test_shared_guidance.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    ExplicitSharedGuidanceAttachmentRecord,
+    FitConfigurationRecord,
+    KnotCountPolicyRecord,
+    KnotPlacementPolicyRecord,
+    ParameterizationPolicyRecord,
+    Path3D,
+    PathBackedProgression,
+    Station,
+    as_section,
+    generate_shared_whole_loft_trajectory_candidates,
+    prepare_dense_loft_fit_descriptors,
+)
+from impression.modeling.drawing2d import make_circle, make_rect
+
+
+def _dense_fixture() -> list[Station]:
+    return [
+        Station(
+            t=0.0,
+            section=as_section(make_rect(size=(1.0, 1.0))),
+            origin=(0.0, 0.0, 0.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=0.5,
+            section=as_section(make_circle(radius=0.6)),
+            origin=(0.3, 0.1, 0.5),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+        Station(
+            t=1.0,
+            section=as_section(make_rect(size=(0.8, 1.2))),
+            origin=(1.0, 0.0, 1.0),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        ),
+    ]
+
+
+def _fit_config() -> FitConfigurationRecord:
+    return FitConfigurationRecord(
+        parameterization_policy=ParameterizationPolicyRecord(method="uniform"),
+        knot_count_policy=KnotCountPolicyRecord(strategy="fixed", control_point_count=3),
+        knot_placement_policy=KnotPlacementPolicyRecord(placement_method="uniform_internal"),
+    )
+
+
+def _progression() -> PathBackedProgression:
+    return PathBackedProgression(path=Path3D.from_points([(0.0, 0.0, 0.0), (1.0, 0.0, 1.0)]))
+
+
+def test_explicit_shared_guidance_attaches_through_a_durable_attachment_record() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+
+    record = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-0",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    assert record.trajectory_candidate_id == candidate.candidate_id
+    assert record.progression_identity == _progression().identity
+
+
+def test_attachment_identity_remains_inspectable() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+
+    record = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-1",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    assert record.identity[0] == "explicit_shared_guidance_attachment"
+    assert record.identity[1] == "guidance-1"
+
+
+def test_attachment_record_shape_is_stable_and_replayable() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    first = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-2",
+        progression=_progression(),
+        candidate=candidate,
+    )
+    second = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-2",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    assert first.replay_payload == second.replay_payload
+
+
+def test_deterministic_attachment_identity_is_preserved() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    first = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-3",
+        progression=_progression(),
+        candidate=candidate,
+    )
+    second = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-3",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    assert first.identity == second.identity
+
+
+def test_attachment_metadata_remains_durable_for_later_diagnostics() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    record = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-4",
+        progression=_progression(),
+        candidate=candidate,
+        metadata_entries=(("source", "authored_guidance"), ("note", "hourglass")), 
+    )
+
+    assert record.metadata_entries == (("source", "authored_guidance"), ("note", "hourglass"))


### PR DESCRIPTION
## Summary
- add durable explicit shared-guidance attachment records for path-backed progression
- keep attachment identity and replay payload inspectable and deterministic
- document and test the first shared-guidance attachment lane

## Testing
- ./.venv/bin/pytest tests/test_shared_guidance.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
