### PR TITLE
Implement 0.1.0.a Feature Spec 07B2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -276,6 +276,24 @@ That first guidance milestone keeps:
 - replay payload shape stable
 - attachment metadata durable for later diagnostics
 
+Planner consumption of explicit shared guidance is then represented separately:
+
+```python
+from impression.modeling import ExplicitSharedGuidancePlannerConsumption
+
+consumption = ExplicitSharedGuidancePlannerConsumption(
+    planner_stage="in_between_travel",
+    topology_station_ids=("topo-0", "topo-1"),
+    attachment_identity=attachment.identity,
+)
+```
+
+That keeps the second guidance milestone explicit too:
+
+- planner consumption remains deterministic
+- guidance stays bounded to in-between travel semantics
+- topology-owned planning truth remains primary
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -103,6 +103,8 @@ from .shared_trajectory import (
 )
 from .shared_guidance import (
     ExplicitSharedGuidanceAttachmentRecord,
+    ExplicitSharedGuidancePlannerConsumption,
+    ExplicitSharedGuidancePlannerStage,
 )
 from .bspline import BSpline2D, BSpline3D
 from .fit_records import (
@@ -297,6 +299,8 @@ __all__ = [
     "classify_curve_intent_candidate",
     "SharedWholeLoftTrajectoryAssessment",
     "ExplicitSharedGuidanceAttachmentRecord",
+    "ExplicitSharedGuidancePlannerConsumption",
+    "ExplicitSharedGuidancePlannerStage",
     "SharedWholeLoftTrajectoryCandidate",
     "SharedWholeLoftTrajectoryPosture",
     "assess_shared_whole_loft_trajectory_candidates",

--- a/src/impression/modeling/shared_guidance.py
+++ b/src/impression/modeling/shared_guidance.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from .progression import PathBackedProgression
 from .shared_trajectory import SharedWholeLoftTrajectoryCandidate
+
+ExplicitSharedGuidancePlannerStage = Literal["in_between_travel"]
 
 
 def _normalize_metadata_entries(
@@ -21,6 +24,14 @@ def _normalize_metadata_entries(
             raise ValueError("metadata values must be non-empty.")
         normalized.append((normalized_key, normalized_value))
     return tuple(normalized)
+
+
+def _normalize_planner_stage(value: str) -> ExplicitSharedGuidancePlannerStage:
+    allowed: set[str] = {"in_between_travel"}
+    stage = str(value)
+    if stage not in allowed:
+        raise ValueError("planner_stage must be one of: in_between_travel.")
+    return stage  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)
@@ -98,6 +109,48 @@ class ExplicitSharedGuidanceAttachmentRecord:
         )
 
 
+@dataclass(frozen=True)
+class ExplicitSharedGuidancePlannerConsumption:
+    planner_stage: ExplicitSharedGuidancePlannerStage
+    topology_station_ids: tuple[str, ...]
+    attachment_identity: tuple[object, ...]
+    bounded_to_in_between_travel: bool = True
+    overrides_topology_truth: bool = False
+
+    def __init__(
+        self,
+        *,
+        planner_stage: ExplicitSharedGuidancePlannerStage,
+        topology_station_ids: tuple[str, ...] | list[str],
+        attachment_identity: tuple[object, ...],
+        bounded_to_in_between_travel: bool = True,
+        overrides_topology_truth: bool = False,
+    ) -> None:
+        normalized_topology = tuple(str(value).strip() for value in topology_station_ids)
+        if any(not value for value in normalized_topology):
+            raise ValueError("topology_station_ids must be non-empty strings.")
+        object.__setattr__(self, "planner_stage", _normalize_planner_stage(planner_stage))
+        object.__setattr__(self, "topology_station_ids", normalized_topology)
+        object.__setattr__(self, "attachment_identity", attachment_identity)
+        object.__setattr__(self, "bounded_to_in_between_travel", bool(bounded_to_in_between_travel))
+        object.__setattr__(self, "overrides_topology_truth", bool(overrides_topology_truth))
+        if not self.bounded_to_in_between_travel:
+            raise ValueError("explicit shared guidance must remain bounded to in-between travel.")
+        if self.overrides_topology_truth:
+            raise ValueError("explicit shared guidance must not override topology truth.")
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "explicit_shared_guidance_planner_consumption",
+            self.planner_stage,
+            self.topology_station_ids,
+            self.attachment_identity,
+        )
+
+
 __all__ = [
     "ExplicitSharedGuidanceAttachmentRecord",
+    "ExplicitSharedGuidancePlannerConsumption",
+    "ExplicitSharedGuidancePlannerStage",
 ]

--- a/tests/test_shared_guidance.py
+++ b/tests/test_shared_guidance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from impression.modeling import (
     ExplicitSharedGuidanceAttachmentRecord,
+    ExplicitSharedGuidancePlannerConsumption,
     FitConfigurationRecord,
     KnotCountPolicyRecord,
     KnotPlacementPolicyRecord,
@@ -136,7 +137,121 @@ def test_attachment_metadata_remains_durable_for_later_diagnostics() -> None:
         guidance_id="guidance-4",
         progression=_progression(),
         candidate=candidate,
-        metadata_entries=(("source", "authored_guidance"), ("note", "hourglass")), 
+        metadata_entries=(("source", "authored_guidance"), ("note", "hourglass")),
     )
 
     assert record.metadata_entries == (("source", "authored_guidance"), ("note", "hourglass"))
+
+
+def test_planner_stages_that_consume_explicit_shared_guidance_are_inspectable() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-5",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    consumption = ExplicitSharedGuidancePlannerConsumption(
+        planner_stage="in_between_travel",
+        topology_station_ids=("topo-0", "topo-1"),
+        attachment_identity=attachment.identity,
+    )
+
+    assert consumption.planner_stage == "in_between_travel"
+    assert consumption.attachment_identity == attachment.identity
+
+
+def test_topology_truth_remains_visible_alongside_guidance_consumption() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-6",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    consumption = ExplicitSharedGuidancePlannerConsumption(
+        planner_stage="in_between_travel",
+        topology_station_ids=("topo-0", "topo-1"),
+        attachment_identity=attachment.identity,
+    )
+
+    assert consumption.topology_station_ids == ("topo-0", "topo-1")
+
+
+def test_explicit_shared_guidance_does_not_override_topology_owned_planning_truth() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-7",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    try:
+        ExplicitSharedGuidancePlannerConsumption(
+            planner_stage="in_between_travel",
+            topology_station_ids=("topo-0", "topo-1"),
+            attachment_identity=attachment.identity,
+            overrides_topology_truth=True,
+        )
+    except ValueError as exc:
+        assert "must not override topology truth" in str(exc)
+    else:
+        raise AssertionError("Expected topology override to fail.")
+
+
+def test_planner_consumption_behavior_remains_deterministic() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-8",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    first = ExplicitSharedGuidancePlannerConsumption(
+        planner_stage="in_between_travel",
+        topology_station_ids=("topo-0", "topo-1"),
+        attachment_identity=attachment.identity,
+    )
+    second = ExplicitSharedGuidancePlannerConsumption(
+        planner_stage="in_between_travel",
+        topology_station_ids=("topo-0", "topo-1"),
+        attachment_identity=attachment.identity,
+    )
+
+    assert first.identity == second.identity
+
+
+def test_guidance_influence_stays_bounded_to_in_between_travel_semantics() -> None:
+    candidate = generate_shared_whole_loft_trajectory_candidates(
+        prepare_dense_loft_fit_descriptors(_dense_fixture()),
+        fit_configuration=_fit_config(),
+    )[0]
+    attachment = ExplicitSharedGuidanceAttachmentRecord.from_candidate(
+        guidance_id="guidance-9",
+        progression=_progression(),
+        candidate=candidate,
+    )
+
+    try:
+        ExplicitSharedGuidancePlannerConsumption(
+            planner_stage="in_between_travel",
+            topology_station_ids=("topo-0", "topo-1"),
+            attachment_identity=attachment.identity,
+            bounded_to_in_between_travel=False,
+        )
+    except ValueError as exc:
+        assert "must remain bounded to in-between travel" in str(exc)
+    else:
+        raise AssertionError("Expected out-of-bounds guidance consumption to fail.")


### PR DESCRIPTION
## Summary
- add explicit planner-consumption records for shared guidance attachments
- keep guidance influence bounded to in-between travel semantics and subordinate to topology truth
- document and test deterministic shared-guidance consumption boundaries

## Testing
- ./.venv/bin/pytest tests/test_shared_guidance.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
