### PR TITLE
Implement 0.1.0.a Feature Spec 05A1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -294,6 +294,26 @@ That keeps the second guidance milestone explicit too:
 - guidance stays bounded to in-between travel semantics
 - topology-owned planning truth remains primary
 
+Control-station inference can also emit a reduced progression bundle as a
+replayable result:
+
+```python
+from impression.modeling import ReducedProgressionBundle
+
+bundle = ReducedProgressionBundle.from_progression(
+    bundle_id="reduction-0",
+    progression=progression,
+    retained_progression_values=(0.0, 0.5, 1.0),
+    hidden_control_station_ids=("control-0",),
+)
+```
+
+That bundle contract keeps:
+
+- reduced progression output replayable
+- bundle-local provenance explicit
+- bundle shape stable for identical inputs
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -69,6 +69,9 @@ from .control_stations import (
     HiddenControlStationRecord,
     HiddenControlStationSource,
 )
+from .control_station_inference import (
+    ReducedProgressionBundle,
+)
 from .inference_descriptors import (
     CorrespondenceTrackDescriptor,
     CurveIntentDescriptorFamilies,
@@ -278,6 +281,7 @@ __all__ = [
     "HiddenControlStationPlannerConsumption",
     "HiddenControlStationPlannerStage",
     "HiddenControlStationSource",
+    "ReducedProgressionBundle",
     "DenseLoftDescriptorBand",
     "DenseLoftStationDescriptor",
     "SectionCurveIntentDescriptor",

--- a/src/impression/modeling/control_station_inference.py
+++ b/src/impression/modeling/control_station_inference.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .progression import PathBackedProgression
+
+
+@dataclass(frozen=True)
+class ReducedProgressionBundle:
+    bundle_id: str
+    progression_identity: tuple[object, ...]
+    retained_progression_values: tuple[float, ...]
+    hidden_control_station_ids: tuple[str, ...]
+    provenance_source: str
+    replay_version: str = "0.1.0.a"
+
+    def __init__(
+        self,
+        *,
+        bundle_id: str,
+        progression_identity: tuple[object, ...],
+        retained_progression_values: tuple[float, ...] | list[float],
+        hidden_control_station_ids: tuple[str, ...] | list[str],
+        provenance_source: str = "control_station_inference",
+        replay_version: str = "0.1.0.a",
+    ) -> None:
+        normalized_bundle_id = str(bundle_id).strip()
+        normalized_source = str(provenance_source).strip()
+        normalized_version = str(replay_version).strip()
+        if not normalized_bundle_id:
+            raise ValueError("bundle_id must be non-empty.")
+        if not normalized_source:
+            raise ValueError("provenance_source must be non-empty.")
+        if not normalized_version:
+            raise ValueError("replay_version must be non-empty.")
+        normalized_progression = tuple(float(value) for value in retained_progression_values)
+        if len(normalized_progression) < 2:
+            raise ValueError("retained_progression_values must contain at least two values.")
+        if tuple(sorted(normalized_progression)) != normalized_progression:
+            raise ValueError("retained_progression_values must remain ordered.")
+        normalized_hidden = tuple(str(value).strip() for value in hidden_control_station_ids)
+        if any(not value for value in normalized_hidden):
+            raise ValueError("hidden_control_station_ids must be non-empty strings.")
+        object.__setattr__(self, "bundle_id", normalized_bundle_id)
+        object.__setattr__(self, "progression_identity", progression_identity)
+        object.__setattr__(self, "retained_progression_values", normalized_progression)
+        object.__setattr__(self, "hidden_control_station_ids", normalized_hidden)
+        object.__setattr__(self, "provenance_source", normalized_source)
+        object.__setattr__(self, "replay_version", normalized_version)
+
+    @classmethod
+    def from_progression(
+        cls,
+        *,
+        bundle_id: str,
+        progression: PathBackedProgression,
+        retained_progression_values: tuple[float, ...] | list[float],
+        hidden_control_station_ids: tuple[str, ...] | list[str],
+        provenance_source: str = "control_station_inference",
+    ) -> "ReducedProgressionBundle":
+        return cls(
+            bundle_id=bundle_id,
+            progression_identity=progression.identity,
+            retained_progression_values=retained_progression_values,
+            hidden_control_station_ids=hidden_control_station_ids,
+            provenance_source=provenance_source,
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "reduced_progression_bundle",
+            self.bundle_id,
+            self.progression_identity,
+            self.retained_progression_values,
+        )
+
+    @property
+    def replay_payload(self) -> tuple[object, ...]:
+        return (
+            "reduced_progression_bundle",
+            self.bundle_id,
+            self.replay_version,
+            self.progression_identity,
+            self.retained_progression_values,
+            self.hidden_control_station_ids,
+            self.provenance_source,
+        )
+
+
+__all__ = [
+    "ReducedProgressionBundle",
+]

--- a/tests/test_control_station_inference.py
+++ b/tests/test_control_station_inference.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    Path3D,
+    PathBackedProgression,
+    ReducedProgressionBundle,
+)
+
+
+def _progression() -> PathBackedProgression:
+    return PathBackedProgression(path=Path3D.from_points([(0.0, 0.0, 0.0), (1.0, 0.0, 1.0)]))
+
+
+def test_reduced_progression_bundles_emit_the_required_replay_payload_structure() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-0",
+        progression=_progression(),
+        retained_progression_values=(0.0, 0.5, 1.0),
+        hidden_control_station_ids=("control-0",),
+    )
+
+    assert bundle.replay_payload[0] == "reduced_progression_bundle"
+    assert bundle.replay_payload[3] == _progression().identity
+
+
+def test_bundle_local_provenance_fields_remain_inspectable() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-1",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-1",),
+        provenance_source="dense_station_inference",
+    )
+
+    assert bundle.provenance_source == "dense_station_inference"
+
+
+def test_reduced_progression_output_is_replayable() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-2",
+        progression=_progression(),
+        retained_progression_values=(0.0, 0.5, 1.0),
+        hidden_control_station_ids=("control-2", "control-3"),
+    )
+
+    assert bundle.replay_payload[-2] == ("control-2", "control-3")
+
+
+def test_bundle_shape_is_stable_for_identical_inputs() -> None:
+    first = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-3",
+        progression=_progression(),
+        retained_progression_values=(0.0, 0.5, 1.0),
+        hidden_control_station_ids=("control-4",),
+    )
+    second = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-3",
+        progression=_progression(),
+        retained_progression_values=(0.0, 0.5, 1.0),
+        hidden_control_station_ids=("control-4",),
+    )
+
+    assert first.replay_payload == second.replay_payload
+
+
+def test_bundle_local_provenance_remains_explicit() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-4",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-5",),
+        provenance_source="shared_trajectory_fit",
+    )
+
+    assert bundle.provenance_source == "shared_trajectory_fit"


### PR DESCRIPTION
## Summary
- add the reduced progression bundle contract for control-station inference
- keep replay payload shape and bundle-local provenance explicit and stable
- document and test the first reduction output bundle lane

## Testing
- ./.venv/bin/pytest tests/test_control_station_inference.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
