### PR TITLE
Implement 0.1.0.a Feature Spec 05A2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -314,6 +314,26 @@ That bundle contract keeps:
 - bundle-local provenance explicit
 - bundle shape stable for identical inputs
 
+Retained station classes and diagnostic references can then be carried
+explicitly beside that bundle:
+
+```python
+from impression.modeling import RetainedStationRecord
+
+retained = RetainedStationRecord(
+    station_id="topo-0",
+    kind="topology",
+    progression_value=0.0,
+    diagnostic_references=("diag-0",),
+)
+```
+
+That result layer keeps:
+
+- topology and hidden-control station classes distinct
+- diagnostic references inspectable
+- retained structure explicit after reduction
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -71,6 +71,8 @@ from .control_stations import (
 )
 from .control_station_inference import (
     ReducedProgressionBundle,
+    RetainedStationKind,
+    RetainedStationRecord,
 )
 from .inference_descriptors import (
     CorrespondenceTrackDescriptor,
@@ -282,6 +284,8 @@ __all__ = [
     "HiddenControlStationPlannerStage",
     "HiddenControlStationSource",
     "ReducedProgressionBundle",
+    "RetainedStationKind",
+    "RetainedStationRecord",
     "DenseLoftDescriptorBand",
     "DenseLoftStationDescriptor",
     "SectionCurveIntentDescriptor",

--- a/src/impression/modeling/control_station_inference.py
+++ b/src/impression/modeling/control_station_inference.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
-from .progression import PathBackedProgression
+from .control_stations import HiddenControlStationRecord
+from .progression import PathBackedProgression, ProgressionStationAttachment
+
+RetainedStationKind = Literal["topology", "hidden_control"]
+
+
+def _normalize_retained_station_kind(value: str) -> RetainedStationKind:
+    allowed: set[str] = {"topology", "hidden_control"}
+    kind = str(value)
+    if kind not in allowed:
+        raise ValueError("kind must be one of: topology, hidden_control.")
+    return kind  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)
@@ -88,6 +100,74 @@ class ReducedProgressionBundle:
         )
 
 
+@dataclass(frozen=True)
+class RetainedStationRecord:
+    station_id: str
+    kind: RetainedStationKind
+    progression_value: float
+    diagnostic_references: tuple[str, ...] = ()
+
+    def __init__(
+        self,
+        *,
+        station_id: str,
+        kind: RetainedStationKind,
+        progression_value: float,
+        diagnostic_references: tuple[str, ...] | list[str] = (),
+    ) -> None:
+        normalized_station_id = str(station_id).strip()
+        normalized_diagnostics = tuple(str(value).strip() for value in diagnostic_references)
+        if not normalized_station_id:
+            raise ValueError("station_id must be non-empty.")
+        if any(not value for value in normalized_diagnostics):
+            raise ValueError("diagnostic_references must be non-empty strings.")
+        object.__setattr__(self, "station_id", normalized_station_id)
+        object.__setattr__(self, "kind", _normalize_retained_station_kind(kind))
+        object.__setattr__(self, "progression_value", float(progression_value))
+        object.__setattr__(self, "diagnostic_references", normalized_diagnostics)
+
+    @classmethod
+    def from_attachment(
+        cls,
+        *,
+        station_id: str,
+        attachment: ProgressionStationAttachment,
+        diagnostic_references: tuple[str, ...] | list[str] = (),
+    ) -> "RetainedStationRecord":
+        return cls(
+            station_id=station_id,
+            kind="topology",
+            progression_value=attachment.progression_value,
+            diagnostic_references=diagnostic_references,
+        )
+
+    @classmethod
+    def from_hidden_control(
+        cls,
+        *,
+        record: HiddenControlStationRecord,
+        progression_value: float,
+        diagnostic_references: tuple[str, ...] | list[str] = (),
+    ) -> "RetainedStationRecord":
+        return cls(
+            station_id=record.station_id,
+            kind="hidden_control",
+            progression_value=progression_value,
+            diagnostic_references=diagnostic_references,
+        )
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "retained_station_record",
+            self.station_id,
+            self.kind,
+            self.progression_value,
+        )
+
+
 __all__ = [
     "ReducedProgressionBundle",
+    "RetainedStationKind",
+    "RetainedStationRecord",
 ]

--- a/tests/test_control_station_inference.py
+++ b/tests/test_control_station_inference.py
@@ -1,14 +1,32 @@
 from __future__ import annotations
 
 from impression.modeling import (
+    HiddenControlStationProvenanceRecord,
+    HiddenControlStationRecord,
     Path3D,
     PathBackedProgression,
+    ProgressionStationAttachment,
     ReducedProgressionBundle,
+    RetainedStationRecord,
+    Station,
+    as_section,
 )
+from impression.modeling.drawing2d import make_rect
 
 
 def _progression() -> PathBackedProgression:
     return PathBackedProgression(path=Path3D.from_points([(0.0, 0.0, 0.0), (1.0, 0.0, 1.0)]))
+
+
+def _station(progress: float = 0.5) -> Station:
+    return Station(
+        t=progress,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, progress),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
+    )
 
 
 def test_reduced_progression_bundles_emit_the_required_replay_payload_structure() -> None:
@@ -73,3 +91,83 @@ def test_bundle_local_provenance_remains_explicit() -> None:
     )
 
     assert bundle.provenance_source == "shared_trajectory_fit"
+
+
+def test_reduced_progression_results_retain_topology_and_hidden_control_station_classifications() -> None:
+    attachment = ProgressionStationAttachment.from_station(
+        progression=_progression(),
+        station=_station(0.25),
+        station_index=0,
+    )
+    hidden = HiddenControlStationRecord.from_station(
+        station_id="control-0",
+        station=_station(0.75),
+        provenance=HiddenControlStationProvenanceRecord(),
+    )
+
+    topology = RetainedStationRecord.from_attachment(
+        station_id="topo-0",
+        attachment=attachment,
+    )
+    control = RetainedStationRecord.from_hidden_control(
+        record=hidden,
+        progression_value=0.75,
+    )
+
+    assert topology.kind == "topology"
+    assert control.kind == "hidden_control"
+
+
+def test_supporting_diagnostic_references_remain_inspectable_from_retained_station_records() -> None:
+    attachment = ProgressionStationAttachment.from_station(
+        progression=_progression(),
+        station=_station(0.5),
+        station_index=0,
+    )
+    record = RetainedStationRecord.from_attachment(
+        station_id="topo-1",
+        attachment=attachment,
+        diagnostic_references=("diag-a", "diag-b"),
+    )
+
+    assert record.diagnostic_references == ("diag-a", "diag-b")
+
+
+def test_retained_station_class_recording_is_explicit() -> None:
+    record = RetainedStationRecord(
+        station_id="topo-2",
+        kind="topology",
+        progression_value=1.0,
+    )
+
+    assert record.kind == "topology"
+
+
+def test_diagnostic_association_does_not_blur_topology_and_control_station_classes() -> None:
+    topology = RetainedStationRecord(
+        station_id="shared-id",
+        kind="topology",
+        progression_value=0.0,
+        diagnostic_references=("diag-topo",),
+    )
+    control = RetainedStationRecord(
+        station_id="shared-id",
+        kind="hidden_control",
+        progression_value=0.5,
+        diagnostic_references=("diag-control",),
+    )
+
+    assert topology.kind != control.kind
+    assert topology.diagnostic_references != control.diagnostic_references
+
+
+def test_retained_structure_remains_inspectable_after_reduction() -> None:
+    record = RetainedStationRecord(
+        station_id="topo-3",
+        kind="topology",
+        progression_value=0.25,
+        diagnostic_references=("diag-structure",),
+    )
+
+    assert record.identity[0] == "retained_station_record"
+    assert record.progression_value == 0.25


### PR DESCRIPTION
## Summary
- add retained station records with explicit topology/control classification
- keep diagnostic references inspectable without blurring retained station kinds
- document and test the retained-structure result layer

## Testing
- ./.venv/bin/pytest tests/test_control_station_inference.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
