### PR TITLE
Implement 0.1.0.a Feature Spec 05B

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -334,6 +334,24 @@ That result layer keeps:
 - diagnostic references inspectable
 - retained structure explicit after reduction
 
+Structural preservation and refusal are then assessed explicitly:
+
+```python
+from impression.modeling import assess_control_station_inference
+
+assessment = assess_control_station_inference(
+    bundle=bundle,
+    retained_station_records=(retained,),
+    required_topology_station_ids=("topo-0",),
+)
+```
+
+That assessment keeps:
+
+- topology-critical drops explicit
+- refusal a first-class valid outcome
+- structural preservation inspectable even when a reduction is refused
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -70,9 +70,13 @@ from .control_stations import (
     HiddenControlStationSource,
 )
 from .control_station_inference import (
+    ControlStationInferenceAssessment,
+    ControlStationInferencePosture,
     ReducedProgressionBundle,
     RetainedStationKind,
     RetainedStationRecord,
+    StructuralPreservationReport,
+    assess_control_station_inference,
 )
 from .inference_descriptors import (
     CorrespondenceTrackDescriptor,
@@ -283,9 +287,13 @@ __all__ = [
     "HiddenControlStationPlannerConsumption",
     "HiddenControlStationPlannerStage",
     "HiddenControlStationSource",
+    "ControlStationInferenceAssessment",
+    "ControlStationInferencePosture",
     "ReducedProgressionBundle",
     "RetainedStationKind",
     "RetainedStationRecord",
+    "StructuralPreservationReport",
+    "assess_control_station_inference",
     "DenseLoftDescriptorBand",
     "DenseLoftStationDescriptor",
     "SectionCurveIntentDescriptor",

--- a/src/impression/modeling/control_station_inference.py
+++ b/src/impression/modeling/control_station_inference.py
@@ -7,6 +7,7 @@ from .control_stations import HiddenControlStationRecord
 from .progression import PathBackedProgression, ProgressionStationAttachment
 
 RetainedStationKind = Literal["topology", "hidden_control"]
+ControlStationInferencePosture = Literal["accepted", "refused"]
 
 
 def _normalize_retained_station_kind(value: str) -> RetainedStationKind:
@@ -15,6 +16,14 @@ def _normalize_retained_station_kind(value: str) -> RetainedStationKind:
     if kind not in allowed:
         raise ValueError("kind must be one of: topology, hidden_control.")
     return kind  # type: ignore[return-value]
+
+
+def _normalize_control_station_inference_posture(value: str) -> ControlStationInferencePosture:
+    allowed: set[str] = {"accepted", "refused"}
+    posture = str(value)
+    if posture not in allowed:
+        raise ValueError("posture must be one of: accepted, refused.")
+    return posture  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)
@@ -166,8 +175,91 @@ class RetainedStationRecord:
         )
 
 
+@dataclass(frozen=True)
+class StructuralPreservationReport:
+    required_topology_station_ids: tuple[str, ...]
+    retained_topology_station_ids: tuple[str, ...]
+    dropped_topology_station_ids: tuple[str, ...]
+    supporting_diagnostic_references: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ControlStationInferenceAssessment:
+    bundle: ReducedProgressionBundle | None
+    structural_preservation: StructuralPreservationReport
+    posture: ControlStationInferencePosture
+    reason: str
+
+    def __init__(
+        self,
+        *,
+        bundle: ReducedProgressionBundle | None,
+        structural_preservation: StructuralPreservationReport,
+        posture: ControlStationInferencePosture,
+        reason: str,
+    ) -> None:
+        normalized_reason = str(reason).strip()
+        if not normalized_reason:
+            raise ValueError("reason must be non-empty.")
+        object.__setattr__(self, "bundle", bundle)
+        object.__setattr__(self, "structural_preservation", structural_preservation)
+        object.__setattr__(self, "posture", _normalize_control_station_inference_posture(posture))
+        object.__setattr__(self, "reason", normalized_reason)
+
+
+def assess_control_station_inference(
+    *,
+    bundle: ReducedProgressionBundle,
+    retained_station_records: tuple[RetainedStationRecord, ...] | list[RetainedStationRecord],
+    required_topology_station_ids: tuple[str, ...] | list[str],
+) -> ControlStationInferenceAssessment:
+    normalized_required = tuple(str(value).strip() for value in required_topology_station_ids)
+    if any(not value for value in normalized_required):
+        raise ValueError("required_topology_station_ids must be non-empty strings.")
+
+    retained_topology = tuple(
+        record.station_id
+        for record in retained_station_records
+        if record.kind == "topology"
+    )
+    retained_topology_set = set(retained_topology)
+    dropped_topology = tuple(
+        station_id for station_id in normalized_required if station_id not in retained_topology_set
+    )
+    diagnostic_references = tuple(
+        dict.fromkeys(
+            diagnostic
+            for record in retained_station_records
+            for diagnostic in record.diagnostic_references
+        )
+    )
+    structural_report = StructuralPreservationReport(
+        required_topology_station_ids=normalized_required,
+        retained_topology_station_ids=retained_topology,
+        dropped_topology_station_ids=dropped_topology,
+        supporting_diagnostic_references=diagnostic_references,
+    )
+    if dropped_topology:
+        return ControlStationInferenceAssessment(
+            bundle=None,
+            structural_preservation=structural_report,
+            posture="refused",
+            reason="missing_topology_critical_structure",
+        )
+    return ControlStationInferenceAssessment(
+        bundle=bundle,
+        structural_preservation=structural_report,
+        posture="accepted",
+        reason="topology_critical_structure_preserved",
+    )
+
+
 __all__ = [
+    "ControlStationInferenceAssessment",
+    "ControlStationInferencePosture",
     "ReducedProgressionBundle",
     "RetainedStationKind",
     "RetainedStationRecord",
+    "StructuralPreservationReport",
+    "assess_control_station_inference",
 ]

--- a/tests/test_control_station_inference.py
+++ b/tests/test_control_station_inference.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from impression.modeling import (
+    ControlStationInferenceAssessment,
     HiddenControlStationProvenanceRecord,
     HiddenControlStationRecord,
     Path3D,
@@ -9,6 +10,7 @@ from impression.modeling import (
     ReducedProgressionBundle,
     RetainedStationRecord,
     Station,
+    assess_control_station_inference,
     as_section,
 )
 from impression.modeling.drawing2d import make_rect
@@ -171,3 +173,116 @@ def test_retained_structure_remains_inspectable_after_reduction() -> None:
 
     assert record.identity[0] == "retained_station_record"
     assert record.progression_value == 0.25
+
+
+def test_representative_reductions_emit_structural_preservation_reports() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-5",
+        progression=_progression(),
+        retained_progression_values=(0.0, 0.5, 1.0),
+        hidden_control_station_ids=("control-6",),
+    )
+    retained = (
+        RetainedStationRecord(
+            station_id="topo-0",
+            kind="topology",
+            progression_value=0.0,
+            diagnostic_references=("diag-topo",),
+        ),
+        RetainedStationRecord(
+            station_id="control-6",
+            kind="hidden_control",
+            progression_value=0.5,
+            diagnostic_references=("diag-control",),
+        ),
+    )
+
+    assessment = assess_control_station_inference(
+        bundle=bundle,
+        retained_station_records=retained,
+        required_topology_station_ids=("topo-0",),
+    )
+
+    assert isinstance(assessment, ControlStationInferenceAssessment)
+    assert assessment.structural_preservation.retained_topology_station_ids == ("topo-0",)
+
+
+def test_unsafe_reductions_emit_explicit_refusal_outcomes() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-6",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-7",),
+    )
+
+    assessment = assess_control_station_inference(
+        bundle=bundle,
+        retained_station_records=(),
+        required_topology_station_ids=("topo-0",),
+    )
+
+    assert assessment.posture == "refused"
+    assert assessment.bundle is None
+
+
+def test_topology_critical_structure_is_not_dropped_silently() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-7",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-8",),
+    )
+
+    assessment = assess_control_station_inference(
+        bundle=bundle,
+        retained_station_records=(),
+        required_topology_station_ids=("topo-0", "topo-1"),
+    )
+
+    assert assessment.structural_preservation.dropped_topology_station_ids == ("topo-0", "topo-1")
+
+
+def test_refusal_causes_remain_durable_and_inspectable() -> None:
+    bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-8",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-9",),
+    )
+
+    assessment = assess_control_station_inference(
+        bundle=bundle,
+        retained_station_records=(),
+        required_topology_station_ids=("topo-2",),
+    )
+
+    assert assessment.reason == "missing_topology_critical_structure"
+
+
+def test_structural_preservation_and_refusal_remain_first_class_valid_outcomes() -> None:
+    accepted_bundle = ReducedProgressionBundle.from_progression(
+        bundle_id="reduction-9",
+        progression=_progression(),
+        retained_progression_values=(0.0, 1.0),
+        hidden_control_station_ids=("control-10",),
+    )
+    accepted = assess_control_station_inference(
+        bundle=accepted_bundle,
+        retained_station_records=(
+            RetainedStationRecord(
+                station_id="topo-4",
+                kind="topology",
+                progression_value=0.0,
+                diagnostic_references=("diag-ok",),
+            ),
+        ),
+        required_topology_station_ids=("topo-4",),
+    )
+    refused = assess_control_station_inference(
+        bundle=accepted_bundle,
+        retained_station_records=(),
+        required_topology_station_ids=("topo-4",),
+    )
+
+    assert accepted.posture == "accepted"
+    assert refused.posture == "refused"


### PR DESCRIPTION
## Summary
- add structural preservation reporting and explicit refusal posture for control-station inference
- keep topology-critical drops durable and inspectable instead of silently accepting unsafe reductions
- document and test the structural-preservation assessment layer

## Testing
- ./.venv/bin/pytest tests/test_control_station_inference.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
