### PR TITLE
Implement 0.1.0.a Feature Spec 09A1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -352,6 +352,26 @@ That assessment keeps:
 - refusal a first-class valid outcome
 - structural preservation inspectable even when a reduction is refused
 
+Inference features can also share one diagnostic bundle schema for retained and
+dropped structure, drift, structural preservation, and evidence references:
+
+```python
+from impression.modeling import SharedInferenceDiagnosticBundle
+
+bundle = SharedInferenceDiagnosticBundle(
+    retained_station_entries=(("topo-0", "topology"),),
+    dropped_station_entries=(("topo-1", "topology"),),
+    evidence_references=("fit-a",),
+    provenance_references=("inferred:dense_station_inference",),
+)
+```
+
+That shared schema keeps:
+
+- bundle shape stable across inference branches
+- retained/dropped, drift, and structural fields reusable
+- replay payload durable enough for later reporting layers
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -103,6 +103,11 @@ from .curve_intent import (
     CurveIntentPosture,
     classify_curve_intent_candidate,
 )
+from .inference_diagnostics import (
+    InferenceFitDriftSummary,
+    InferenceStructuralPreservationSummary,
+    SharedInferenceDiagnosticBundle,
+)
 from .shared_trajectory import (
     SharedWholeLoftTrajectoryAssessment,
     SharedWholeLoftTrajectoryCandidate,
@@ -313,6 +318,9 @@ __all__ = [
     "CurveIntentCandidateReport",
     "CurveIntentPosture",
     "classify_curve_intent_candidate",
+    "InferenceFitDriftSummary",
+    "InferenceStructuralPreservationSummary",
+    "SharedInferenceDiagnosticBundle",
     "SharedWholeLoftTrajectoryAssessment",
     "ExplicitSharedGuidanceAttachmentRecord",
     "ExplicitSharedGuidancePlannerConsumption",

--- a/src/impression/modeling/inference_diagnostics.py
+++ b/src/impression/modeling/inference_diagnostics.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .control_station_inference import StructuralPreservationReport
+from .fit_records import FitAssessmentReport
+
+
+def _normalize_station_entries(
+    entries: tuple[tuple[str, str], ...] | list[tuple[str, str]],
+    *,
+    label: str,
+) -> tuple[tuple[str, str], ...]:
+    normalized: list[tuple[str, str]] = []
+    for station_id, kind in entries:
+        normalized_id = str(station_id).strip()
+        normalized_kind = str(kind).strip()
+        if not normalized_id:
+            raise ValueError(f"{label} station ids must be non-empty.")
+        if not normalized_kind:
+            raise ValueError(f"{label} station kinds must be non-empty.")
+        normalized.append((normalized_id, normalized_kind))
+    return tuple(normalized)
+
+
+def _normalize_string_entries(
+    values: tuple[str, ...] | list[str],
+    *,
+    label: str,
+) -> tuple[str, ...]:
+    normalized = tuple(str(value).strip() for value in values)
+    if any(not value for value in normalized):
+        raise ValueError(f"{label} entries must be non-empty strings.")
+    return normalized
+
+
+@dataclass(frozen=True)
+class InferenceFitDriftSummary:
+    metric_name: str
+    residual_value: float
+    acceptance_threshold: float
+    decision_outcome: str
+    decision_reason: str
+
+    @classmethod
+    def from_fit_assessment(cls, assessment: FitAssessmentReport) -> "InferenceFitDriftSummary":
+        return cls(
+            metric_name=assessment.residual_report.metric_name,
+            residual_value=assessment.residual_report.residual_value,
+            acceptance_threshold=assessment.residual_report.acceptance_threshold,
+            decision_outcome=assessment.decision_outcome,
+            decision_reason=assessment.decision_reason,
+        )
+
+
+@dataclass(frozen=True)
+class InferenceStructuralPreservationSummary:
+    required_topology_station_ids: tuple[str, ...]
+    retained_topology_station_ids: tuple[str, ...]
+    dropped_topology_station_ids: tuple[str, ...]
+
+    @classmethod
+    def from_report(
+        cls,
+        report: StructuralPreservationReport,
+    ) -> "InferenceStructuralPreservationSummary":
+        return cls(
+            required_topology_station_ids=report.required_topology_station_ids,
+            retained_topology_station_ids=report.retained_topology_station_ids,
+            dropped_topology_station_ids=report.dropped_topology_station_ids,
+        )
+
+
+@dataclass(frozen=True)
+class SharedInferenceDiagnosticBundle:
+    retained_station_entries: tuple[tuple[str, str], ...]
+    dropped_station_entries: tuple[tuple[str, str], ...]
+    fit_drift: InferenceFitDriftSummary | None
+    structural_preservation: InferenceStructuralPreservationSummary | None
+    evidence_references: tuple[str, ...]
+    provenance_references: tuple[str, ...]
+    schema_version: str = "0.1.0.a"
+
+    def __init__(
+        self,
+        *,
+        retained_station_entries: tuple[tuple[str, str], ...] | list[tuple[str, str]] = (),
+        dropped_station_entries: tuple[tuple[str, str], ...] | list[tuple[str, str]] = (),
+        fit_drift: InferenceFitDriftSummary | None = None,
+        structural_preservation: InferenceStructuralPreservationSummary | None = None,
+        evidence_references: tuple[str, ...] | list[str] = (),
+        provenance_references: tuple[str, ...] | list[str] = (),
+        schema_version: str = "0.1.0.a",
+    ) -> None:
+        normalized_version = str(schema_version).strip()
+        if not normalized_version:
+            raise ValueError("schema_version must be non-empty.")
+        object.__setattr__(
+            self,
+            "retained_station_entries",
+            _normalize_station_entries(retained_station_entries, label="retained"),
+        )
+        object.__setattr__(
+            self,
+            "dropped_station_entries",
+            _normalize_station_entries(dropped_station_entries, label="dropped"),
+        )
+        object.__setattr__(self, "fit_drift", fit_drift)
+        object.__setattr__(self, "structural_preservation", structural_preservation)
+        object.__setattr__(
+            self,
+            "evidence_references",
+            _normalize_string_entries(evidence_references, label="evidence_reference"),
+        )
+        object.__setattr__(
+            self,
+            "provenance_references",
+            _normalize_string_entries(provenance_references, label="provenance_reference"),
+        )
+        object.__setattr__(self, "schema_version", normalized_version)
+
+    @property
+    def identity(self) -> tuple[object, ...]:
+        return (
+            "shared_inference_diagnostic_bundle",
+            self.schema_version,
+            self.retained_station_entries,
+            self.dropped_station_entries,
+            self.evidence_references,
+            self.provenance_references,
+        )
+
+    @property
+    def replay_payload(self) -> tuple[object, ...]:
+        fit_payload = None
+        if self.fit_drift is not None:
+            fit_payload = (
+                self.fit_drift.metric_name,
+                self.fit_drift.residual_value,
+                self.fit_drift.acceptance_threshold,
+                self.fit_drift.decision_outcome,
+                self.fit_drift.decision_reason,
+            )
+        structural_payload = None
+        if self.structural_preservation is not None:
+            structural_payload = (
+                self.structural_preservation.required_topology_station_ids,
+                self.structural_preservation.retained_topology_station_ids,
+                self.structural_preservation.dropped_topology_station_ids,
+            )
+        return (
+            "shared_inference_diagnostic_bundle",
+            self.schema_version,
+            self.retained_station_entries,
+            self.dropped_station_entries,
+            fit_payload,
+            structural_payload,
+            self.evidence_references,
+            self.provenance_references,
+        )
+
+
+__all__ = [
+    "InferenceFitDriftSummary",
+    "InferenceStructuralPreservationSummary",
+    "SharedInferenceDiagnosticBundle",
+]

--- a/tests/test_inference_diagnostics.py
+++ b/tests/test_inference_diagnostics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    FitAssessmentReport,
+    FitResidualReport,
+    InferenceFitDriftSummary,
+    InferenceStructuralPreservationSummary,
+    SharedInferenceDiagnosticBundle,
+    StructuralPreservationReport,
+)
+
+
+def _fit_assessment() -> FitAssessmentReport:
+    return FitAssessmentReport.from_residual(
+        FitResidualReport(
+            metric_name="max_distance_to_station_polyline",
+            residual_value=0.1,
+            acceptance_threshold=0.25,
+            approximation_posture="approximate",
+            exact_threshold=0.0,
+        )
+    )
+
+
+def _structural_report() -> StructuralPreservationReport:
+    return StructuralPreservationReport(
+        required_topology_station_ids=("topo-0", "topo-1"),
+        retained_topology_station_ids=("topo-0",),
+        dropped_topology_station_ids=("topo-1",),
+        supporting_diagnostic_references=("diag-0",),
+    )
+
+
+def test_shared_diagnostic_bundles_expose_retained_dropped_drift_structural_and_evidence_fields() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"), ("control-0", "hidden_control")),
+        dropped_station_entries=(("topo-1", "topology"),),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        structural_preservation=InferenceStructuralPreservationSummary.from_report(_structural_report()),
+        evidence_references=("shared_trajectory_polyline",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+
+    assert bundle.retained_station_entries[0] == ("topo-0", "topology")
+    assert bundle.dropped_station_entries == (("topo-1", "topology"),)
+    assert bundle.fit_drift is not None
+    assert bundle.structural_preservation is not None
+    assert bundle.evidence_references == ("shared_trajectory_polyline",)
+
+
+def test_schema_shape_remains_inspectable_and_reusable() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(),
+        evidence_references=("fit_candidate",),
+        provenance_references=("explicit:authored_path",),
+    )
+
+    assert bundle.identity[0] == "shared_inference_diagnostic_bundle"
+    assert bundle.replay_payload[0] == "shared_inference_diagnostic_bundle"
+
+
+def test_bundle_schema_remains_stable_across_inference_branches() -> None:
+    station_bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        evidence_references=("station_polyline_exact",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+    trajectory_bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        evidence_references=("whole_loft_shared_trajectory",),
+        provenance_references=("inferred:shared_trajectory_fit",),
+    )
+
+    assert len(station_bundle.replay_payload) == len(trajectory_bundle.replay_payload)
+
+
+def test_schema_is_durable_enough_for_replay_and_testing() -> None:
+    first = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+    second = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+
+    assert first.replay_payload == second.replay_payload
+
+
+def test_schema_supports_later_reporting_consumers_without_branch_specific_mutation() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        structural_preservation=InferenceStructuralPreservationSummary.from_report(_structural_report()),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+
+    assert bundle.replay_payload[4] is not None
+    assert bundle.replay_payload[5] is not None


### PR DESCRIPTION
## Summary
- add the shared inference diagnostic bundle schema
- keep retained/dropped, drift, structural preservation, and evidence references in one stable replayable contract
- document and test the shared bundle shape for later reporting layers

## Testing
- ./.venv/bin/pytest tests/test_inference_diagnostics.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
