### PR TITLE
Implement 0.1.0.a Feature Spec 09A2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -372,6 +372,22 @@ That shared schema keeps:
 - retained/dropped, drift, and structural fields reusable
 - replay payload durable enough for later reporting layers
 
+Later inference branches can then populate that same bundle contract through
+shared helper entry points:
+
+```python
+from impression.modeling import SharedInferenceDiagnosticBundle
+
+fit_bundle = SharedInferenceDiagnosticBundle.from_station_fit(
+    assessment=assessment,
+    evidence_reference="station_polyline_exact",
+    provenance_reference="inferred:dense_station_inference",
+)
+```
+
+This keeps bundle population consistent across branches instead of letting each
+feature invent its own reporting shape.
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/inference_diagnostics.py
+++ b/src/impression/modeling/inference_diagnostics.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .control_station_inference import StructuralPreservationReport
+from .control_station_inference import (
+    ControlStationInferenceAssessment,
+    RetainedStationRecord,
+    StructuralPreservationReport,
+)
 from .fit_records import FitAssessmentReport
+from .shared_trajectory import SharedWholeLoftTrajectoryAssessment
 
 
 def _normalize_station_entries(
@@ -157,6 +162,66 @@ class SharedInferenceDiagnosticBundle:
             structural_payload,
             self.evidence_references,
             self.provenance_references,
+        )
+
+    @classmethod
+    def from_station_fit(
+        cls,
+        *,
+        assessment: FitAssessmentReport,
+        evidence_reference: str,
+        provenance_reference: str,
+    ) -> "SharedInferenceDiagnosticBundle":
+        return cls(
+            fit_drift=InferenceFitDriftSummary.from_fit_assessment(assessment),
+            evidence_references=(evidence_reference,),
+            provenance_references=(provenance_reference,),
+        )
+
+    @classmethod
+    def from_shared_trajectory_assessment(
+        cls,
+        *,
+        assessment: SharedWholeLoftTrajectoryAssessment,
+        provenance_reference: str,
+    ) -> "SharedInferenceDiagnosticBundle":
+        evidence_reference = assessment.reason
+        if assessment.candidate is not None:
+            evidence_reference = assessment.candidate.candidate_id
+        return cls(
+            fit_drift=None,
+            evidence_references=(evidence_reference,),
+            provenance_references=(provenance_reference,),
+        )
+
+    @classmethod
+    def from_control_station_inference(
+        cls,
+        *,
+        assessment: ControlStationInferenceAssessment,
+        retained_station_records: tuple[RetainedStationRecord, ...] | list[RetainedStationRecord],
+        provenance_reference: str,
+    ) -> "SharedInferenceDiagnosticBundle":
+        retained_entries = tuple(
+            (record.station_id, record.kind) for record in retained_station_records
+        )
+        dropped_entries = tuple(
+            (station_id, "topology")
+            for station_id in assessment.structural_preservation.dropped_topology_station_ids
+        )
+        return cls(
+            retained_station_entries=retained_entries,
+            dropped_station_entries=dropped_entries,
+            structural_preservation=InferenceStructuralPreservationSummary.from_report(
+                StructuralPreservationReport(
+                    required_topology_station_ids=assessment.structural_preservation.required_topology_station_ids,
+                    retained_topology_station_ids=assessment.structural_preservation.retained_topology_station_ids,
+                    dropped_topology_station_ids=assessment.structural_preservation.dropped_topology_station_ids,
+                    supporting_diagnostic_references=assessment.structural_preservation.supporting_diagnostic_references,
+                )
+            ),
+            evidence_references=assessment.structural_preservation.supporting_diagnostic_references,
+            provenance_references=(provenance_reference,),
         )
 
 

--- a/tests/test_inference_diagnostics.py
+++ b/tests/test_inference_diagnostics.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
 from impression.modeling import (
+    ControlStationInferenceAssessment,
+    HiddenControlStationProvenanceRecord,
+    HiddenControlStationRecord,
     FitAssessmentReport,
     FitResidualReport,
     InferenceFitDriftSummary,
     InferenceStructuralPreservationSummary,
+    Path3D,
+    PathBackedProgression,
+    ProgressionStationAttachment,
+    ReducedProgressionBundle,
+    RetainedStationRecord,
     SharedInferenceDiagnosticBundle,
+    SharedWholeLoftTrajectoryAssessment,
     StructuralPreservationReport,
+    Station,
+    as_section,
+    assess_control_station_inference,
 )
+from impression.modeling.drawing2d import make_rect
 
 
 def _fit_assessment() -> FitAssessmentReport:
@@ -28,6 +41,21 @@ def _structural_report() -> StructuralPreservationReport:
         retained_topology_station_ids=("topo-0",),
         dropped_topology_station_ids=("topo-1",),
         supporting_diagnostic_references=("diag-0",),
+    )
+
+
+def _progression() -> PathBackedProgression:
+    return PathBackedProgression(path=Path3D.from_points([(0.0, 0.0, 0.0), (1.0, 0.0, 1.0)]))
+
+
+def _station(progress: float = 0.5) -> Station:
+    return Station(
+        t=progress,
+        section=as_section(make_rect(size=(1.0, 1.0))),
+        origin=(0.0, 0.0, progress),
+        u=(1.0, 0.0, 0.0),
+        v=(0.0, 1.0, 0.0),
+        n=(0.0, 0.0, 1.0),
     )
 
 
@@ -108,3 +136,114 @@ def test_schema_supports_later_reporting_consumers_without_branch_specific_mutat
 
     assert bundle.replay_payload[4] is not None
     assert bundle.replay_payload[5] is not None
+
+
+def test_representative_inference_branches_populate_the_shared_bundle_through_the_same_contract() -> None:
+    station_bundle = SharedInferenceDiagnosticBundle.from_station_fit(
+        assessment=_fit_assessment(),
+        evidence_reference="station_polyline_exact",
+        provenance_reference="inferred:dense_station_inference",
+    )
+    trajectory_bundle = SharedInferenceDiagnosticBundle.from_shared_trajectory_assessment(
+        assessment=SharedWholeLoftTrajectoryAssessment(
+            candidate=None,
+            confidence=0.0,
+            posture="refused",
+            reason="missing_shared_whole_loft_trajectory_candidates",
+        ),
+        provenance_reference="inferred:shared_trajectory_fit",
+    )
+
+    assert isinstance(station_bundle, SharedInferenceDiagnosticBundle)
+    assert isinstance(trajectory_bundle, SharedInferenceDiagnosticBundle)
+
+
+def test_reporting_consumers_can_read_populated_bundles_without_branch_specific_assumptions() -> None:
+    bundle = SharedInferenceDiagnosticBundle.from_station_fit(
+        assessment=_fit_assessment(),
+        evidence_reference="station_polyline_exact",
+        provenance_reference="inferred:dense_station_inference",
+    )
+
+    assert bundle.replay_payload[0] == "shared_inference_diagnostic_bundle"
+    assert bundle.evidence_references == ("station_polyline_exact",)
+
+
+def test_cross_feature_bundle_population_remains_consistent() -> None:
+    bundle_from_fit = SharedInferenceDiagnosticBundle.from_station_fit(
+        assessment=_fit_assessment(),
+        evidence_reference="station_polyline_exact",
+        provenance_reference="inferred:dense_station_inference",
+    )
+    bundle_from_trajectory = SharedInferenceDiagnosticBundle.from_shared_trajectory_assessment(
+        assessment=SharedWholeLoftTrajectoryAssessment(
+            candidate=None,
+            confidence=0.0,
+            posture="refused",
+            reason="missing_shared_whole_loft_trajectory_candidates",
+        ),
+        provenance_reference="inferred:shared_trajectory_fit",
+    )
+
+    assert len(bundle_from_fit.replay_payload) == len(bundle_from_trajectory.replay_payload)
+
+
+def test_reuse_posture_does_not_collapse_into_ad_hoc_per_branch_behavior() -> None:
+    attachment = ProgressionStationAttachment.from_station(
+        progression=_progression(),
+        station=_station(0.25),
+        station_index=0,
+    )
+    hidden = HiddenControlStationRecord.from_station(
+        station_id="control-0",
+        station=_station(0.75),
+        provenance=HiddenControlStationProvenanceRecord(),
+    )
+    retained = (
+        RetainedStationRecord.from_attachment(
+            station_id="topo-0",
+            attachment=attachment,
+            diagnostic_references=("diag-topo",),
+        ),
+        RetainedStationRecord.from_hidden_control(
+            record=hidden,
+            progression_value=0.75,
+            diagnostic_references=("diag-control",),
+        ),
+    )
+    assessment = assess_control_station_inference(
+        bundle=ReducedProgressionBundle.from_progression(
+            bundle_id="reduction-0",
+            progression=_progression(),
+            retained_progression_values=(0.0, 0.75, 1.0),
+            hidden_control_station_ids=("control-0",),
+        ),
+        retained_station_records=retained,
+        required_topology_station_ids=("topo-0",),
+    )
+
+    bundle = SharedInferenceDiagnosticBundle.from_control_station_inference(
+        assessment=assessment,
+        retained_station_records=retained,
+        provenance_reference="inferred:control_station_inference",
+    )
+
+    assert bundle.retained_station_entries[0] == ("topo-0", "topology")
+    assert bundle.retained_station_entries[1] == ("control-0", "hidden_control")
+
+
+def test_reporting_remains_aligned_with_the_populated_bundle_contract() -> None:
+    assessment = ControlStationInferenceAssessment(
+        bundle=None,
+        structural_preservation=_structural_report(),
+        posture="refused",
+        reason="missing_topology_critical_structure",
+    )
+    bundle = SharedInferenceDiagnosticBundle.from_control_station_inference(
+        assessment=assessment,
+        retained_station_records=(),
+        provenance_reference="inferred:control_station_inference",
+    )
+
+    assert bundle.structural_preservation is not None
+    assert bundle.dropped_station_entries == (("topo-1", "topology"),)


### PR DESCRIPTION
## Summary
- add shared diagnostic bundle population helpers for fit, trajectory, and reduction branches
- keep bundle reuse consistent across inference features
- document and test the population and reuse posture

## Testing
- ./.venv/bin/pytest tests/test_inference_diagnostics.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
