### PR TITLE
Implement 0.1.0.a Feature Spec 09B1

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -388,6 +388,21 @@ fit_bundle = SharedInferenceDiagnosticBundle.from_station_fit(
 This keeps bundle population consistent across branches instead of letting each
 feature invent its own reporting shape.
 
+Developer-facing inspection can then consume the shared bundle through a
+structured inspection record:
+
+```python
+from impression.modeling import DeveloperInferenceInspection
+
+inspection = DeveloperInferenceInspection.from_bundle(bundle)
+```
+
+That keeps developer-facing explainability honest:
+
+- retained and dropped structure stay inspectable
+- drift stays visible for debugging and review
+- inferred provenance is visible instead of being silently treated as certainty
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -108,6 +108,10 @@ from .inference_diagnostics import (
     InferenceStructuralPreservationSummary,
     SharedInferenceDiagnosticBundle,
 )
+from .inference_reporting import (
+    DeveloperInferenceCertaintyPosture,
+    DeveloperInferenceInspection,
+)
 from .shared_trajectory import (
     SharedWholeLoftTrajectoryAssessment,
     SharedWholeLoftTrajectoryCandidate,
@@ -321,6 +325,8 @@ __all__ = [
     "InferenceFitDriftSummary",
     "InferenceStructuralPreservationSummary",
     "SharedInferenceDiagnosticBundle",
+    "DeveloperInferenceCertaintyPosture",
+    "DeveloperInferenceInspection",
     "SharedWholeLoftTrajectoryAssessment",
     "ExplicitSharedGuidanceAttachmentRecord",
     "ExplicitSharedGuidancePlannerConsumption",

--- a/src/impression/modeling/inference_reporting.py
+++ b/src/impression/modeling/inference_reporting.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .inference_diagnostics import SharedInferenceDiagnosticBundle
+
+DeveloperInferenceCertaintyPosture = Literal["certain", "uncertain", "refused"]
+
+
+def _normalize_developer_certainty_posture(value: str) -> DeveloperInferenceCertaintyPosture:
+    allowed: set[str] = {"certain", "uncertain", "refused"}
+    posture = str(value)
+    if posture not in allowed:
+        raise ValueError("certainty_posture must be one of: certain, uncertain, refused.")
+    return posture  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class DeveloperInferenceInspection:
+    retained_station_entries: tuple[tuple[str, str], ...]
+    dropped_station_entries: tuple[tuple[str, str], ...]
+    fit_drift: tuple[object, ...] | None
+    provenance_references: tuple[str, ...]
+    certainty_posture: DeveloperInferenceCertaintyPosture
+    summary_reason: str
+
+    def __init__(
+        self,
+        *,
+        retained_station_entries: tuple[tuple[str, str], ...],
+        dropped_station_entries: tuple[tuple[str, str], ...],
+        fit_drift: tuple[object, ...] | None,
+        provenance_references: tuple[str, ...],
+        certainty_posture: DeveloperInferenceCertaintyPosture,
+        summary_reason: str,
+    ) -> None:
+        normalized_reason = str(summary_reason).strip()
+        if not normalized_reason:
+            raise ValueError("summary_reason must be non-empty.")
+        object.__setattr__(self, "retained_station_entries", retained_station_entries)
+        object.__setattr__(self, "dropped_station_entries", dropped_station_entries)
+        object.__setattr__(self, "fit_drift", fit_drift)
+        object.__setattr__(self, "provenance_references", provenance_references)
+        object.__setattr__(
+            self,
+            "certainty_posture",
+            _normalize_developer_certainty_posture(certainty_posture),
+        )
+        object.__setattr__(self, "summary_reason", normalized_reason)
+
+    @classmethod
+    def from_bundle(
+        cls,
+        bundle: SharedInferenceDiagnosticBundle,
+    ) -> "DeveloperInferenceInspection":
+        if bundle.dropped_station_entries:
+            posture: DeveloperInferenceCertaintyPosture = "refused"
+            reason = "dropped_structure_present"
+        elif bundle.fit_drift is not None and bundle.fit_drift.decision_outcome == "refused":
+            posture = "refused"
+            reason = "fit_refused"
+        elif any(reference.startswith("inferred:") for reference in bundle.provenance_references):
+            posture = "uncertain"
+            reason = "inferred_provenance_requires_inspection"
+        else:
+            posture = "certain"
+            reason = "explicit_structure_without_refusal"
+
+        fit_drift_payload = None
+        if bundle.fit_drift is not None:
+            fit_drift_payload = (
+                bundle.fit_drift.metric_name,
+                bundle.fit_drift.residual_value,
+                bundle.fit_drift.acceptance_threshold,
+                bundle.fit_drift.decision_outcome,
+                bundle.fit_drift.decision_reason,
+            )
+        return cls(
+            retained_station_entries=bundle.retained_station_entries,
+            dropped_station_entries=bundle.dropped_station_entries,
+            fit_drift=fit_drift_payload,
+            provenance_references=bundle.provenance_references,
+            certainty_posture=posture,
+            summary_reason=reason,
+        )
+
+
+__all__ = [
+    "DeveloperInferenceCertaintyPosture",
+    "DeveloperInferenceInspection",
+]

--- a/tests/test_inference_reporting.py
+++ b/tests/test_inference_reporting.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from impression.modeling import (
+    DeveloperInferenceInspection,
+    FitAssessmentReport,
+    FitResidualReport,
+    InferenceFitDriftSummary,
+    InferenceStructuralPreservationSummary,
+    SharedInferenceDiagnosticBundle,
+    StructuralPreservationReport,
+)
+
+
+def _fit_assessment() -> FitAssessmentReport:
+    return FitAssessmentReport.from_residual(
+        FitResidualReport(
+            metric_name="max_distance_to_station_polyline",
+            residual_value=0.1,
+            acceptance_threshold=0.25,
+            approximation_posture="approximate",
+            exact_threshold=0.0,
+        )
+    )
+
+
+def _structural_report() -> StructuralPreservationReport:
+    return StructuralPreservationReport(
+        required_topology_station_ids=("topo-0",),
+        retained_topology_station_ids=("topo-0",),
+        dropped_topology_station_ids=(),
+        supporting_diagnostic_references=("diag-0",),
+    )
+
+
+def test_representative_inference_branches_emit_retained_dropped_and_drift_explanations_for_developer_inspection() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(("topo-1", "topology"),),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        structural_preservation=InferenceStructuralPreservationSummary.from_report(_structural_report()),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+    inspection = DeveloperInferenceInspection.from_bundle(bundle)
+
+    assert inspection.retained_station_entries == (("topo-0", "topology"),)
+    assert inspection.dropped_station_entries == (("topo-1", "topology"),)
+    assert inspection.fit_drift is not None
+
+
+def test_exact_vs_inferred_provenance_remains_visible_in_developer_facing_inspection() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:dense_station_inference",),
+    )
+    inspection = DeveloperInferenceInspection.from_bundle(bundle)
+
+    assert inspection.provenance_references == ("inferred:dense_station_inference",)
+
+
+def test_developer_facing_explainability_stays_aligned_with_shared_diagnostic_bundles() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"), ("control-0", "hidden_control")),
+        dropped_station_entries=(),
+        evidence_references=("fit-a",),
+        provenance_references=("explicit:authored_path",),
+    )
+    inspection = DeveloperInferenceInspection.from_bundle(bundle)
+
+    assert inspection.retained_station_entries == bundle.retained_station_entries
+
+
+def test_retained_dropped_and_drift_summaries_remain_inspectable() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(),
+        fit_drift=InferenceFitDriftSummary.from_fit_assessment(_fit_assessment()),
+        evidence_references=("fit-a",),
+        provenance_references=("explicit:authored_path",),
+    )
+    inspection = DeveloperInferenceInspection.from_bundle(bundle)
+
+    assert inspection.fit_drift is not None
+    assert inspection.summary_reason
+
+
+def test_developer_facing_inspection_does_not_overstate_weak_inference_as_certain_truth() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"),),
+        dropped_station_entries=(),
+        evidence_references=("fit-a",),
+        provenance_references=("inferred:shared_trajectory_fit",),
+    )
+    inspection = DeveloperInferenceInspection.from_bundle(bundle)
+
+    assert inspection.certainty_posture == "uncertain"


### PR DESCRIPTION
## Summary
- add structured developer-facing inference inspection records
- keep retained/dropped structure, drift, and provenance visible without overstating weak inference as certain truth
- document and test the developer inspection layer

## Testing
- ./.venv/bin/pytest tests/test_inference_reporting.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
