### PR TITLE
Implement 0.1.0.a Feature Spec 09B2

### DIFF
--- a/docs/modeling/progression.md
+++ b/docs/modeling/progression.md
@@ -403,6 +403,21 @@ That keeps developer-facing explainability honest:
 - drift stays visible for debugging and review
 - inferred provenance is visible instead of being silently treated as certainty
 
+Downstream consumers can then receive a smaller report that still preserves
+uncertainty, refusal, and provenance:
+
+```python
+from impression.modeling import DownstreamInferenceReport
+
+report = DownstreamInferenceReport.from_bundle(bundle)
+```
+
+That keeps downstream reporting honest too:
+
+- refusal and uncertainty remain first-class outputs
+- inferred provenance remains visible where it matters
+- downstream consumers do not need the full internal inspection record
+
 Confidence and refusal are then handled by a separate posture layer:
 
 ```python

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -111,6 +111,8 @@ from .inference_diagnostics import (
 from .inference_reporting import (
     DeveloperInferenceCertaintyPosture,
     DeveloperInferenceInspection,
+    DownstreamInferenceOutcome,
+    DownstreamInferenceReport,
 )
 from .shared_trajectory import (
     SharedWholeLoftTrajectoryAssessment,
@@ -327,6 +329,8 @@ __all__ = [
     "SharedInferenceDiagnosticBundle",
     "DeveloperInferenceCertaintyPosture",
     "DeveloperInferenceInspection",
+    "DownstreamInferenceOutcome",
+    "DownstreamInferenceReport",
     "SharedWholeLoftTrajectoryAssessment",
     "ExplicitSharedGuidanceAttachmentRecord",
     "ExplicitSharedGuidancePlannerConsumption",

--- a/src/impression/modeling/inference_reporting.py
+++ b/src/impression/modeling/inference_reporting.py
@@ -6,6 +6,7 @@ from typing import Literal
 from .inference_diagnostics import SharedInferenceDiagnosticBundle
 
 DeveloperInferenceCertaintyPosture = Literal["certain", "uncertain", "refused"]
+DownstreamInferenceOutcome = Literal["accepted", "uncertain", "refused"]
 
 
 def _normalize_developer_certainty_posture(value: str) -> DeveloperInferenceCertaintyPosture:
@@ -14,6 +15,14 @@ def _normalize_developer_certainty_posture(value: str) -> DeveloperInferenceCert
     if posture not in allowed:
         raise ValueError("certainty_posture must be one of: certain, uncertain, refused.")
     return posture  # type: ignore[return-value]
+
+
+def _normalize_downstream_inference_outcome(value: str) -> DownstreamInferenceOutcome:
+    allowed: set[str] = {"accepted", "uncertain", "refused"}
+    outcome = str(value)
+    if outcome not in allowed:
+        raise ValueError("outcome must be one of: accepted, uncertain, refused.")
+    return outcome  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)
@@ -86,7 +95,68 @@ class DeveloperInferenceInspection:
         )
 
 
+@dataclass(frozen=True)
+class DownstreamInferenceReport:
+    outcome: DownstreamInferenceOutcome
+    refusal_summary: str | None
+    uncertainty_summary: str | None
+    provenance_references: tuple[str, ...]
+    retained_station_count: int
+    dropped_station_count: int
+
+    def __init__(
+        self,
+        *,
+        outcome: DownstreamInferenceOutcome,
+        refusal_summary: str | None,
+        uncertainty_summary: str | None,
+        provenance_references: tuple[str, ...],
+        retained_station_count: int,
+        dropped_station_count: int,
+    ) -> None:
+        object.__setattr__(self, "outcome", _normalize_downstream_inference_outcome(outcome))
+        object.__setattr__(self, "refusal_summary", refusal_summary)
+        object.__setattr__(self, "uncertainty_summary", uncertainty_summary)
+        object.__setattr__(self, "provenance_references", provenance_references)
+        object.__setattr__(self, "retained_station_count", int(retained_station_count))
+        object.__setattr__(self, "dropped_station_count", int(dropped_station_count))
+
+    @classmethod
+    def from_bundle(
+        cls,
+        bundle: SharedInferenceDiagnosticBundle,
+    ) -> "DownstreamInferenceReport":
+        if bundle.dropped_station_entries:
+            return cls(
+                outcome="refused",
+                refusal_summary="topology_critical_structure_dropped",
+                uncertainty_summary=None,
+                provenance_references=bundle.provenance_references,
+                retained_station_count=len(bundle.retained_station_entries),
+                dropped_station_count=len(bundle.dropped_station_entries),
+            )
+        if any(reference.startswith("inferred:") for reference in bundle.provenance_references):
+            return cls(
+                outcome="uncertain",
+                refusal_summary=None,
+                uncertainty_summary="inferred_result_requires_consumer_caution",
+                provenance_references=bundle.provenance_references,
+                retained_station_count=len(bundle.retained_station_entries),
+                dropped_station_count=len(bundle.dropped_station_entries),
+            )
+        return cls(
+            outcome="accepted",
+            refusal_summary=None,
+            uncertainty_summary=None,
+            provenance_references=bundle.provenance_references,
+            retained_station_count=len(bundle.retained_station_entries),
+            dropped_station_count=len(bundle.dropped_station_entries),
+        )
+
+
 __all__ = [
     "DeveloperInferenceCertaintyPosture",
     "DeveloperInferenceInspection",
+    "DownstreamInferenceOutcome",
+    "DownstreamInferenceReport",
 ]

--- a/tests/test_inference_reporting.py
+++ b/tests/test_inference_reporting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from impression.modeling import (
     DeveloperInferenceInspection,
+    DownstreamInferenceReport,
     FitAssessmentReport,
     FitResidualReport,
     InferenceFitDriftSummary,
@@ -96,3 +97,86 @@ def test_developer_facing_inspection_does_not_overstate_weak_inference_as_certai
     inspection = DeveloperInferenceInspection.from_bundle(bundle)
 
     assert inspection.certainty_posture == "uncertain"
+
+
+def test_representative_inference_branches_emit_downstream_refusal_and_uncertainty_summaries() -> None:
+    refused = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(("topo-1", "topology"),),
+            evidence_references=("fit-a",),
+            provenance_references=("inferred:dense_station_inference",),
+        )
+    )
+    uncertain = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(),
+            evidence_references=("fit-a",),
+            provenance_references=("inferred:dense_station_inference",),
+        )
+    )
+
+    assert refused.refusal_summary is not None
+    assert uncertain.uncertainty_summary is not None
+
+
+def test_downstream_reporting_preserves_exact_vs_inferred_provenance_where_required() -> None:
+    report = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(),
+            evidence_references=("fit-a",),
+            provenance_references=("inferred:shared_trajectory_fit",),
+        )
+    )
+
+    assert report.provenance_references == ("inferred:shared_trajectory_fit",)
+
+
+def test_uncertainty_and_refusal_remain_first_class_downstream_outputs() -> None:
+    uncertain = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(),
+            evidence_references=("fit-a",),
+            provenance_references=("inferred:shared_trajectory_fit",),
+        )
+    )
+    refused = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(("topo-1", "topology"),),
+            evidence_references=("fit-a",),
+            provenance_references=("explicit:authored_path",),
+        )
+    )
+
+    assert uncertain.outcome == "uncertain"
+    assert refused.outcome == "refused"
+
+
+def test_downstream_reporting_does_not_overstate_weak_inference_as_certain_truth() -> None:
+    report = DownstreamInferenceReport.from_bundle(
+        SharedInferenceDiagnosticBundle(
+            retained_station_entries=(("topo-0", "topology"),),
+            dropped_station_entries=(),
+            evidence_references=("fit-a",),
+            provenance_references=("inferred:dense_station_inference",),
+        )
+    )
+
+    assert report.outcome == "uncertain"
+
+
+def test_downstream_reporting_remains_aligned_with_shared_diagnostic_bundle_contract() -> None:
+    bundle = SharedInferenceDiagnosticBundle(
+        retained_station_entries=(("topo-0", "topology"), ("control-0", "hidden_control")),
+        dropped_station_entries=(),
+        evidence_references=("fit-a",),
+        provenance_references=("explicit:authored_path",),
+    )
+    report = DownstreamInferenceReport.from_bundle(bundle)
+
+    assert report.retained_station_count == 2
+    assert report.dropped_station_count == 0


### PR DESCRIPTION
## Summary
- add downstream inference reports for refusal, uncertainty, and provenance communication
- keep downstream reporting aligned with the shared diagnostic bundle without exposing unnecessary internal detail
- document and test the downstream reporting layer

## Testing
- ./.venv/bin/pytest tests/test_inference_reporting.py -q
- ./.venv/bin/pytest tests/test_loft_suite.py -q
