### PR TITLE
Add topology identity record tests

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -310,7 +310,7 @@ Only final leaf specifications appear here.
 ### Topology-Owned Point Correspondence
 
 - [x] [Loft Spec 52: Topology Path Core Records (v1.0)](../specifications/loft-52-topology-path-core-records-v1_0.md)
-- [ ] [Loft Spec 53: Topology Segment and Landmark Identity Records (v1.0)](../specifications/loft-53-topology-segment-landmark-identity-records-v1_0.md)
+- [x] [Loft Spec 53: Topology Segment and Landmark Identity Records (v1.0)](../specifications/loft-53-topology-segment-landmark-identity-records-v1_0.md)
 - [ ] [Loft Spec 54: Path Input Adapters to Topology Paths (v1.0)](../specifications/loft-54-path-input-adapters-to-topology-paths-v1_0.md)
 - [ ] [Loft Spec 62: Topology Builder Core API (v1.0)](../specifications/loft-62-topology-builder-core-api-v1_0.md)
 - [ ] [Loft Spec 63: Topology Lifecycle Builder API (v1.0)](../specifications/loft-63-topology-lifecycle-builder-api-v1_0.md)

--- a/project/release-0.1.0a/specifications/loft-53-topology-segment-landmark-identity-records-v1_0.md
+++ b/project/release-0.1.0a/specifications/loft-53-topology-segment-landmark-identity-records-v1_0.md
@@ -1,0 +1,173 @@
+# Loft Spec 53: Topology Segment and Landmark Identity Records (v1.0)
+
+Date: 2026-05-25
+Status: Proposed
+Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Topology Segment And Landmark Identity Records`
+
+## Purpose
+
+Define durable point, segment, and landmark identity records so authored names,
+ids, roles, and correspondence rails survive topology normalization and become
+available to loft planning.
+
+## Scope
+
+Owns:
+
+- `TopologyPoint`, `TopologySegment`, and `TopologyLandmark` record fields.
+- Identity/provenance validation for ids, names, correspondence ids, roles, and
+  protection policy.
+- Record-level duplicate and missing-reference diagnostics.
+
+Does not own:
+
+- Public builder syntax for creating these records.
+- Input adapters from existing curve types.
+- Rail priority, high-confidence inference, birth/death resolution, or
+  executor consumption.
+
+## Implementation Routing
+
+- Primary modules/files:
+  - `src/impression/modeling/topology.py` - add identity record classes and
+    validation helpers.
+- Supporting modules/files:
+  - `src/impression/modeling/loft.py` - later planner reads records; no direct
+    executor work in this spec.
+- GUI/QML files, if applicable:
+  - not applicable.
+- Reusable library/module files:
+  - `src/impression/modeling/topology.py` - reusable identity record boundary.
+- Tests:
+  - `tests/test_topology_identity_records.py` - ids, names, roles, duplicate
+    rejection, provenance, and protection policy behavior.
+
+## Chosen Defaults / Parameters
+
+- `name` is user-facing and optional.
+- `id` is stable record identity; if omitted and `name` is present, helpers may
+  derive `id` from `name` and must mark provenance as derived.
+- `correspondence_id` is the authoritative planner rail key.
+- `protection_policy` defaults to `protected` for corners, seams, explicit
+  landmarks, and user-authored correspondence ids; otherwise it defaults to
+  `sample`.
+- Roles are plain string values initially; expected roles include `corner`,
+  `seam`, `feature`, `tangent_transition`, `sample`, and `inferred_support`.
+
+## Data Ownership
+
+- Source of truth: topology identity records own authored point and landmark
+  identity before normalization.
+- Read ownership: adapters, station normalization, rail resolver, lifecycle
+  resolver, and resampler may read identity records.
+- Write ownership: topology builders/adapters create identity records;
+  normalization writes mapped ids into derived correspondence structures.
+- Derived/cache data: normalized ids and loop-local ordinals are derived from
+  original identity records plus normalization diagnostics.
+- Privacy/logging constraints: diagnostics may log ids, names, roles, and
+  correspondence ids; no external file paths or user private content.
+
+## Dependencies And Routes
+
+- Domain/service dependencies:
+  - `TopologyPath`
+  - `Loop`
+  - `Section`
+  - station normalization path in `src/impression/modeling/loft.py`
+- Database dependencies:
+  - none.
+- GUI route, if applicable:
+  - not applicable.
+- Background/concurrency route, if applicable:
+  - not applicable; pure synchronous record validation.
+
+## Reuse And Extraction Plan
+
+- Existing code to reuse:
+  - `Loop` and `Section` identity/reference handling where present.
+- Current reuse readiness:
+  - add to existing reusable topology module.
+- Extraction/wrapping needed:
+  - none.
+- Additions to existing library/modules:
+  - `TopologyPoint`
+  - `TopologySegment`
+  - `TopologyLandmark`
+  - `validate_topology_identity_records(...)`
+- New reusable modules to expose:
+  - none.
+- One-off code justification, if any:
+  - none.
+
+## Required DTOs / Functions / Components
+
+- DTOs/models:
+  - `TopologyPoint` - fields: `id`, `coordinates`, `ordinal`, `role`, `name`,
+    `correspondence_id`, `protection_policy`, `provenance`.
+  - `TopologySegment` - fields: `id`, `name`, `source_kind`, `start_ref`,
+    `end_ref`, `curve`, `correspondence_id`, `provenance`.
+  - `TopologyLandmark` - fields: `id`, `name`, `segment_id`, `parameter`,
+    `point_ordinal`, `role`, `correspondence_id`, `protection_policy`,
+    `provenance`.
+- Functions/methods:
+  - `validate_topology_identity_records(path: TopologyPath) -> None` - checks
+    identity uniqueness and references.
+  - `derive_stable_id(name: str) -> str` - deterministic helper id derivation.
+- UI fields / visible data, if applicable:
+  - public API fields: `id`, `name`, `role`, `correspondence_id`,
+    `protection_policy`.
+- UI elements / controls, if applicable:
+  - not applicable.
+- UI components, if applicable:
+  - not applicable.
+
+## Performance Contract
+
+- Validation is O(n) over points, segments, and landmarks.
+- Duplicate checks use sets/maps and do not perform geometric search.
+- Record creation must not trigger sampling or loft planning.
+
+## Error And State Behavior
+
+- Duplicate ids or correspondence ids in a scope that requires uniqueness raise
+  `ValueError`.
+- Missing segment references or invalid point ordinals raise `ValueError`.
+- Conflicting protection policies on the same correspondence id raise
+  `ValueError`.
+- Diagnostics should include the owning path id and offending record id.
+
+## Test Strategy
+
+- Unit tests:
+  - stable id derivation from names.
+  - explicit ids overriding derived ids.
+  - duplicate id and missing reference failures.
+  - protection policy defaults by role and correspondence id.
+  - provenance preservation through validation.
+- Service/DB tests:
+  - not applicable.
+- GUI/controller tests, if applicable:
+  - not applicable.
+- Production-data rule:
+  - Tests must not require the user's production database.
+
+## Acceptance Criteria
+
+- Segment, landmark, and point records can represent named authored rails.
+- Duplicate or broken identity records fail before loft planning.
+- Records expose enough identity for station normalization and rail resolution
+  without depending on sample indices.
+
+## Readiness Checklist
+
+- [x] Implementation owner/module is named.
+- [x] Existing code reuse/extraction decision is explicit.
+- [x] Existing library/module additions or new reusable module boundaries are named, or marked not applicable.
+- [x] UI fields/elements are listed, or marked not applicable.
+- [x] Chosen defaults are explicit.
+- [x] Data source of truth and write owner are explicit.
+- [x] GUI/concurrency route is explicit, or marked not applicable.
+- [x] Performance bounds are explicit, or marked not applicable.
+- [x] Privacy/logging constraints are explicit, or marked not applicable.
+- [x] Test strategy does not depend on production data.
+- [x] Acceptance criteria are testable.

--- a/tests/test_topology_identity_records.py
+++ b/tests/test_topology_identity_records.py
@@ -1,0 +1,94 @@
+import pytest
+
+from impression.modeling.topology import (
+    TopologyLandmark,
+    TopologyPath,
+    TopologyPoint,
+    TopologySegment,
+    derive_stable_id,
+)
+
+
+def test_derive_stable_id_normalizes_user_facing_names() -> None:
+    assert derive_stable_id("Bottom Left") == "bottom-left"
+    assert derive_stable_id("  Crown/Peak!  ") == "crown-peak"
+
+
+def test_topology_point_derives_id_and_protection_policy_from_name_and_role() -> None:
+    point = TopologyPoint(
+        id=None,
+        name="Bottom Left",
+        coordinates=(0.0, 0.0),
+        ordinal=0,
+        role="corner",
+        correspondence_id="corner-a",
+    )
+
+    assert point.id == "bottom-left"
+    assert point.protection_policy == "protected"
+    assert point.provenance["id_source"] == "derived_from_name"
+
+
+def test_topology_identity_validation_rejects_duplicate_point_ids() -> None:
+    p0 = TopologyPoint(id="a", coordinates=(0.0, 0.0), ordinal=0)
+    p1 = TopologyPoint(id="a", coordinates=(1.0, 0.0), ordinal=1)
+    p2 = TopologyPoint(id="c", coordinates=(0.0, 1.0), ordinal=2)
+
+    with pytest.raises(ValueError, match="duplicate point ids"):
+        TopologyPath(points=(p0, p1, p2))
+
+
+def test_topology_landmark_rejects_missing_segment_reference() -> None:
+    segment = TopologySegment(id="edge-a", name="edge-a")
+    landmark = TopologyLandmark(
+        name="missing-segment-landmark",
+        segment_id="edge-b",
+        parameter=0.5,
+    )
+
+    with pytest.raises(ValueError, match="segment_id"):
+        TopologyPath(
+            points=(
+                TopologyPoint(id="a", coordinates=(0.0, 0.0), ordinal=0),
+                TopologyPoint(id="b", coordinates=(1.0, 0.0), ordinal=1),
+                TopologyPoint(id="c", coordinates=(0.0, 1.0), ordinal=2),
+            ),
+            segments=(segment,),
+            landmarks=(landmark,),
+        )
+
+
+def test_topology_landmark_rejects_point_ordinal_outside_path_points() -> None:
+    landmark = TopologyLandmark(name="bad-point", point_ordinal=3)
+
+    with pytest.raises(ValueError, match="point_ordinal"):
+        TopologyPath.from_points(
+            [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)],
+            landmarks=(landmark,),
+        )
+
+
+def test_topology_identity_validation_rejects_conflicting_protection_policy() -> None:
+    point = TopologyPoint(
+        id="a",
+        coordinates=(0.0, 0.0),
+        ordinal=0,
+        correspondence_id="shared",
+        protection_policy="protected",
+    )
+    landmark = TopologyLandmark(
+        name="sample-shared",
+        point_ordinal=0,
+        correspondence_id="shared",
+        protection_policy="sample",
+    )
+
+    with pytest.raises(ValueError, match="Conflicting protection policies"):
+        TopologyPath(
+            points=(
+                point,
+                TopologyPoint(id="b", coordinates=(1.0, 0.0), ordinal=1),
+                TopologyPoint(id="c", coordinates=(0.0, 1.0), ordinal=2),
+            ),
+            landmarks=(landmark,),
+        )


### PR DESCRIPTION
## Summary
- Adds the Loft Spec 53 specification document to the active release workspace.
- Adds focused tests for topology point, segment, and landmark identity records.
- Marks Loft Spec 53 complete in the progression.

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_topology_path_records.py tests/test_topology_identity_records.py