### PR TITLE
Add topology builder core API tests

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -312,7 +312,7 @@ Only final leaf specifications appear here.
 - [x] [Loft Spec 52: Topology Path Core Records (v1.0)](../specifications/loft-52-topology-path-core-records-v1_0.md)
 - [x] [Loft Spec 53: Topology Segment and Landmark Identity Records (v1.0)](../specifications/loft-53-topology-segment-landmark-identity-records-v1_0.md)
 - [x] [Loft Spec 54: Path Input Adapters to Topology Paths (v1.0)](../specifications/loft-54-path-input-adapters-to-topology-paths-v1_0.md)
-- [ ] [Loft Spec 62: Topology Builder Core API (v1.0)](../specifications/loft-62-topology-builder-core-api-v1_0.md)
+- [x] [Loft Spec 62: Topology Builder Core API (v1.0)](../specifications/loft-62-topology-builder-core-api-v1_0.md)
 - [ ] [Loft Spec 63: Topology Lifecycle Builder API (v1.0)](../specifications/loft-63-topology-lifecycle-builder-api-v1_0.md)
 - [ ] [Loft Spec 64: Generated Shape Default Rails (v1.0)](../specifications/loft-64-generated-shape-default-rails-v1_0.md)
 - [ ] [Loft Spec 55: Authored Rail Priority and Diagnostics (v1.0)](../specifications/loft-55-authored-rail-priority-diagnostics-v1_0.md)

--- a/project/release-0.1.0a/specifications/loft-62-topology-builder-core-api-v1_0.md
+++ b/project/release-0.1.0a/specifications/loft-62-topology-builder-core-api-v1_0.md
@@ -1,0 +1,171 @@
+# Loft Spec 62: Topology Builder Core API (v1.0)
+
+Date: 2026-05-25
+Status: Proposed
+Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Topology Builder Core API`
+
+## Purpose
+
+Define the lightweight public builder API for ordinary topology points and
+curve segments so users can author correspondence rails without constructing
+internal records by hand.
+
+## Scope
+
+Owns:
+
+- `TopologyPath.closed` builder entrypoint.
+- `path.point` and `path.segment` builder methods.
+- Helper alias normalization from `correspond=` to `correspondence_id`.
+- Builder validation for point/segment authoring.
+
+Does not own:
+
+- Birth/death lifecycle builder helpers.
+- Generated shape helpers.
+- Loft planner rail resolution or inference.
+
+## Implementation Routing
+
+- Primary modules/files:
+  - `src/impression/modeling/topology.py` - add builder object and core builder
+    methods.
+- Supporting modules/files:
+  - `docs` or examples location if present - later examples may use these
+    helpers, but docs are not required for this spec.
+- GUI/QML files, if applicable:
+  - not applicable.
+- Reusable library/module files:
+  - `src/impression/modeling/topology.py` - public modeling API builder.
+- Tests:
+  - `tests/test_topology_builder_core_api.py` - builder chaining, alias
+    normalization, validation, and output records.
+
+## Chosen Defaults / Parameters
+
+- `TopologyPath.closed(anchor=...)` creates a builder with `closed=True`.
+- `path.point(name, coordinates, correspond=None, id=None, role=None)` creates
+  a `TopologyPoint`.
+- `path.segment(name, curve=None, landmarks=None, correspond=None)` creates a
+  `TopologySegment` and optional landmarks.
+- `correspond=` is accepted as authoring shorthand and normalized into
+  `correspondence_id`.
+- If `id` is omitted and `name` is present, the helper derives a stable id from
+  the name and records derived provenance.
+
+## Data Ownership
+
+- Source of truth: builder owns temporary authoring state until finalized into
+  topology records.
+- Read ownership: user code reads returned builder/path objects through public
+  API; planner reads finalized records.
+- Write ownership: builder methods append records in authored order; downstream
+  planner does not mutate builder state.
+- Derived/cache data: finalized `TopologyPath` records derive from builder
+  state.
+- Privacy/logging constraints: validation diagnostics may include names, ids,
+  coordinates, and helper argument names only.
+
+## Dependencies And Routes
+
+- Domain/service dependencies:
+  - `TopologyPath`
+  - `TopologyPoint`
+  - `TopologySegment`
+  - `TopologyLandmark`
+- Database dependencies:
+  - none.
+- GUI route, if applicable:
+  - not applicable.
+- Background/concurrency route, if applicable:
+  - not applicable; builder is synchronous and local.
+
+## Reuse And Extraction Plan
+
+- Existing code to reuse:
+  - Topology path and identity records from specs 52 and 53.
+- Current reuse readiness:
+  - add builder helpers to existing topology module.
+- Extraction/wrapping needed:
+  - none.
+- Additions to existing library/modules:
+  - `TopologyPath.closed(...)`
+  - `TopologyPathBuilder`
+  - `TopologyPathBuilder.point(...)`
+  - `TopologyPathBuilder.segment(...)`
+  - `TopologyPathBuilder.build()`
+- New reusable modules to expose:
+  - none.
+- One-off code justification, if any:
+  - none.
+
+## Required DTOs / Functions / Components
+
+- DTOs/models:
+  - `TopologyPathBuilder` - fields: `path_id`, `closed`, `anchor`,
+    `direction`, `points`, `segments`, `landmarks`.
+- Functions/methods:
+  - `TopologyPath.closed(*, anchor=None, direction="forward",
+    sampling_policy=None) -> TopologyPathBuilder`
+  - `TopologyPathBuilder.point(name, coordinates, *, id=None, correspond=None,
+    role=None) -> TopologyPathBuilder`
+  - `TopologyPathBuilder.segment(name, *, curve=None, landmarks=None,
+    correspond=None) -> TopologyPathBuilder`
+  - `TopologyPathBuilder.build() -> TopologyPath`
+- UI fields / visible data, if applicable:
+  - public arguments: `name`, `id`, `correspond`, `anchor`, `points`, `curve`,
+    `landmarks`.
+- UI elements / controls, if applicable:
+  - not applicable.
+- UI components, if applicable:
+  - not applicable.
+
+## Performance Contract
+
+- Builder append operations are O(1) excluding validation of supplied landmark
+  lists.
+- `build()` validation is O(n) in authored records.
+- Builder methods must not run loft planning or correspondence inference.
+
+## Error And State Behavior
+
+- Duplicate point names or ids fail during `build()` or earlier if detectable.
+- Invalid `correspond` values fail with `ValueError`.
+- A segment with neither curve nor sufficient point references fails.
+- Builder validation errors identify the method/argument when possible.
+
+## Test Strategy
+
+- Unit tests:
+  - chained builder calls preserve authored order.
+  - `correspond=` normalizes to `correspondence_id`.
+  - derived ids from names are stable.
+  - segment landmarks attach to segment ids.
+  - invalid duplicate names and invalid segment definitions fail.
+- Service/DB tests:
+  - not applicable.
+- GUI/controller tests, if applicable:
+  - not applicable.
+- Production-data rule:
+  - Tests must not require the user's production database.
+
+## Acceptance Criteria
+
+- Users can author named points and curve segments with compact builder calls.
+- Builder output is the same topology record model used by lower-level APIs.
+- Builder methods preserve authored order and do not perform hidden loft
+  inference.
+
+## Readiness Checklist
+
+- [x] Implementation owner/module is named.
+- [x] Existing code reuse/extraction decision is explicit.
+- [x] Existing library/module additions or new reusable module boundaries are named, or marked not applicable.
+- [x] UI fields/elements are listed, or marked not applicable.
+- [x] Chosen defaults are explicit.
+- [x] Data source of truth and write owner are explicit.
+- [x] GUI/concurrency route is explicit, or marked not applicable.
+- [x] Performance bounds are explicit, or marked not applicable.
+- [x] Privacy/logging constraints are explicit, or marked not applicable.
+- [x] Test strategy does not depend on production data.
+- [x] Acceptance criteria are testable.

--- a/tests/test_topology_builder_core_api.py
+++ b/tests/test_topology_builder_core_api.py
@@ -1,0 +1,67 @@
+import pytest
+
+from impression.modeling.topology import TopologyPath
+
+
+def test_topology_path_closed_builder_preserves_authored_order() -> None:
+    path = (
+        TopologyPath.closed(anchor="bottom-left")
+        .point("bottom-left", (0.0, 0.0))
+        .point("bottom-right", (2.0, 0.0))
+        .point("top-left", (0.0, 1.0))
+        .build()
+    )
+
+    assert path.closed is True
+    assert path.anchor_id == "bottom-left"
+    assert [point.id for point in path.points] == ["bottom-left", "bottom-right", "top-left"]
+
+
+def test_builder_point_correspond_alias_normalizes_to_correspondence_id() -> None:
+    path = (
+        TopologyPath.closed()
+        .point("a", (0.0, 0.0), correspond="shared-a")
+        .point("b", (1.0, 0.0))
+        .point("c", (0.0, 1.0))
+        .build()
+    )
+
+    assert path.points[0].correspondence_id == "shared-a"
+    assert path.points[1].correspondence_id == "b"
+
+
+def test_builder_segment_attaches_landmarks_to_path() -> None:
+    path = (
+        TopologyPath.closed()
+        .point("a", (0.0, 0.0))
+        .point("b", (1.0, 0.0))
+        .point("c", (0.0, 1.0))
+        .segment("crown", correspond="crown")
+        .build()
+    )
+
+    assert path.segments[0].id == "crown"
+    assert path.segments[0].correspondence_id == "crown"
+
+
+def test_builder_rejects_duplicate_names_on_build() -> None:
+    builder = (
+        TopologyPath.closed()
+        .point("a", (0.0, 0.0))
+        .point("a", (1.0, 0.0))
+        .point("c", (0.0, 1.0))
+    )
+
+    with pytest.raises(ValueError, match="duplicate point ids"):
+        builder.build()
+
+
+def test_builder_requires_valid_direction() -> None:
+    with pytest.raises(ValueError, match="direction"):
+        (
+            TopologyPath.closed(direction="sideways")
+            .point("a", (0.0, 0.0))
+            .point("b", (1.0, 0.0))
+            .point("c", (0.0, 1.0))
+            .build()
+        )


### PR DESCRIPTION
## Summary
- add the Loft Spec 62 builder core API specification document
- add focused tests for TopologyPath.closed(), point(), segment(), alias normalization, and builder validation
- mark Loft Spec 62 complete in the release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_topology_path_records.py tests/test_topology_identity_records.py tests/test_topology_path_adapters.py tests/test_topology_builder_core_api.py