### PR TITLE
Add generated topology shape rails

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -314,7 +314,7 @@ Only final leaf specifications appear here.
 - [x] [Loft Spec 54: Path Input Adapters to Topology Paths (v1.0)](../specifications/loft-54-path-input-adapters-to-topology-paths-v1_0.md)
 - [x] [Loft Spec 62: Topology Builder Core API (v1.0)](../specifications/loft-62-topology-builder-core-api-v1_0.md)
 - [x] [Loft Spec 63: Topology Lifecycle Builder API (v1.0)](../specifications/loft-63-topology-lifecycle-builder-api-v1_0.md)
-- [ ] [Loft Spec 64: Generated Shape Default Rails (v1.0)](../specifications/loft-64-generated-shape-default-rails-v1_0.md)
+- [x] [Loft Spec 64: Generated Shape Default Rails (v1.0)](../specifications/loft-64-generated-shape-default-rails-v1_0.md)
 - [ ] [Loft Spec 55: Authored Rail Priority and Diagnostics (v1.0)](../specifications/loft-55-authored-rail-priority-diagnostics-v1_0.md)
 - [ ] [Loft Spec 56: High-Confidence Inference and Refusal Policy (v1.0)](../specifications/loft-56-high-confidence-inference-refusal-policy-v1_0.md)
 - [ ] [Loft Spec 57: Point Lifecycle Event Records (v1.0)](../specifications/loft-57-point-lifecycle-event-records-v1_0.md)

--- a/project/release-0.1.0a/specifications/loft-64-generated-shape-default-rails-v1_0.md
+++ b/project/release-0.1.0a/specifications/loft-64-generated-shape-default-rails-v1_0.md
@@ -1,0 +1,168 @@
+# Loft Spec 64: Generated Shape Default Rails (v1.0)
+
+Date: 2026-05-25
+Status: Proposed
+Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Generated Shape Default Rails`
+
+## Purpose
+
+Define generated topology rails for common shape helpers so rectangles, circles,
+and rounded rectangles are useful authored topology inputs instead of anonymous
+point lists.
+
+## Scope
+
+Owns:
+
+- `TopologyPath.named_rect`, `TopologyPath.named_rounded_rect`, and
+  `TopologyPath.named_circle`.
+- Default generated names, correspondence ids, roles, and provenance for
+  common landmarks.
+- Override behavior for user-supplied names or anchors.
+
+Does not own:
+
+- General point/segment builder syntax.
+- Generated shape geometry primitives outside topology helper output.
+- Loft planner rail priority or inference.
+
+## Implementation Routing
+
+- Primary modules/files:
+  - `src/impression/modeling/topology.py` - add generated shape topology
+    helpers and generated rail provenance.
+- Supporting modules/files:
+  - Existing generated shape helper modules - source dimensions/point
+    generation where reusable.
+- GUI/QML files, if applicable:
+  - not applicable.
+- Reusable library/module files:
+  - `src/impression/modeling/topology.py` - generated topology helper API.
+- Tests:
+  - `tests/test_topology_generated_shape_rails.py` - generated names, anchors,
+    correspondence ids, provenance, and overrides.
+
+## Chosen Defaults / Parameters
+
+- Rectangles generate corner rails and side-midpoint rails.
+- Circles generate authored start and quadrant rails.
+- Rounded rectangles generate straight segment names, corner arc names, and
+  tangent transition landmarks.
+- `anchor` defaults to the generated start/corner appropriate to the shape.
+- User-supplied names or correspondence ids override generated ones but keep
+  generated provenance for non-overridden rails.
+- `name_prefix` may namespace generated ids for multiple shapes.
+
+## Data Ownership
+
+- Source of truth: generated helper creates topology records with generated
+  provenance.
+- Read ownership: topology adapters and loft planner read generated rails like
+  other topology identity records.
+- Write ownership: generated helper writes records at construction; downstream
+  planner writes derived correspondence.
+- Derived/cache data: generated rails are recomputable from shape dimensions,
+  anchor, and name prefix.
+- Privacy/logging constraints: diagnostics may include generated ids, names,
+  dimensions, and override names only.
+
+## Dependencies And Routes
+
+- Domain/service dependencies:
+  - topology path core records
+  - topology identity records
+  - existing generated shape helpers
+- Database dependencies:
+  - none.
+- GUI route, if applicable:
+  - not applicable.
+- Background/concurrency route, if applicable:
+  - not applicable; helper construction is synchronous.
+
+## Reuse And Extraction Plan
+
+- Existing code to reuse:
+  - Existing rectangle, rounded rectangle, and circle point/curve generation
+    helpers where present.
+- Current reuse readiness:
+  - add generated topology helpers to existing topology module.
+- Extraction/wrapping needed:
+  - wrap generated shape point output into topology points, segments, and
+    landmarks with provenance.
+- Additions to existing library/modules:
+  - `TopologyPath.named_rect(...)`
+  - `TopologyPath.named_rounded_rect(...)`
+  - `TopologyPath.named_circle(...)`
+  - `GeneratedRailProvenance`
+- New reusable modules to expose:
+  - none.
+- One-off code justification, if any:
+  - none.
+
+## Required DTOs / Functions / Components
+
+- DTOs/models:
+  - `GeneratedRailProvenance` - fields: `shape_kind`, `name_prefix`,
+    `generated_role`, `source_parameter`, `overridden`.
+- Functions/methods:
+  - `TopologyPath.named_rect(width, height, *, anchor="bottom-left",
+    name_prefix=None) -> TopologyPath`
+  - `TopologyPath.named_rounded_rect(width, height, radius, *,
+    anchor="bottom-left", name_prefix=None) -> TopologyPath`
+  - `TopologyPath.named_circle(radius, *, anchor=None,
+    name_prefix=None) -> TopologyPath`
+- UI fields / visible data, if applicable:
+  - public arguments: `width`, `height`, `radius`, `anchor`, `name_prefix`.
+- UI elements / controls, if applicable:
+  - not applicable.
+- UI components, if applicable:
+  - not applicable.
+
+## Performance Contract
+
+- Generated helper construction is O(1) for each supported primitive.
+- Helpers do not run planner inference or resampling.
+- Generated rail override validation is O(n) in generated rail count.
+
+## Error And State Behavior
+
+- Non-positive dimensions or radius raise `ValueError`.
+- Invalid anchor names raise `ValueError` and list valid generated anchors.
+- Override collisions raise `ValueError`.
+- Generated helpers record provenance so diagnostics can distinguish generated
+  rails from authored rails.
+
+## Test Strategy
+
+- Unit tests:
+  - rectangle generated corner and midpoint names.
+  - circle generated quadrant rails and authored start.
+  - rounded rectangle segment, arc, and tangent transition rails.
+  - `name_prefix` namespaces generated ids.
+  - invalid dimensions, invalid anchor, and override collision failures.
+- Service/DB tests:
+  - not applicable.
+- GUI/controller tests, if applicable:
+  - not applicable.
+- Production-data rule:
+  - Tests must not require the user's production database.
+
+## Acceptance Criteria
+
+- Common generated shapes produce topology paths with useful default rails.
+- Users can override generated names without losing provenance for other rails.
+- Generated rails participate in the same identity model as authored rails.
+
+## Readiness Checklist
+
+- [x] Implementation owner/module is named.
+- [x] Existing code reuse/extraction decision is explicit.
+- [x] Existing library/module additions or new reusable module boundaries are named, or marked not applicable.
+- [x] UI fields/elements are listed, or marked not applicable.
+- [x] Chosen defaults are explicit.
+- [x] Data source of truth and write owner are explicit.
+- [x] GUI/concurrency route is explicit, or marked not applicable.
+- [x] Performance bounds are explicit, or marked not applicable.
+- [x] Privacy/logging constraints are explicit, or marked not applicable.
+- [x] Test strategy does not depend on production data.
+- [x] Acceptance criteria are testable.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -167,6 +167,7 @@ from .heightmap import heightmap, displace_heightmap
 from .drafting import make_line, make_plane, make_arrow, make_dimension
 from .text import make_text, text, text_profiles, text_sections
 from .topology import (
+    GeneratedRailProvenance,
     Loop,
     Region,
     Section,
@@ -430,6 +431,7 @@ __all__ = [
     "text",
     "text_profiles",
     "text_sections",
+    "GeneratedRailProvenance",
     "Loop",
     "Region",
     "Section",

--- a/src/impression/modeling/topology.py
+++ b/src/impression/modeling/topology.py
@@ -237,6 +237,63 @@ class TopologyLifecycleBuilderRequest:
 
 
 @dataclass(frozen=True)
+class GeneratedRailProvenance:
+    shape_kind: str
+    name_prefix: str | None
+    generated_role: str
+    source_parameter: str | None = None
+    overridden: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "shape_kind", str(self.shape_kind))
+        object.__setattr__(self, "name_prefix", None if self.name_prefix is None else str(self.name_prefix))
+        object.__setattr__(self, "generated_role", str(self.generated_role))
+        object.__setattr__(
+            self,
+            "source_parameter",
+            None if self.source_parameter is None else str(self.source_parameter),
+        )
+        object.__setattr__(self, "overridden", bool(self.overridden))
+
+
+def _generated_rail_name(base_name: str, name_prefix: str | None) -> str:
+    if name_prefix is None:
+        return base_name
+    return f"{derive_stable_id(name_prefix)}-{base_name}"
+
+
+def _generated_rail_provenance(
+    shape_kind: str,
+    name_prefix: str | None,
+    generated_role: str,
+    source_parameter: str | None = None,
+    *,
+    overridden: bool = False,
+) -> dict[str, object]:
+    return {
+        "source": "generated_shape_default_rails",
+        "generated_rail": GeneratedRailProvenance(
+            shape_kind=shape_kind,
+            name_prefix=name_prefix,
+            generated_role=generated_role,
+            source_parameter=source_parameter,
+            overridden=overridden,
+        ),
+    }
+
+
+def _resolve_generated_anchor(anchor: str | None, valid_base_names: Sequence[str], name_prefix: str | None) -> str:
+    base_anchor = anchor or valid_base_names[0]
+    generated_names = {_generated_rail_name(name, name_prefix): name for name in valid_base_names}
+    if base_anchor in valid_base_names:
+        return _generated_rail_name(base_anchor, name_prefix)
+    if base_anchor in generated_names:
+        return base_anchor
+    valid = ", ".join(valid_base_names)
+    raise ValueError(f"Invalid generated topology anchor {anchor!r}; valid anchors: {valid}.")
+
+
+@dataclass(frozen=True)
 class TopologyPath:
     id: str = "topology-path"
     closed: bool = True
@@ -404,6 +461,213 @@ class TopologyPath:
         id: str = "topology-path",
     ) -> "TopologyPathBuilder":
         return TopologyPathBuilder(id=id, closed=True, anchor=anchor, direction=direction, sampling_policy=sampling_policy)
+
+    @classmethod
+    def named_rect(
+        cls,
+        width: float,
+        height: float,
+        *,
+        anchor: str = "bottom-left",
+        name_prefix: str | None = None,
+    ) -> "TopologyPath":
+        width = float(width)
+        height = float(height)
+        if not np.isfinite(width) or width <= 0 or not np.isfinite(height) or height <= 0:
+            raise ValueError("named_rect width and height must be positive.")
+        half_w = width / 2.0
+        half_h = height / 2.0
+        rails = (
+            ("bottom-left", (-half_w, -half_h), "corner"),
+            ("bottom-mid", (0.0, -half_h), "side_midpoint"),
+            ("bottom-right", (half_w, -half_h), "corner"),
+            ("right-mid", (half_w, 0.0), "side_midpoint"),
+            ("top-right", (half_w, half_h), "corner"),
+            ("top-mid", (0.0, half_h), "side_midpoint"),
+            ("top-left", (-half_w, half_h), "corner"),
+            ("left-mid", (-half_w, 0.0), "side_midpoint"),
+        )
+        return cls._from_generated_point_rails(
+            "rect",
+            rails,
+            anchor=anchor,
+            name_prefix=name_prefix,
+            metadata={"width": width, "height": height},
+        )
+
+    @classmethod
+    def named_circle(
+        cls,
+        radius: float,
+        *,
+        anchor: str | None = None,
+        name_prefix: str | None = None,
+    ) -> "TopologyPath":
+        radius = float(radius)
+        if not np.isfinite(radius) or radius <= 0:
+            raise ValueError("named_circle radius must be positive.")
+        rails = (
+            ("start", (radius, 0.0), "start"),
+            ("north", (0.0, radius), "quadrant"),
+            ("west", (-radius, 0.0), "quadrant"),
+            ("south", (0.0, -radius), "quadrant"),
+        )
+        return cls._from_generated_point_rails(
+            "circle",
+            rails,
+            anchor=anchor or "start",
+            name_prefix=name_prefix,
+            metadata={"radius": radius},
+        )
+
+    @classmethod
+    def named_rounded_rect(
+        cls,
+        width: float,
+        height: float,
+        radius: float,
+        *,
+        anchor: str = "bottom-left",
+        name_prefix: str | None = None,
+    ) -> "TopologyPath":
+        width = float(width)
+        height = float(height)
+        radius = float(radius)
+        if not np.isfinite(width) or width <= 0 or not np.isfinite(height) or height <= 0:
+            raise ValueError("named_rounded_rect width and height must be positive.")
+        if not np.isfinite(radius) or radius <= 0:
+            raise ValueError("named_rounded_rect radius must be positive.")
+        if radius > min(width, height) / 2.0:
+            raise ValueError("named_rounded_rect radius must fit within width and height.")
+
+        half_w = width / 2.0
+        half_h = height / 2.0
+        rails = (
+            ("bottom-left", (-half_w + radius, -half_h), "tangent_transition"),
+            ("bottom-right", (half_w - radius, -half_h), "tangent_transition"),
+            ("right-bottom", (half_w, -half_h + radius), "tangent_transition"),
+            ("right-top", (half_w, half_h - radius), "tangent_transition"),
+            ("top-right", (half_w - radius, half_h), "tangent_transition"),
+            ("top-left", (-half_w + radius, half_h), "tangent_transition"),
+            ("left-top", (-half_w, half_h - radius), "tangent_transition"),
+            ("left-bottom", (-half_w, -half_h + radius), "tangent_transition"),
+        )
+        points = cls._generated_points("rounded_rect", rails, name_prefix)
+        segment_specs = (
+            ("bottom", "bottom-left", "bottom-right", "straight"),
+            ("bottom-right-arc", "bottom-right", "right-bottom", "corner_arc"),
+            ("right", "right-bottom", "right-top", "straight"),
+            ("top-right-arc", "right-top", "top-right", "corner_arc"),
+            ("top", "top-right", "top-left", "straight"),
+            ("top-left-arc", "top-left", "left-top", "corner_arc"),
+            ("left", "left-top", "left-bottom", "straight"),
+            ("bottom-left-arc", "left-bottom", "bottom-left", "corner_arc"),
+        )
+        point_by_base = {base_name: point for point, (base_name, _, _) in zip(points, rails, strict=True)}
+        segments: list[TopologySegment] = []
+        landmarks: list[TopologyLandmark] = []
+        for segment_name, start_name, end_name, role in segment_specs:
+            generated_name = _generated_rail_name(segment_name, name_prefix)
+            segment_id = derive_stable_id(generated_name)
+            segment_landmarks = (
+                TopologyLandmark(
+                    name=f"{generated_name}-start",
+                    segment_id=segment_id,
+                    parameter=0.0,
+                    role="tangent_transition",
+                    correspondence_id=point_by_base[start_name].correspondence_id,
+                    provenance=_generated_rail_provenance("rounded_rect", name_prefix, "tangent_transition", start_name),
+                ),
+                TopologyLandmark(
+                    name=f"{generated_name}-end",
+                    segment_id=segment_id,
+                    parameter=1.0,
+                    role="tangent_transition",
+                    correspondence_id=point_by_base[end_name].correspondence_id,
+                    provenance=_generated_rail_provenance("rounded_rect", name_prefix, "tangent_transition", end_name),
+                ),
+            )
+            landmarks.extend(segment_landmarks)
+            segments.append(
+                TopologySegment(
+                    id=segment_id,
+                    name=generated_name,
+                    source_kind=role,
+                    start_ref=point_by_base[start_name].id,
+                    end_ref=point_by_base[end_name].id,
+                    correspondence_id=segment_id,
+                    landmarks=segment_landmarks,
+                    provenance=_generated_rail_provenance("rounded_rect", name_prefix, role, segment_name),
+                )
+            )
+        return cls(
+            id=_generated_rail_name("rounded-rect", name_prefix),
+            closed=True,
+            anchor_id=_resolve_generated_anchor(anchor, [name for name, _, _ in rails], name_prefix),
+            anchor_policy="generated",
+            points=tuple(points),
+            segments=tuple(segments),
+            landmarks=tuple(landmarks),
+            metadata={
+                "source": "generated_shape_default_rails",
+                "shape_kind": "rounded_rect",
+                "width": width,
+                "height": height,
+                "radius": radius,
+                "name_prefix": name_prefix,
+            },
+        )
+
+    @classmethod
+    def _from_generated_point_rails(
+        cls,
+        shape_kind: str,
+        rails: Sequence[tuple[str, tuple[float, float], str]],
+        *,
+        anchor: str,
+        name_prefix: str | None,
+        metadata: dict[str, object],
+    ) -> "TopologyPath":
+        return cls(
+            id=_generated_rail_name(shape_kind, name_prefix),
+            closed=True,
+            anchor_id=_resolve_generated_anchor(anchor, [name for name, _, _ in rails], name_prefix),
+            anchor_policy="generated",
+            points=tuple(cls._generated_points(shape_kind, rails, name_prefix)),
+            metadata={
+                "source": "generated_shape_default_rails",
+                "shape_kind": shape_kind,
+                "name_prefix": name_prefix,
+                **metadata,
+            },
+        )
+
+    @staticmethod
+    def _generated_points(
+        shape_kind: str,
+        rails: Sequence[tuple[str, tuple[float, float], str]],
+        name_prefix: str | None,
+    ) -> tuple[TopologyPoint, ...]:
+        points: list[TopologyPoint] = []
+        seen_ids: set[str] = set()
+        for ordinal, (base_name, coordinates, role) in enumerate(rails):
+            generated_name = _generated_rail_name(base_name, name_prefix)
+            point_id = derive_stable_id(generated_name)
+            if point_id in seen_ids:
+                raise ValueError(f"Generated topology rail collision for {point_id!r}.")
+            seen_ids.add(point_id)
+            points.append(
+                TopologyPoint(
+                    id=point_id,
+                    name=generated_name,
+                    coordinates=coordinates,
+                    ordinal=ordinal,
+                    role=role,
+                    correspondence_id=point_id,
+                    provenance=_generated_rail_provenance(shape_kind, name_prefix, role, base_name),
+                )
+            )
+        return tuple(points)
 
     def validate(self) -> None:
         if not self.id:
@@ -1381,6 +1645,7 @@ def split_merge_ambiguous(a_loop: np.ndarray, b_loop: np.ndarray) -> bool:
 
 __all__ = [
     "Loop",
+    "GeneratedRailProvenance",
     "Region",
     "Section",
     "TopologyLandmark",

--- a/tests/test_topology_generated_shape_rails.py
+++ b/tests/test_topology_generated_shape_rails.py
@@ -1,0 +1,86 @@
+import pytest
+
+from impression.modeling.topology import GeneratedRailProvenance, TopologyPath
+
+
+def _generated_roles(path: TopologyPath) -> dict[str, str]:
+    return {point.name: point.provenance["generated_rail"].generated_role for point in path.points}
+
+
+def test_named_rect_generates_corner_and_midpoint_rails() -> None:
+    path = TopologyPath.named_rect(4.0, 2.0)
+
+    assert path.anchor_id == "bottom-left"
+    assert [point.name for point in path.points] == [
+        "bottom-left",
+        "bottom-mid",
+        "bottom-right",
+        "right-mid",
+        "top-right",
+        "top-mid",
+        "top-left",
+        "left-mid",
+    ]
+    roles = _generated_roles(path)
+    assert roles["bottom-left"] == "corner"
+    assert roles["bottom-mid"] == "side_midpoint"
+    assert path.points[0].correspondence_id == "bottom-left"
+    assert isinstance(path.points[0].provenance["generated_rail"], GeneratedRailProvenance)
+
+
+def test_named_circle_generates_start_and_quadrant_rails() -> None:
+    path = TopologyPath.named_circle(2.0)
+
+    assert path.anchor_id == "start"
+    assert [point.name for point in path.points] == ["start", "north", "west", "south"]
+    assert _generated_roles(path) == {
+        "start": "start",
+        "north": "quadrant",
+        "west": "quadrant",
+        "south": "quadrant",
+    }
+
+
+def test_named_rounded_rect_generates_segments_arcs_and_tangent_landmarks() -> None:
+    path = TopologyPath.named_rounded_rect(4.0, 2.0, 0.25)
+
+    assert path.anchor_id == "bottom-left"
+    assert [segment.name for segment in path.segments] == [
+        "bottom",
+        "bottom-right-arc",
+        "right",
+        "top-right-arc",
+        "top",
+        "top-left-arc",
+        "left",
+        "bottom-left-arc",
+    ]
+    assert {segment.source_kind for segment in path.segments} == {"straight", "corner_arc"}
+    assert len(path.landmarks) == 16
+    assert {landmark.role for landmark in path.landmarks} == {"tangent_transition"}
+
+
+def test_name_prefix_namespaces_generated_ids_and_anchor() -> None:
+    path = TopologyPath.named_rect(4.0, 2.0, name_prefix="outer shell", anchor="outer-shell-top-left")
+
+    assert path.anchor_id == "outer-shell-top-left"
+    assert path.points[0].id == "outer-shell-bottom-left"
+    assert path.points[0].name == "outer-shell-bottom-left"
+    assert path.points[0].correspondence_id == "outer-shell-bottom-left"
+    provenance = path.points[0].provenance["generated_rail"]
+    assert provenance.name_prefix == "outer shell"
+    assert provenance.source_parameter == "bottom-left"
+
+
+def test_generated_shape_rails_validate_dimensions_and_anchor() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        TopologyPath.named_rect(0.0, 2.0)
+
+    with pytest.raises(ValueError, match="positive"):
+        TopologyPath.named_circle(0.0)
+
+    with pytest.raises(ValueError, match="fit"):
+        TopologyPath.named_rounded_rect(1.0, 1.0, 0.75)
+
+    with pytest.raises(ValueError, match="valid anchors"):
+        TopologyPath.named_rect(1.0, 1.0, anchor="missing")


### PR DESCRIPTION
## Summary
- add GeneratedRailProvenance for generated topology helper output
- add named_rect, named_circle, and named_rounded_rect topology helpers
- add focused generated rail tests and mark Loft Spec 64 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_topology_path_records.py tests/test_topology_identity_records.py tests/test_topology_path_adapters.py tests/test_topology_builder_core_api.py tests/test_topology_lifecycle_builder_api.py tests/test_topology_generated_shape_rails.py