### PR TITLE
Add surface correspondence executor consumption

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -321,7 +321,7 @@ Only final leaf specifications appear here.
 - [x] [Loft Spec 58: Birth/Death Synthetic Support Resolution (v1.0)](../specifications/loft-58-birth-death-synthetic-support-resolution-v1_0.md)
 - [x] [Loft Spec 59: Correspondence-Preserving Resampling Contract (v1.0)](../specifications/loft-59-correspondence-preserving-resampling-contract-v1_0.md)
 - [x] [Loft Spec 60: Mesh Executor Correspondence Consumption (v1.0)](../specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md)
-- [ ] [Loft Spec 61: Surface Executor Correspondence Consumption (v1.0)](../specifications/loft-61-surface-executor-correspondence-consumption-v1_0.md)
+- [x] [Loft Spec 61: Surface Executor Correspondence Consumption (v1.0)](../specifications/loft-61-surface-executor-correspondence-consumption-v1_0.md)
 
 ## Polish Specifications
 

--- a/project/release-0.1.0a/specifications/loft-61-surface-executor-correspondence-consumption-v1_0.md
+++ b/project/release-0.1.0a/specifications/loft-61-surface-executor-correspondence-consumption-v1_0.md
@@ -1,0 +1,159 @@
+# Loft Spec 61: Surface Executor Correspondence Consumption (v1.0)
+
+Date: 2026-05-25
+Status: Proposed
+Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Surface Executor Correspondence Consumption`
+
+## Purpose
+
+Update the surface loft executor so ruled surface patch construction consumes
+validated sample correspondence records and refuses missing correspondence
+instead of falling back to index-only matching.
+
+## Scope
+
+Owns:
+
+- Surface executor validation for sample correspondence records.
+- `RuledSurfacePatch` construction from correspondence-aligned samples.
+- Diagnostics for missing, inconsistent, or semantically invalid surface
+  correspondence input.
+
+Does not own:
+
+- Planner resampling and sample allocation.
+- Mesh executor behavior.
+- Surface body patch family implementation outside loft handoff.
+
+## Implementation Routing
+
+- Primary modules/files:
+  - `src/impression/modeling/loft.py` - update `_loft_execute_plan_surface`
+    and surface executor helpers.
+- Supporting modules/files:
+  - `src/impression/modeling/surface.py` or current surface patch owner - use
+    `RuledSurfacePatch`.
+- GUI/QML files, if applicable:
+  - not applicable.
+- Reusable library/module files:
+  - `src/impression/modeling/loft.py` - surface executor consumption path.
+- Tests:
+  - `tests/test_loft_surface_executor_correspondence.py` - ruled patch
+    boundaries, lifecycle supports, and missing-record refusal.
+
+## Chosen Defaults / Parameters
+
+- Surface executor requires validated `ResampledLoopCorrespondence`.
+- Surface executor refuses missing sample records and never silently falls back
+  to mesh-first or index-only correspondence.
+- Boundary construction preserves protected sample order exactly.
+- Surface patch diagnostics include track and lifecycle references when a
+  boundary cannot be emitted.
+
+## Data Ownership
+
+- Source of truth: planner owns correspondence truth; surface executor owns
+  emitted surface patches.
+- Read ownership: surface executor reads immutable resampled correspondence.
+- Write ownership: surface executor writes surface body/shell/patch output and
+  executor diagnostics only.
+- Derived/cache data: surface patch boundaries derive from sample arrays and
+  records.
+- Privacy/logging constraints: diagnostics may log sample indices, track ids,
+  lifecycle ids, and refusal reasons.
+
+## Dependencies And Routes
+
+- Domain/service dependencies:
+  - `ResampledLoopCorrespondence`
+  - `SampleCorrespondenceRecord`
+  - `RuledSurfacePatch`
+  - surface body/shell construction helpers
+- Database dependencies:
+  - none.
+- GUI route, if applicable:
+  - not applicable.
+- Background/concurrency route, if applicable:
+  - not applicable; use current loft execution path.
+
+## Reuse And Extraction Plan
+
+- Existing code to reuse:
+  - `RuledSurfacePatch`
+  - Existing surface loft executor route.
+- Current reuse readiness:
+  - update existing surface executor path.
+- Extraction/wrapping needed:
+  - wrap surface boundary construction to accept sample correspondence records.
+- Additions to existing library/modules:
+  - `emit_surface_patches_from_sample_correspondence(...)`
+  - `validate_surface_executor_correspondence_input(...)`
+- New reusable modules to expose:
+  - none.
+- One-off code justification, if any:
+  - none.
+
+## Required DTOs / Functions / Components
+
+- DTOs/models:
+  - `SurfaceSampleEmissionDiagnostic` - fields: `loop_pair_id`,
+    `sample_index`, `track_id`, `lifecycle_event_id`, `reason`.
+- Functions/methods:
+  - `validate_surface_executor_correspondence_input(resampled) -> None`
+  - `emit_surface_patches_from_sample_correspondence(resampled,
+    surface_builder) -> SurfaceBody`
+- UI fields / visible data, if applicable:
+  - not applicable.
+- UI elements / controls, if applicable:
+  - not applicable.
+- UI components, if applicable:
+  - not applicable.
+
+## Performance Contract
+
+- Surface boundary emission is O(s) per loop pair.
+- Validation is O(s).
+- Surface executor must not resample, infer, or repair correspondence.
+
+## Error And State Behavior
+
+- Missing sample records refuse with `missing_sample_correspondence`.
+- Surface boundary sample mismatch refuses with `surface_boundary_sample_mismatch`.
+- Missing lifecycle support referenced by a sample refuses with
+  `missing_lifecycle_support`.
+- Refusal happens before partial surface body output.
+
+## Test Strategy
+
+- Unit tests:
+  - ruled patch boundaries follow sample correspondence records.
+  - protected landmarks remain patch boundary samples.
+  - birth/death supports are preserved in surface output.
+  - missing records refuse.
+  - surface executor does not call mesh fallback for correspondence failure.
+- Service/DB tests:
+  - not applicable.
+- GUI/controller tests, if applicable:
+  - not applicable.
+- Production-data rule:
+  - Tests must not require the user's production database.
+
+## Acceptance Criteria
+
+- Surface loft execution consumes explicit sample correspondence records.
+- Missing correspondence refuses before output, with no mesh fallback.
+- Ruled surface boundaries preserve protected landmarks and lifecycle supports.
+
+## Readiness Checklist
+
+- [x] Implementation owner/module is named.
+- [x] Existing code reuse/extraction decision is explicit.
+- [x] Existing library/module additions or new reusable module boundaries are named, or marked not applicable.
+- [x] UI fields/elements are listed, or marked not applicable.
+- [x] Chosen defaults are explicit.
+- [x] Data source of truth and write owner are explicit.
+- [x] GUI/concurrency route is explicit, or marked not applicable.
+- [x] Performance bounds are explicit, or marked not applicable.
+- [x] Privacy/logging constraints are explicit, or marked not applicable.
+- [x] Test strategy does not depend on production data.
+- [x] Acceptance criteria are testable.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -51,6 +51,7 @@ from .loft import (
     PointLifecycleEvent,
     PointLifecycleState,
     SampleCorrespondenceRecord,
+    SurfaceSampleEmissionDiagnostic,
     SyntheticSupportReference,
     LoftPlan,
     LoftAmbiguityCandidate,
@@ -65,6 +66,7 @@ from .loft import (
     loft_endcaps,
     accept_or_refuse_inferred_correspondence,
     emit_mesh_faces_from_sample_correspondence,
+    emit_surface_patches_from_sample_correspondence,
     insert_synthetic_support_reference,
     locate_parent_span,
     project_point_to_span,
@@ -77,6 +79,7 @@ from .loft import (
     validate_mesh_executor_correspondence_input,
     validate_rail_priority,
     validate_sample_correspondence,
+    validate_surface_executor_correspondence_input,
 )
 from .path3d import Arc3D, Bezier3D, Line3D, Path3D
 from .progression import (
@@ -425,6 +428,7 @@ __all__ = [
     "PointLifecycleEvent",
     "PointLifecycleState",
     "SampleCorrespondenceRecord",
+    "SurfaceSampleEmissionDiagnostic",
     "SyntheticSupportReference",
     "LoftPlan",
     "LoftAmbiguityCandidate",
@@ -434,6 +438,7 @@ __all__ = [
     "loft_plan_ambiguities",
     "accept_or_refuse_inferred_correspondence",
     "emit_mesh_faces_from_sample_correspondence",
+    "emit_surface_patches_from_sample_correspondence",
     "insert_synthetic_support_reference",
     "locate_parent_span",
     "project_point_to_span",
@@ -446,6 +451,7 @@ __all__ = [
     "validate_mesh_executor_correspondence_input",
     "validate_rail_priority",
     "validate_sample_correspondence",
+    "validate_surface_executor_correspondence_input",
     "boolean_union",
     "boolean_difference",
     "boolean_intersection",

--- a/src/impression/modeling/loft.py
+++ b/src/impression/modeling/loft.py
@@ -166,6 +166,15 @@ class MeshSampleEmissionDiagnostic:
 
 
 @dataclass(frozen=True)
+class SurfaceSampleEmissionDiagnostic:
+    loop_pair_id: str
+    sample_index: int | None
+    track_id: str | None
+    lifecycle_event_id: str | None
+    reason: str
+
+
+@dataclass(frozen=True)
 class _RailRecord:
     ref: str
     key: str
@@ -1156,6 +1165,63 @@ def emit_mesh_faces_from_sample_correspondence(
     if mesh_builder is not None and hasattr(mesh_builder, "append"):
         mesh_builder.append(mesh)
     return mesh
+
+
+def validate_surface_executor_correspondence_input(resampled: ResampledLoopCorrespondence) -> None:
+    loop_pair_id = str(resampled.diagnostics.get("loop_pair_id", "loop-pair"))
+    if len(resampled.source_samples) != len(resampled.target_samples):
+        diagnostic = SurfaceSampleEmissionDiagnostic(
+            loop_pair_id, None, None, None, "surface_boundary_sample_mismatch"
+        )
+        raise ValueError(f"{diagnostic.reason}: source and target boundary samples differ.")
+    if not resampled.sample_records or len(resampled.sample_records) != len(resampled.source_samples):
+        diagnostic = SurfaceSampleEmissionDiagnostic(loop_pair_id, None, None, None, "missing_sample_correspondence")
+        raise ValueError(f"{diagnostic.reason}: sample records are required.")
+    for index, record in enumerate(resampled.sample_records):
+        if record.index != index:
+            diagnostic = SurfaceSampleEmissionDiagnostic(
+                loop_pair_id,
+                index,
+                record.track_id,
+                record.lifecycle_event_id,
+                "surface_boundary_sample_mismatch",
+            )
+            raise ValueError(f"{diagnostic.reason}: record index {record.index} does not match {index}.")
+        if record.lifecycle_event_id and record.track_id is None:
+            diagnostic = SurfaceSampleEmissionDiagnostic(
+                loop_pair_id,
+                index,
+                None,
+                record.lifecycle_event_id,
+                "missing_lifecycle_support",
+            )
+            raise ValueError(f"{diagnostic.reason}: lifecycle sample lacks support track.")
+
+
+def emit_surface_patches_from_sample_correspondence(
+    resampled: ResampledLoopCorrespondence,
+    surface_builder: object | None = None,
+) -> SurfaceBody:
+    validate_surface_executor_correspondence_input(resampled)
+    start_curve = np.column_stack([resampled.source_samples, np.zeros(len(resampled.source_samples))])
+    end_curve = np.column_stack([resampled.target_samples, np.ones(len(resampled.target_samples))])
+    patch = RuledSurfacePatch(
+        family="ruled",
+        start_curve=start_curve,
+        end_curve=end_curve,
+        metadata={
+            "executor": "surface_correspondence",
+            "sample_records": resampled.sample_records,
+            "protected_indices": resampled.protected_indices,
+        },
+    )
+    body = make_surface_body(
+        (make_surface_shell((patch,), metadata={"executor": "surface_correspondence"}),),
+        metadata={"executor": "surface_correspondence", "sample_records": resampled.sample_records},
+    )
+    if surface_builder is not None and hasattr(surface_builder, "append"):
+        surface_builder.append(body)
+    return body
 
 
 @dataclass(frozen=True)
@@ -6206,10 +6272,12 @@ __all__ = [
     "PointLifecycleEvent",
     "PointLifecycleState",
     "SampleCorrespondenceRecord",
+    "SurfaceSampleEmissionDiagnostic",
     "SyntheticSupportReference",
     "LoftPlan",
     "accept_or_refuse_inferred_correspondence",
     "emit_mesh_faces_from_sample_correspondence",
+    "emit_surface_patches_from_sample_correspondence",
     "insert_synthetic_support_reference",
     "locate_parent_span",
     "project_point_to_span",
@@ -6222,6 +6290,7 @@ __all__ = [
     "validate_mesh_executor_correspondence_input",
     "validate_rail_priority",
     "validate_sample_correspondence",
+    "validate_surface_executor_correspondence_input",
     "loft_profiles",
     "loft",
     "loft_plan_sections",

--- a/tests/test_loft_surface_executor_correspondence.py
+++ b/tests/test_loft_surface_executor_correspondence.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from impression.modeling.loft import (
+    SampleCorrespondenceRecord,
+    emit_surface_patches_from_sample_correspondence,
+    resolve_authored_rails,
+    resolve_point_birth_death_events,
+    resample_loop_correspondence,
+    validate_surface_executor_correspondence_input,
+)
+from impression.modeling.topology import TopologyPath
+
+
+def _path(points: tuple[tuple[str, tuple[float, float], str], ...]) -> TopologyPath:
+    builder = TopologyPath.closed()
+    for name, coordinates, correspondence_id in points:
+        builder.point(name, coordinates, correspond=correspondence_id)
+    return builder.build()
+
+
+def test_surface_ruled_patch_boundaries_follow_sample_correspondence() -> None:
+    source = _path((("a", (0.0, 0.0), "a"), ("b", (1.0, 0.0), "b"), ("c", (0.0, 1.0), "c")))
+    target = _path((("a", (0.0, 0.0), "a"), ("b", (2.0, 0.0), "b"), ("c", (0.0, 2.0), "c")))
+    resampled = resample_loop_correspondence({"source": source, "target": target}, sample_count="auto")
+
+    body = emit_surface_patches_from_sample_correspondence(resampled)
+    patch = body.shells[0].patches[0]
+
+    assert body.patch_count == 1
+    assert patch.start_curve.shape == (3, 3)
+    assert patch.end_curve.shape == (3, 3)
+    assert tuple(patch.end_curve[1]) == (2.0, 0.0, 1.0)
+    assert patch.metadata["sample_records"][1].track_id == "b->b"
+
+
+def test_surface_preserves_protected_landmarks_as_boundary_samples() -> None:
+    source = _path((("a", (0.0, 0.0), "a"), ("b", (1.0, 0.0), "b"), ("c", (0.0, 1.0), "c")))
+    target = _path((("a", (0.0, 0.0), "a"), ("b", (1.0, 0.0), "b"), ("c", (0.0, 1.0), "c")))
+    resampled = resample_loop_correspondence({"source": source, "target": target}, sample_count=5)
+
+    body = emit_surface_patches_from_sample_correspondence(resampled)
+
+    assert body.shells[0].patches[0].metadata["protected_indices"] == (0, 1, 2)
+
+
+def test_surface_preserves_birth_support_in_output_metadata() -> None:
+    source = _path((("a", (0.0, 0.0), "a"), ("b", (1.0, 0.0), "b"), ("c", (0.0, 1.0), "c")))
+    target = _path(
+        (("a", (0.0, 0.0), "a"), ("born", (0.5, 0.0), "born"), ("b", (1.0, 0.0), "b"), ("c", (0.0, 1.0), "c"))
+    )
+    rail_result = resolve_authored_rails(source, target)
+    lifecycle = resolve_point_birth_death_events({"source": source, "target": target}, rail_result, None)
+    resampled = resample_loop_correspondence(
+        {"source": source, "target": target, "rail_result": rail_result, "lifecycle_resolution": lifecycle},
+        sample_count="auto",
+    )
+
+    body = emit_surface_patches_from_sample_correspondence(resampled)
+
+    assert any(record.lifecycle_event_id for record in body.metadata["sample_records"])
+
+
+def test_surface_executor_refuses_missing_records_without_mesh_fallback() -> None:
+    broken = SimpleNamespace(
+        source_samples=np.zeros((3, 2)),
+        target_samples=np.zeros((3, 2)),
+        sample_records=(),
+        diagnostics={},
+    )
+
+    with pytest.raises(ValueError, match="missing_sample_correspondence"):
+        emit_surface_patches_from_sample_correspondence(broken)
+
+
+def test_surface_executor_refuses_semantically_invalid_lifecycle_sample() -> None:
+    broken = SimpleNamespace(
+        source_samples=np.zeros((1, 2)),
+        target_samples=np.zeros((1, 2)),
+        sample_records=(SampleCorrespondenceRecord(index=0, lifecycle_event_id="birth-a", track_id=None),),
+        diagnostics={},
+    )
+
+    with pytest.raises(ValueError, match="missing_lifecycle_support"):
+        validate_surface_executor_correspondence_input(broken)


### PR DESCRIPTION
## Summary
- add surface sample emission diagnostics and defensive correspondence validation
- add ruled surface patch emission from explicit sample correspondence records
- add focused surface executor correspondence tests and mark Loft Spec 61 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_loft_surface_executor_correspondence.py tests/test_loft_mesh_executor_correspondence.py tests/test_loft_correspondence_resampling.py