### PR TITLE
Add .impress units root validation

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -338,7 +338,7 @@ Only final leaf specifications appear here.
 
 ### Impress Surface Native File Format Architecture
 - [x] [Impress Spec 01: .impress Document Root And Schema Version (v1.0)](../specifications/impress-01-impress-document-root-and-schema-version-v1_0.md)
-- [ ] [Impress Spec 02: .impress Units And Root Validation Policy (v1.0)](../specifications/impress-02-impress-units-and-root-validation-policy-v1_0.md)
+- [x] [Impress Spec 02: .impress Units And Root Validation Policy (v1.0)](../specifications/impress-02-impress-units-and-root-validation-policy-v1_0.md)
 - [ ] [Impress Spec 03: .impress SurfaceBodyStore And Identity Policy (v1.0)](../specifications/impress-03-impress-surfacebodystore-and-identity-policy-v1_0.md)
 - [ ] [Impress Spec 04: .impress Body And Shell Payload Codec (v1.0)](../specifications/impress-04-impress-body-and-shell-payload-codec-v1_0.md)
 - [ ] [Impress Spec 05: .impress Patch Payload Codec (v1.0)](../specifications/impress-05-impress-patch-payload-codec-v1_0.md)

--- a/src/impression/io/__init__.py
+++ b/src/impression/io/__init__.py
@@ -2,22 +2,30 @@
 
 from .impress import (
     CURRENT_IMPRESS_SCHEMA_VERSION,
+    DEFAULT_IMPRESS_LENGTH_UNIT,
     IMPRESS_FORMAT,
     ImpressDocumentRoot,
     ImpressFormatError,
+    ImpressUnits,
+    SUPPORTED_IMPRESS_LENGTH_UNITS,
     UnsupportedImpressSchemaVersion,
     make_impress_document_root,
+    validate_impress_units,
     validate_impress_document_root,
 )
 from .stl import write_stl
 
 __all__ = [
     "CURRENT_IMPRESS_SCHEMA_VERSION",
+    "DEFAULT_IMPRESS_LENGTH_UNIT",
     "IMPRESS_FORMAT",
     "ImpressDocumentRoot",
     "ImpressFormatError",
+    "ImpressUnits",
+    "SUPPORTED_IMPRESS_LENGTH_UNITS",
     "UnsupportedImpressSchemaVersion",
     "make_impress_document_root",
+    "validate_impress_units",
     "validate_impress_document_root",
     "write_stl",
 ]

--- a/src/impression/io/impress.py
+++ b/src/impression/io/impress.py
@@ -5,6 +5,8 @@ from typing import Mapping
 
 IMPRESS_FORMAT = "impress"
 CURRENT_IMPRESS_SCHEMA_VERSION = "1.0"
+DEFAULT_IMPRESS_LENGTH_UNIT = "unitless"
+SUPPORTED_IMPRESS_LENGTH_UNITS = frozenset({"unitless", "mm", "cm", "m", "in", "ft"})
 
 
 class ImpressFormatError(ValueError):
@@ -16,17 +18,32 @@ class UnsupportedImpressSchemaVersion(ImpressFormatError):
 
 
 @dataclass(frozen=True)
+class ImpressUnits:
+    """Symbolic `.impress` file units.
+
+    Unit conversion is intentionally outside the V1 root validation contract.
+    """
+
+    length: str = DEFAULT_IMPRESS_LENGTH_UNIT
+
+    def to_json_object(self) -> dict[str, object]:
+        return {"length": self.length}
+
+
+@dataclass(frozen=True)
 class ImpressDocumentRoot:
     """Minimal `.impress` document envelope."""
 
     schema_version: str = CURRENT_IMPRESS_SCHEMA_VERSION
     format: str = IMPRESS_FORMAT
+    units: ImpressUnits = field(default_factory=ImpressUnits)
     metadata: Mapping[str, object] = field(default_factory=dict)
 
     def to_json_object(self) -> dict[str, object]:
         return {
             "format": self.format,
             "schema_version": self.schema_version,
+            "units": self.units.to_json_object(),
             "metadata": dict(self.metadata),
         }
 
@@ -34,20 +51,56 @@ class ImpressDocumentRoot:
 def make_impress_document_root(
     *,
     schema_version: str = CURRENT_IMPRESS_SCHEMA_VERSION,
+    units: ImpressUnits | Mapping[str, object] | None = None,
     metadata: Mapping[str, object] | None = None,
 ) -> ImpressDocumentRoot:
     """Create a validated minimal `.impress` document root."""
 
+    normalized_units = validate_impress_units(units)
     root = ImpressDocumentRoot(
         schema_version=schema_version,
+        units=normalized_units,
         metadata={} if metadata is None else dict(metadata),
     )
     validate_impress_document_root(root.to_json_object())
     return root
 
 
+def validate_impress_units(units: ImpressUnits | Mapping[str, object] | None) -> ImpressUnits:
+    """Validate and normalize symbolic `.impress` units."""
+
+    if units is None:
+        return ImpressUnits()
+    if isinstance(units, ImpressUnits):
+        unit_record = units
+    elif isinstance(units, Mapping):
+        unknown_keys = set(units) - {"length"}
+        if unknown_keys:
+            keys = ", ".join(sorted(str(key) for key in unknown_keys))
+            raise ImpressFormatError(f"Unsupported `.impress` unit fields: {keys}.")
+        length = units.get("length", DEFAULT_IMPRESS_LENGTH_UNIT)
+        if not isinstance(length, str):
+            raise ImpressFormatError("`.impress` length unit must be a string.")
+        unit_record = ImpressUnits(length=length)
+    else:
+        raise ImpressFormatError("`.impress` units must be an object when present.")
+
+    if unit_record.length not in SUPPORTED_IMPRESS_LENGTH_UNITS:
+        supported = ", ".join(sorted(SUPPORTED_IMPRESS_LENGTH_UNITS))
+        raise ImpressFormatError(
+            f"Unsupported `.impress` length unit {unit_record.length!r}; expected one of {supported}."
+        )
+    return unit_record
+
+
 def validate_impress_document_root(root: Mapping[str, object]) -> ImpressDocumentRoot:
     """Validate a minimal `.impress` root envelope and return its typed form."""
+
+    if not isinstance(root, Mapping):
+        raise ImpressFormatError("`.impress` root must be an object.")
+    non_string_keys = [key for key in root if not isinstance(key, str)]
+    if non_string_keys:
+        raise ImpressFormatError("`.impress` root keys must be strings.")
 
     format_value = root.get("format")
     if format_value != IMPRESS_FORMAT:
@@ -66,4 +119,5 @@ def validate_impress_document_root(root: Mapping[str, object]) -> ImpressDocumen
     if not isinstance(metadata, Mapping):
         raise ImpressFormatError("`.impress` root metadata must be an object when present.")
 
-    return ImpressDocumentRoot(schema_version=schema_version, metadata=dict(metadata))
+    units = validate_impress_units(root.get("units"))
+    return ImpressDocumentRoot(schema_version=schema_version, units=units, metadata=dict(metadata))

--- a/tests/test_impress_io.py
+++ b/tests/test_impress_io.py
@@ -4,10 +4,13 @@ import pytest
 
 from impression.io import (
     CURRENT_IMPRESS_SCHEMA_VERSION,
+    DEFAULT_IMPRESS_LENGTH_UNIT,
     IMPRESS_FORMAT,
     ImpressFormatError,
+    ImpressUnits,
     UnsupportedImpressSchemaVersion,
     make_impress_document_root,
+    validate_impress_units,
     validate_impress_document_root,
 )
 
@@ -18,6 +21,7 @@ def test_make_impress_document_root_declares_format_and_schema() -> None:
     assert root.to_json_object() == {
         "format": IMPRESS_FORMAT,
         "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION,
+        "units": {"length": DEFAULT_IMPRESS_LENGTH_UNIT},
         "metadata": {"author": "test"},
     }
 
@@ -27,11 +31,13 @@ def test_validate_impress_document_root_returns_typed_root() -> None:
         {
             "format": "impress",
             "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION,
+            "units": {"length": "mm"},
             "metadata": {"purpose": "roundtrip"},
         }
     )
 
     assert root.schema_version == CURRENT_IMPRESS_SCHEMA_VERSION
+    assert root.units == ImpressUnits(length="mm")
     assert root.metadata == {"purpose": "roundtrip"}
 
 
@@ -43,6 +49,9 @@ def test_validate_impress_document_root_returns_typed_root() -> None:
         {"format": "impress"},
         {"format": "impress", "schema_version": ""},
         {"format": "impress", "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION, "metadata": []},
+        {"format": "impress", "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION, "units": []},
+        {"format": "impress", "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION, "units": {"angle": "degree"}},
+        {"format": "impress", "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION, "units": {"length": "parsec"}},
     ],
 )
 def test_validate_impress_document_root_rejects_invalid_roots(payload: dict[str, object]) -> None:
@@ -53,3 +62,35 @@ def test_validate_impress_document_root_rejects_invalid_roots(payload: dict[str,
 def test_validate_impress_document_root_rejects_unsupported_schema() -> None:
     with pytest.raises(UnsupportedImpressSchemaVersion, match="Unsupported `.impress` schema_version"):
         validate_impress_document_root({"format": "impress", "schema_version": "999.0"})
+
+
+def test_validate_impress_document_root_defaults_missing_units() -> None:
+    root = validate_impress_document_root(
+        {
+            "format": "impress",
+            "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION,
+            "metadata": {},
+        }
+    )
+
+    assert root.units == ImpressUnits()
+
+
+def test_make_impress_document_root_accepts_symbolic_units() -> None:
+    root = make_impress_document_root(units={"length": "in"})
+
+    assert root.units == ImpressUnits(length="in")
+    assert root.to_json_object()["units"] == {"length": "in"}
+
+
+def test_validate_impress_units_rejects_invalid_unit() -> None:
+    with pytest.raises(ImpressFormatError, match="Unsupported `.impress` length unit"):
+        validate_impress_units({"length": "px"})
+
+
+def test_validate_impress_document_root_rejects_unsafe_root_shape() -> None:
+    with pytest.raises(ImpressFormatError, match="root must be an object"):
+        validate_impress_document_root([])  # type: ignore[arg-type]
+
+    with pytest.raises(ImpressFormatError, match="root keys must be strings"):
+        validate_impress_document_root({1: "impress", "schema_version": CURRENT_IMPRESS_SCHEMA_VERSION})  # type: ignore[dict-item]


### PR DESCRIPTION
## Summary
- add symbolic .impress units record and validator
- default root units to unitless and preserve declared symbolic units
- add bounded root-shape refusal checks before future payload decode
- mark Impress Spec 02 complete in progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_impress_io.py -q