### PR TITLE
Document .impress interchange boundary

### DIFF
--- a/project/release-0.1.0a/architecture/impress-surface-native-file-format-architecture.md
+++ b/project/release-0.1.0a/architecture/impress-surface-native-file-format-architecture.md
@@ -364,6 +364,21 @@ STEP, IGES, BREP, JT, and other CAD formats are interchange formats. They are
 valuable, but they should be implemented as adapters around the surface-native
 store rather than as the internal persistence model.
 
+### V1 Boundary Policy
+
+`.impress` V1 does not promise STEP, IGES, BREP, JT, STL, or imported-mesh
+compatibility. The only V1 persistence promise is native `SurfaceBody` truth as
+defined by this architecture and the active `.impress` schema version.
+
+The V1 reader must refuse industry-format payloads, mesh payloads, executable
+implicit/code payloads, and unknown adapter records when they appear in the
+native document root. Refusal is the correct behavior because accepting those
+records would imply an adapter contract that has not been specified.
+
+The V1 writer must not emit industry-interchange adapter state. It may emit only
+surface-native payloads, metadata that is valid JSON data, and schema fields
+defined by this architecture.
+
 Recommended adapter posture:
 
 ```text
@@ -382,6 +397,45 @@ industry formats may not represent cleanly:
 - generator provenance
 - patch-family capability flags
 - exact release-schema assumptions
+
+### Imported Mesh Classification
+
+Imported meshes are tool data, not `.impress` surface truth.
+
+An imported mesh may be represented in future work as an explicit imported mesh
+record owned by the mesh toolchain. That record must be classified separately
+from `SurfaceBody`, must not masquerade as a surface patch, and must not become
+a hidden fallback for failed surface-body loading.
+
+V1 `.impress` has no imported mesh record. If a file contains a root-level mesh
+payload, an embedded STL-like payload, or a patch whose geometry is merely a
+mesh, the loader must reject the file with an unsupported payload diagnostic.
+
+### External Adapter Placeholder
+
+Future external adapters should attach outside the native persistence path:
+
+```text
+External CAD file
+-> adapter parser / validator
+-> SurfaceBodyStore conversion report
+-> SurfaceBody runtime objects
+-> optional .impress save
+```
+
+Adapter placeholders are documentation-only in V1. No adapter placeholder in a
+`.impress` file is executable, dynamically imported, or interpreted as code.
+When adapter support is eventually specified, it must define:
+
+- supported source/target format and version
+- data-only adapter payload schema
+- validation and refusal diagnostics
+- conversion report shape
+- lossiness and unsupported-entity policy
+- security limits for external payloads
+
+Until then, STEP/IGES/BREP/JT import/export and STL mesh import remain outside
+the `.impress` native file contract.
 
 ## Security And Robustness
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -349,7 +349,7 @@ Only final leaf specifications appear here.
 - [x] [Impress Spec 10: .impress Reader And Load Result Contract (v1.0)](../specifications/impress-10-impress-reader-and-load-result-contract-v1_0.md)
 - [x] [Impress Spec 11: .impress Atomic File Write And Error Handling (v1.0)](../specifications/impress-11-impress-atomic-file-write-and-error-handling-v1_0.md)
 - [x] [Impress Spec 12: .impress Round Trip And Refusal Tests (v1.0)](../specifications/impress-12-impress-round-trip-and-refusal-tests-v1_0.md)
-- [ ] [Impress Spec 13: .impress Industry Interchange Boundary (v1.0)](../specifications/impress-13-impress-industry-interchange-boundary-v1_0.md)
+- [x] [Impress Spec 13: .impress Industry Interchange Boundary (v1.0)](../specifications/impress-13-impress-industry-interchange-boundary-v1_0.md)
 
 ### Full Surface Patch Family Architecture
 - [ ] [Surface Spec 139: Patch Family Capability Matrix And Spec 66 Retirement (v1.0)](../specifications/surface-139-patch-family-capability-matrix-and-spec-66-retirement-v1_0.md)


### PR DESCRIPTION
## Summary
- document the .impress V1 boundary against STEP/IGES/BREP/JT/STL and imported mesh workflows
- classify imported meshes as mesh-toolchain data rather than native surface truth
- mark Impress Spec 13 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_impress_io.py -q