### PR TITLE
Version analytic impress patch payloads

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -367,7 +367,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 151: Cross-Family Tessellation Adapters (v1.0)](../specifications/surface-151-cross-family-tessellation-adapters-v1_0.md)
 - [x] [Surface Spec 152: Cross-Family Seam Boundary Participation (v1.0)](../specifications/surface-152-cross-family-seam-boundary-participation-v1_0.md)
 - [x] [Surface Spec 153: Family-Aware Boolean Eligibility And Diagnostics (v1.0)](../specifications/surface-153-family-aware-boolean-eligibility-and-diagnostics-v1_0.md)
-- [ ] [Surface Spec 154: .impress Analytic Patch Payloads (v1.0)](../specifications/surface-154-impress-analytic-patch-payloads-v1_0.md)
+- [x] [Surface Spec 154: .impress Analytic Patch Payloads (v1.0)](../specifications/surface-154-impress-analytic-patch-payloads-v1_0.md)
 - [ ] [Surface Spec 155: .impress Spline Patch Payloads (v1.0)](../specifications/surface-155-impress-spline-patch-payloads-v1_0.md)
 - [ ] [Surface Spec 156: .impress Sweep Patch Payload (v1.0)](../specifications/surface-156-impress-sweep-patch-payload-v1_0.md)
 - [ ] [Surface Spec 157: .impress Subdivision Patch Payload (v1.0)](../specifications/surface-157-impress-subdivision-patch-payload-v1_0.md)

--- a/src/impression/io/impress.py
+++ b/src/impression/io/impress.py
@@ -32,6 +32,7 @@ _PATCH_KIND_FAMILIES = {
     "RuledSurfacePatch": "ruled",
     "RevolutionSurfacePatch": "revolution",
 }
+_ANALYTIC_PATCH_PAYLOAD_VERSION = 1
 
 
 class ImpressFormatError(ValueError):
@@ -691,6 +692,11 @@ def decode_surface_patch_payload(payload: Mapping[str, object]) -> SurfacePatch:
     }
     try:
         if kind == "PlanarSurfacePatch":
+            _validate_patch_geometry_fields(
+                geometry,
+                kind=kind,
+                allowed_fields={"payload_version", "origin", "u_axis", "v_axis"},
+            )
             return PlanarSurfacePatch(
                 **common,
                 origin=_validate_vec3_payload(geometry.get("origin"), "origin"),
@@ -698,12 +704,29 @@ def decode_surface_patch_payload(payload: Mapping[str, object]) -> SurfacePatch:
                 v_axis=_validate_vec3_payload(geometry.get("v_axis"), "v_axis"),
             )
         if kind == "RuledSurfacePatch":
+            _validate_patch_geometry_fields(
+                geometry,
+                kind=kind,
+                allowed_fields={"payload_version", "start_curve", "end_curve"},
+            )
             return RuledSurfacePatch(
                 **common,
                 start_curve=_validate_points3_payload(geometry.get("start_curve"), "start_curve"),
                 end_curve=_validate_points3_payload(geometry.get("end_curve"), "end_curve"),
             )
         if kind == "RevolutionSurfacePatch":
+            _validate_patch_geometry_fields(
+                geometry,
+                kind=kind,
+                allowed_fields={
+                    "payload_version",
+                    "profile_curve",
+                    "axis_origin",
+                    "axis_direction",
+                    "start_angle_deg",
+                    "sweep_angle_deg",
+                },
+            )
             return RevolutionSurfacePatch(
                 **common,
                 profile_curve=_validate_points3_payload(geometry.get("profile_curve"), "profile_curve"),
@@ -918,17 +941,20 @@ def _encode_patch_geometry_payload(patch: SurfacePatch) -> dict[str, object]:
     geometry = patch.geometry_payload()
     if isinstance(patch, PlanarSurfacePatch):
         return {
+            "payload_version": _ANALYTIC_PATCH_PAYLOAD_VERSION,
             "origin": _array_payload(geometry["origin"]),
             "u_axis": _array_payload(geometry["u_axis"]),
             "v_axis": _array_payload(geometry["v_axis"]),
         }
     if isinstance(patch, RuledSurfacePatch):
         return {
+            "payload_version": _ANALYTIC_PATCH_PAYLOAD_VERSION,
             "start_curve": _array_payload(geometry["start_curve"]),
             "end_curve": _array_payload(geometry["end_curve"]),
         }
     if isinstance(patch, RevolutionSurfacePatch):
         return {
+            "payload_version": _ANALYTIC_PATCH_PAYLOAD_VERSION,
             "profile_curve": _array_payload(geometry["profile_curve"]),
             "axis_origin": _array_payload(geometry["axis_origin"]),
             "axis_direction": _array_payload(geometry["axis_direction"]),
@@ -936,6 +962,23 @@ def _encode_patch_geometry_payload(patch: SurfacePatch) -> dict[str, object]:
             "sweep_angle_deg": float(geometry["sweep_angle_deg"]),
         }
     raise ImpressFormatError(f"Unsupported SurfacePatch kind {type(patch).__name__!r}.")
+
+
+def _validate_patch_geometry_fields(
+    geometry: Mapping[str, object],
+    *,
+    kind: str,
+    allowed_fields: set[str],
+) -> None:
+    unknown_keys = set(geometry) - allowed_fields
+    if unknown_keys:
+        keys = ", ".join(sorted(str(key) for key in unknown_keys))
+        raise ImpressFormatError(f"Unsupported {kind} geometry fields: {keys}.")
+    payload_version = geometry.get("payload_version")
+    if payload_version != _ANALYTIC_PATCH_PAYLOAD_VERSION:
+        raise ImpressFormatError(
+            f"{kind} geometry payload_version must be {_ANALYTIC_PATCH_PAYLOAD_VERSION}."
+        )
 
 
 def _validate_patch_kind_family(kind: str, family: str) -> None:

--- a/tests/test_impress_io.py
+++ b/tests/test_impress_io.py
@@ -683,6 +683,7 @@ def test_encode_decode_planar_surface_patch_payload_round_trips_base_fields() ->
     assert payload["family"] == "planar"
     assert payload["domain"] == {"u_range": [-1.0, 1.0], "v_range": [2.0, 4.0], "normalized": False}
     assert payload["capability_flags"] == ["evaluatable", "tessellatable"]
+    assert payload["geometry"]["payload_version"] == 1
     assert decoded.stable_identity == patch.stable_identity
     assert decoded.metadata == patch.metadata
 
@@ -702,8 +703,13 @@ def test_encode_decode_ruled_and_revolution_surface_patch_payloads_round_trip() 
         sweep_angle_deg=180.0,
     )
 
-    assert decode_surface_patch_payload(encode_surface_patch_payload(ruled)).stable_identity == ruled.stable_identity
-    assert decode_surface_patch_payload(encode_surface_patch_payload(revolution)).stable_identity == revolution.stable_identity
+    ruled_payload = encode_surface_patch_payload(ruled)
+    revolution_payload = encode_surface_patch_payload(revolution)
+
+    assert ruled_payload["geometry"]["payload_version"] == 1
+    assert revolution_payload["geometry"]["payload_version"] == 1
+    assert decode_surface_patch_payload(ruled_payload).stable_identity == ruled.stable_identity
+    assert decode_surface_patch_payload(revolution_payload).stable_identity == revolution.stable_identity
 
 
 def test_decode_surface_patch_payload_rejects_invalid_family_dispatch() -> None:
@@ -723,6 +729,25 @@ def test_decode_surface_patch_payload_uses_constructor_validation() -> None:
     payload["geometry"] = geometry
 
     with pytest.raises(ImpressFormatError, match="linearly independent"):
+        decode_surface_patch_payload(payload)
+
+
+@pytest.mark.parametrize("mutation, message", [
+    (lambda geometry: geometry.pop("payload_version"), "payload_version"),
+    (lambda geometry: geometry.update({"payload_version": 2}), "payload_version"),
+    (lambda geometry: geometry.update({"mesh": {"vertices": []}}), "Unsupported PlanarSurfacePatch geometry fields"),
+])
+def test_decode_analytic_surface_patch_payload_rejects_unversioned_or_unknown_geometry(
+    mutation,
+    message: str,
+) -> None:
+    patch = PlanarSurfacePatch(family="planar")
+    payload = encode_surface_patch_payload(patch)
+    geometry = dict(payload["geometry"])  # type: ignore[arg-type]
+    mutation(geometry)
+    payload["geometry"] = geometry
+
+    with pytest.raises(ImpressFormatError, match=message):
         decode_surface_patch_payload(payload)
 
 


### PR DESCRIPTION
## Summary
- add typed version fields to planar, ruled, and revolution .impress geometry payloads
- reject missing, future, or unknown analytic geometry fields during decode
- add focused .impress round-trip and refusal coverage for analytic patch payloads

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_impress_io.py -q
- .venv/bin/python -m py_compile src/impression/io/impress.py tests/test_impress_io.py