### PR TITLE
Implement .impress sweep patch payload

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -369,7 +369,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 153: Family-Aware Boolean Eligibility And Diagnostics (v1.0)](../specifications/surface-153-family-aware-boolean-eligibility-and-diagnostics-v1_0.md)
 - [x] [Surface Spec 154: .impress Analytic Patch Payloads (v1.0)](../specifications/surface-154-impress-analytic-patch-payloads-v1_0.md)
 - [x] [Surface Spec 155: .impress Spline Patch Payloads (v1.0)](../specifications/surface-155-impress-spline-patch-payloads-v1_0.md)
-- [ ] [Surface Spec 156: .impress Sweep Patch Payload (v1.0)](../specifications/surface-156-impress-sweep-patch-payload-v1_0.md)
+- [x] [Surface Spec 156: .impress Sweep Patch Payload (v1.0)](../specifications/surface-156-impress-sweep-patch-payload-v1_0.md)
 - [ ] [Surface Spec 157: .impress Subdivision Patch Payload (v1.0)](../specifications/surface-157-impress-subdivision-patch-payload-v1_0.md)
 - [ ] [Surface Spec 158: .impress Implicit Patch Payload Security (v1.0)](../specifications/surface-158-impress-implicit-patch-payload-security-v1_0.md)
 

--- a/src/impression/io/impress.py
+++ b/src/impression/io/impress.py
@@ -9,6 +9,7 @@ from typing import Mapping, Sequence
 
 import numpy as np
 
+from impression.modeling.path3d import Path3D
 from impression.modeling.surface import (
     BSplineSurfacePatch,
     NURBSSurfacePatch,
@@ -16,6 +17,7 @@ from impression.modeling.surface import (
     PlanarSurfacePatch,
     RevolutionSurfacePatch,
     RuledSurfacePatch,
+    SweepSurfacePatch,
     SurfaceAdjacencyRecord,
     SurfaceBoundaryRef,
     SurfaceBody,
@@ -35,9 +37,11 @@ _PATCH_KIND_FAMILIES = {
     "RevolutionSurfacePatch": "revolution",
     "BSplineSurfacePatch": "bspline",
     "NURBSSurfacePatch": "nurbs",
+    "SweepSurfacePatch": "sweep",
 }
 _ANALYTIC_PATCH_PAYLOAD_VERSION = 1
 _SPLINE_PATCH_PAYLOAD_VERSION = 1
+_SWEEP_PATCH_PAYLOAD_VERSION = 1
 
 
 class ImpressFormatError(ValueError):
@@ -779,6 +783,28 @@ def decode_surface_patch_payload(payload: Mapping[str, object]) -> SurfacePatch:
                 control_net=_validate_control_net3_payload(geometry.get("control_net"), "control_net"),
                 weights=_validate_weight_net_payload(geometry.get("weights"), "weights"),
             )
+        if kind == "SweepSurfacePatch":
+            _validate_patch_geometry_fields(
+                geometry,
+                kind=kind,
+                allowed_fields={
+                    "payload_version",
+                    "profile_points_uv",
+                    "path_points",
+                    "frame_policy",
+                    "profile_reference",
+                    "path_reference",
+                },
+                expected_payload_version=_SWEEP_PATCH_PAYLOAD_VERSION,
+            )
+            return SweepSurfacePatch(
+                **common,
+                profile_points_uv=_validate_profile_points2_payload(geometry.get("profile_points_uv"), "profile_points_uv"),
+                path=Path3D.from_points(_validate_points3_payload(geometry.get("path_points"), "path_points")),
+                frame_policy=_validate_string_payload(geometry.get("frame_policy"), "frame_policy"),
+                profile_reference=_validate_optional_string_payload(geometry.get("profile_reference"), "profile_reference"),
+                path_reference=_validate_optional_string_payload(geometry.get("path_reference"), "path_reference"),
+            )
     except (TypeError, ValueError) as exc:
         raise ImpressFormatError(str(exc)) from exc
     raise ImpressFormatError(f"Unsupported SurfacePatch kind {kind!r}.")
@@ -1024,6 +1050,15 @@ def _encode_patch_geometry_payload(patch: SurfacePatch) -> dict[str, object]:
             "control_net": _array_payload(geometry["control_net"]),
             "weights": _array_payload(geometry["weights"]),
         }
+    if isinstance(patch, SweepSurfacePatch):
+        return {
+            "payload_version": _SWEEP_PATCH_PAYLOAD_VERSION,
+            "profile_points_uv": _array_payload(geometry["profile_points_uv"]),
+            "path_points": _array_payload(geometry["path_points"]),
+            "frame_policy": str(geometry["frame_policy"]),
+            "profile_reference": geometry["profile_reference"],
+            "path_reference": geometry["path_reference"],
+        }
     raise ImpressFormatError(f"Unsupported SurfacePatch kind {type(patch).__name__!r}.")
 
 
@@ -1140,6 +1175,18 @@ def _validate_points2_payload(payload: object, name: str) -> np.ndarray:
     return points
 
 
+def _validate_profile_points2_payload(payload: object, name: str) -> np.ndarray:
+    try:
+        points = np.asarray(payload, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must be a numeric 2D point array.") from exc
+    if points.ndim != 2 or points.shape[1] != 2 or points.shape[0] < 2:
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must contain at least two 2D points.")
+    if not np.all(np.isfinite(points)):
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must contain only finite values.")
+    return points
+
+
 def _validate_float_payload(payload: object, name: str) -> float:
     try:
         value = float(payload)
@@ -1157,6 +1204,18 @@ def _validate_float_tuple_payload(payload: object, name: str) -> tuple[float, ..
     if not values:
         raise ImpressFormatError(f"SurfacePatch geometry {name} must not be empty.")
     return values
+
+
+def _validate_string_payload(payload: object, name: str) -> str:
+    if not isinstance(payload, str) or not payload.strip():
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must be a non-empty string.")
+    return payload
+
+
+def _validate_optional_string_payload(payload: object, name: str) -> str | None:
+    if payload is None:
+        return None
+    return _validate_string_payload(payload, name)
 
 
 def validate_impress_document_root(root: Mapping[str, object]) -> ImpressDocumentRoot:

--- a/tests/test_impress_io.py
+++ b/tests/test_impress_io.py
@@ -44,6 +44,7 @@ from impression.io import (
     write_impress_json,
 )
 import numpy as np
+from impression.modeling.path3d import Path3D
 from impression.modeling.surface import (
     BSplineSurfacePatch,
     NURBSSurfacePatch,
@@ -51,6 +52,7 @@ from impression.modeling.surface import (
     PlanarSurfacePatch,
     RevolutionSurfacePatch,
     RuledSurfacePatch,
+    SweepSurfacePatch,
     SurfaceAdjacencyRecord,
     SurfaceBoundaryRef,
     SurfaceSeam,
@@ -762,6 +764,35 @@ def test_encode_decode_spline_surface_patch_payloads_round_trip() -> None:
     assert decode_surface_patch_payload(nurbs_payload).stable_identity == nurbs.stable_identity
 
 
+def test_encode_decode_sweep_surface_patch_payload_round_trips_profile_path_and_frame() -> None:
+    path = Path3D.from_points([(0.0, 0.0, 0.0), (0.0, 0.5, 1.0), (0.0, 0.0, 2.0)])
+    patch = SweepSurfacePatch(
+        family="sweep",
+        profile_points_uv=[(0.0, 0.0), (0.5, 0.2), (1.0, 0.0)],
+        path=path,
+        frame_policy="fixed",
+        profile_reference="profile:outer",
+        path_reference="path:centerline",
+    )
+
+    payload = encode_surface_patch_payload(patch)
+    decoded = decode_surface_patch_payload(payload)
+
+    assert payload["geometry"] == {
+        "payload_version": 1,
+        "profile_points_uv": patch.profile_points_uv.tolist(),
+        "path_points": path.sample().tolist(),
+        "frame_policy": "fixed",
+        "profile_reference": "profile:outer",
+        "path_reference": "path:centerline",
+    }
+    assert decoded.stable_identity == patch.stable_identity
+    assert isinstance(decoded, SweepSurfacePatch)
+    assert decoded.frame_policy == "fixed"
+    assert decoded.profile_reference == "profile:outer"
+    assert decoded.path_reference == "path:centerline"
+
+
 def test_decode_surface_patch_payload_rejects_invalid_family_dispatch() -> None:
     patch = PlanarSurfacePatch(family="planar")
     payload = encode_surface_patch_payload(patch)
@@ -830,6 +861,29 @@ def test_decode_nurbs_surface_patch_payload_rejects_invalid_weights() -> None:
     payload["geometry"] = geometry
 
     with pytest.raises(ImpressFormatError, match="weights"):
+        decode_surface_patch_payload(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda geometry: geometry.pop("payload_version"), "payload_version"),
+        (lambda geometry: geometry.update({"payload_version": 2}), "payload_version"),
+        (lambda geometry: geometry.update({"mesh": {"vertices": []}}), "Unsupported SweepSurfacePatch geometry fields"),
+        (lambda geometry: geometry.update({"profile_points_uv": [[0.0, 0.0]]}), "profile_points_uv"),
+        (lambda geometry: geometry.update({"path_points": [[0.0, 0.0, 0.0]]}), "path_points"),
+        (lambda geometry: geometry.update({"frame_policy": "magic"}), "frame_policy"),
+        (lambda geometry: geometry.update({"profile_reference": ""}), "profile_reference"),
+    ],
+)
+def test_decode_sweep_surface_patch_payload_rejects_invalid_geometry(mutation, message: str) -> None:
+    patch = SweepSurfacePatch(family="sweep")
+    payload = encode_surface_patch_payload(patch)
+    geometry = dict(payload["geometry"])  # type: ignore[arg-type]
+    mutation(geometry)
+    payload["geometry"] = geometry
+
+    with pytest.raises(ImpressFormatError, match=message):
         decode_surface_patch_payload(payload)
 
 


### PR DESCRIPTION
## Summary
- add .impress family dispatch for SweepSurfacePatch
- encode/decode profile points, sampled path points, frame policy, and optional authored references
- add round-trip and explicit refusal coverage for malformed sweep payloads
- mark Surface Spec 156 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_impress_io.py -q