### PR TITLE
Implement .impress implicit patch security

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -371,7 +371,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 155: .impress Spline Patch Payloads (v1.0)](../specifications/surface-155-impress-spline-patch-payloads-v1_0.md)
 - [x] [Surface Spec 156: .impress Sweep Patch Payload (v1.0)](../specifications/surface-156-impress-sweep-patch-payload-v1_0.md)
 - [x] [Surface Spec 157: .impress Subdivision Patch Payload (v1.0)](../specifications/surface-157-impress-subdivision-patch-payload-v1_0.md)
-- [ ] [Surface Spec 158: .impress Implicit Patch Payload Security (v1.0)](../specifications/surface-158-impress-implicit-patch-payload-security-v1_0.md)
+- [x] [Surface Spec 158: .impress Implicit Patch Payload Security (v1.0)](../specifications/surface-158-impress-implicit-patch-payload-security-v1_0.md)
 
 ### Mesh Execution Tessellation Boundary Architecture
 - [ ] [Surface Spec 159: Mesh Execution Inventory And Classification (v1.0)](../specifications/surface-159-mesh-execution-inventory-and-classification-v1_0.md)

--- a/src/impression/io/impress.py
+++ b/src/impression/io/impress.py
@@ -12,6 +12,8 @@ import numpy as np
 from impression.modeling.path3d import Path3D
 from impression.modeling.surface import (
     BSplineSurfacePatch,
+    ImplicitFieldNode,
+    ImplicitSurfacePatch,
     NURBSSurfacePatch,
     ParameterDomain,
     PlanarSurfacePatch,
@@ -41,11 +43,13 @@ _PATCH_KIND_FAMILIES = {
     "NURBSSurfacePatch": "nurbs",
     "SweepSurfacePatch": "sweep",
     "SubdivisionSurfacePatch": "subdivision",
+    "ImplicitSurfacePatch": "implicit",
 }
 _ANALYTIC_PATCH_PAYLOAD_VERSION = 1
 _SPLINE_PATCH_PAYLOAD_VERSION = 1
 _SWEEP_PATCH_PAYLOAD_VERSION = 1
 _SUBDIVISION_PATCH_PAYLOAD_VERSION = 1
+_IMPLICIT_PATCH_PAYLOAD_VERSION = 1
 
 
 class ImpressFormatError(ValueError):
@@ -834,6 +838,18 @@ def decode_surface_patch_payload(payload: Mapping[str, object]) -> SurfacePatch:
                 faces=_validate_subdivision_faces_payload(geometry.get("faces"), "faces"),
                 creases=tuple(_decode_subdivision_crease_payload(crease) for crease in _validate_array_payload(geometry.get("creases"), "creases")),
             )
+        if kind == "ImplicitSurfacePatch":
+            _validate_patch_geometry_fields(
+                geometry,
+                kind=kind,
+                allowed_fields={"payload_version", "field", "bounds"},
+                expected_payload_version=_IMPLICIT_PATCH_PAYLOAD_VERSION,
+            )
+            return ImplicitSurfacePatch(
+                **common,
+                field=_decode_implicit_field_node_payload(geometry.get("field")),
+                bounds=_validate_bounds3_payload(geometry.get("bounds"), "bounds"),
+            )
     except (TypeError, ValueError) as exc:
         raise ImpressFormatError(str(exc)) from exc
     raise ImpressFormatError(f"Unsupported SurfacePatch kind {kind!r}.")
@@ -1103,6 +1119,12 @@ def _encode_patch_geometry_payload(patch: SurfacePatch) -> dict[str, object]:
                 for crease in geometry["creases"]
             ],
         }
+    if isinstance(patch, ImplicitSurfacePatch):
+        return {
+            "payload_version": _IMPLICIT_PATCH_PAYLOAD_VERSION,
+            "field": geometry["field"],
+            "bounds": _array_payload(geometry["bounds"]),
+        }
     raise ImpressFormatError(f"Unsupported SurfacePatch kind {type(patch).__name__!r}.")
 
 
@@ -1145,6 +1167,16 @@ def _validate_range_payload(payload: object, name: str) -> tuple[float, float]:
     if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)) or len(payload) != 2:
         raise ImpressFormatError(f"SurfacePatch domain {name} must be a two-value numeric array.")
     return (_validate_float_payload(payload[0], f"{name}[0]"), _validate_float_payload(payload[1], f"{name}[1]"))
+
+
+def _validate_bounds3_payload(payload: object, name: str) -> tuple[float, float, float, float, float, float]:
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes)) or len(payload) != 6:
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must be a six-value numeric bounds array.")
+    bounds = tuple(_validate_float_payload(value, f"{name}[]") for value in payload)
+    xmin, xmax, ymin, ymax, zmin, zmax = bounds
+    if xmax <= xmin or ymax <= ymin or zmax <= zmin:
+        raise ImpressFormatError(f"SurfacePatch geometry {name} must have positive span on every axis.")
+    return bounds
 
 
 def _validate_nonnegative_int_payload(payload: object, name: str) -> int:
@@ -1315,6 +1347,31 @@ def _decode_subdivision_crease_payload(payload: object) -> SubdivisionCrease:
         return SubdivisionCrease(
             edge=(edge[0], edge[1]),
             sharpness=_validate_float_payload(payload.get("sharpness", 1.0), "crease.sharpness"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ImpressFormatError(str(exc)) from exc
+
+
+def _decode_implicit_field_node_payload(payload: object) -> ImplicitFieldNode:
+    if not isinstance(payload, Mapping):
+        raise ImpressFormatError("Implicit field payload must be an object.")
+    unknown_keys = set(payload) - {"kind", "parameters", "children"}
+    if unknown_keys:
+        keys = ", ".join(sorted(str(key) for key in unknown_keys))
+        raise ImpressFormatError(f"Unsupported implicit field node fields: {keys}.")
+    kind = payload.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        raise ImpressFormatError("Implicit field node kind must be a non-empty string.")
+    parameters = payload.get("parameters", {})
+    if not isinstance(parameters, Mapping):
+        raise ImpressFormatError("Implicit field node parameters must be an object.")
+    children_payload = payload.get("children", [])
+    children = _validate_array_payload(children_payload, "field.children")
+    try:
+        return ImplicitFieldNode(
+            kind=kind,
+            parameters=dict(parameters),
+            children=tuple(_decode_implicit_field_node_payload(child) for child in children),
         )
     except (TypeError, ValueError) as exc:
         raise ImpressFormatError(str(exc)) from exc

--- a/tests/test_impress_io.py
+++ b/tests/test_impress_io.py
@@ -47,6 +47,7 @@ import numpy as np
 from impression.modeling.path3d import Path3D
 from impression.modeling.surface import (
     BSplineSurfacePatch,
+    ImplicitSurfacePatch,
     NURBSSurfacePatch,
     ParameterDomain,
     PlanarSurfacePatch,
@@ -61,6 +62,7 @@ from impression.modeling.surface import (
     TrimLoop,
     make_surface_body,
     make_surface_shell,
+    make_implicit_field_node,
 )
 
 
@@ -382,7 +384,7 @@ def test_impress_acceptance_round_trip_preserves_identity_and_metadata(tmp_path)
             lambda payload: payload["patches"].update(  # type: ignore[index,union-attr]
                 {
                     "implicit-patch": {
-                        "kind": "ImplicitFieldSurfacePatch",
+                        "kind": "ImplicitSurfacePatch",
                         "family": "implicit",
                         "domain": {"u_range": [0.0, 1.0], "v_range": [0.0, 1.0], "normalized": True},
                         "capability_flags": [],
@@ -393,7 +395,7 @@ def test_impress_acceptance_round_trip_preserves_identity_and_metadata(tmp_path)
                     }
                 }
             ),
-            "Unsupported SurfacePatch kind",
+            "Unsupported ImplicitSurfacePatch geometry fields",
         ),
         (
             lambda payload: payload["body_store"]["bodies"][0].update({"stable_identity": "not-the-body"}),  # type: ignore[index,union-attr]
@@ -826,6 +828,33 @@ def test_encode_decode_subdivision_surface_patch_payload_round_trips_cage_crease
     assert decoded.creases == (SubdivisionCrease((0, 1), sharpness=2.5),)
 
 
+def test_encode_decode_implicit_surface_patch_payload_round_trips_safe_field_tree() -> None:
+    field = make_implicit_field_node(
+        "union",
+        children=(
+            make_implicit_field_node("sphere", parameters={"center": (0.0, 0.0, 0.0), "radius": 0.75}),
+            make_implicit_field_node("box", parameters={"center": (0.5, 0.0, 0.0), "half_extents": (0.25, 0.5, 0.5)}),
+        ),
+    )
+    patch = ImplicitSurfacePatch(
+        family="implicit",
+        field=field,
+        bounds=(-1.0, 1.0, -1.5, 1.5, -2.0, 2.0),
+    )
+
+    payload = encode_surface_patch_payload(patch)
+    decoded = decode_surface_patch_payload(payload)
+
+    assert payload["geometry"] == {
+        "payload_version": 1,
+        "field": field.canonical_payload(),
+        "bounds": [-1.0, 1.0, -1.5, 1.5, -2.0, 2.0],
+    }
+    assert decoded.stable_identity == patch.stable_identity
+    assert isinstance(decoded, ImplicitSurfacePatch)
+    assert decoded.bounds == (-1.0, 1.0, -1.5, 1.5, -2.0, 2.0)
+
+
 def test_decode_surface_patch_payload_rejects_invalid_family_dispatch() -> None:
     patch = PlanarSurfacePatch(family="planar")
     payload = encode_surface_patch_payload(patch)
@@ -937,6 +966,41 @@ def test_decode_sweep_surface_patch_payload_rejects_invalid_geometry(mutation, m
 )
 def test_decode_subdivision_surface_patch_payload_rejects_invalid_geometry(mutation, message: str) -> None:
     patch = SubdivisionSurfacePatch(family="subdivision")
+    payload = encode_surface_patch_payload(patch)
+    geometry = dict(payload["geometry"])  # type: ignore[arg-type]
+    mutation(geometry)
+    payload["geometry"] = geometry
+
+    with pytest.raises(ImpressFormatError, match=message):
+        decode_surface_patch_payload(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda geometry: geometry.pop("payload_version"), "payload_version"),
+        (lambda geometry: geometry.update({"payload_version": 2}), "payload_version"),
+        (lambda geometry: geometry.update({"mesh": {"vertices": []}}), "Unsupported ImplicitSurfacePatch geometry fields"),
+        (lambda geometry: geometry.update({"bounds": [0.0, 0.0, -1.0, 1.0, -1.0, 1.0]}), "positive span"),
+        (lambda geometry: geometry.update({"field": {"kind": "python_eval", "parameters": {}, "children": []}}), "Unsupported implicit field node kind"),
+        (lambda geometry: geometry.update({"field": {"kind": "sphere", "parameters": {"eval": "boom"}, "children": []}}), "Unsafe implicit field payload"),
+        (
+            lambda geometry: geometry.update(
+                {
+                    "field": {
+                        "kind": "sphere",
+                        "parameters": {"label": "__import__('os')"},
+                        "children": [],
+                    }
+                }
+            ),
+            "Unsafe implicit field payload",
+        ),
+        (lambda geometry: geometry.update({"field": {"kind": "sphere", "code": "x"}}), "Unsupported implicit field node fields"),
+    ],
+)
+def test_decode_implicit_surface_patch_payload_rejects_unsafe_or_invalid_geometry(mutation, message: str) -> None:
+    patch = ImplicitSurfacePatch(family="implicit")
     payload = encode_surface_patch_payload(patch)
     geometry = dict(payload["geometry"])  # type: ignore[arg-type]
     mutation(geometry)


### PR DESCRIPTION
## Summary
- add .impress family dispatch for ImplicitSurfacePatch
- encode/decode declarative implicit field payloads and bounded implicit domains
- reject executable-shaped parameters, unknown field nodes, unknown payload fields, and invalid bounds
- mark Surface Spec 158 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_impress_io.py -q