### PR TITLE
Promote planar primitives to surface defaults

### DIFF
--- a/docs/modeling/primitives.md
+++ b/docs/modeling/primitives.md
@@ -1,6 +1,9 @@
 # Modeling — Primitives
 
-All primitives are exposed from `impression.modeling` and return internal triangle meshes. Import helpers like:
+All primitives are exposed from `impression.modeling`. Surface-first primitives
+return `SurfaceBody` by default as they are migrated; mesh output remains
+available through explicit `backend="mesh"` compatibility routes. Import helpers
+like:
 
 ```python
 from impression.modeling import make_box, make_cylinder, make_ngon, make_polyhedron, make_sphere, make_torus
@@ -8,7 +11,10 @@ from impression.modeling import make_box, make_cylinder, make_ngon, make_polyhed
 
 > Rendering note: the CLI preview (`impression preview`) or `docs/examples/...` scripts can be used to visualize outputs on a desktop environment.
 
-**Color support:** every `make_*` function accepts an optional `color` argument (RGB/RGBA tuple in 0–1 or a hex/common named color string). Colors are stored with the mesh so previews and future exports respect object colors.
+**Color support:** every `make_*` function accepts an optional `color` argument
+(RGB/RGBA tuple in 0-1 or a hex/common named color string). Surface defaults
+store color as consumer metadata; explicit mesh compatibility routes store color
+with the mesh.
 
 - **Example (two colored cubes):** `docs/examples/primitives/color_dual_example.py`
 - **Example (translucent shell):** `docs/examples/primitives/color_transparency_example.py`
@@ -16,6 +22,7 @@ from impression.modeling import make_box, make_cylinder, make_ngon, make_polyhed
 ## Box
 
 - **Function:** `make_box(size=(dx, dy, dz), center=(0, 0, 0))`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Options**
   - `size`: tuple specifying side lengths along X/Y/Z.
   - `center`: world-space center of the box.
@@ -105,6 +112,7 @@ def build():
 ## Prism / Pyramid
 
 - **Function:** `make_prism(base_size=(dx, dy), top_size=None, height=1.0, ...)`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - `top_size=None` → straight prism, `top_size=(0,0)` → pyramid.
 - **Example:** `docs/examples/primitives/prism_example.py`
 - **Preview:** `impression preview docs/examples/primitives/prism_example.py`
@@ -121,6 +129,7 @@ def build():
 ## Polyhedron (Regular Solids)
 
 - **Function:** `make_polyhedron(faces=6, radius=0.5, center=(0,0,0))`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Supported face counts:** 4 (tetrahedron), 6 (hexahedron/cube), 8 (octahedron), 12 (dodecahedron), 20 (icosahedron).
 - **Example:** `docs/examples/primitives/polyhedron_example.py`
 - **Preview:** `impression preview docs/examples/primitives/polyhedron_example.py`

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -375,7 +375,7 @@ Only final leaf specifications appear here.
 
 ### Mesh Execution Tessellation Boundary Architecture
 - [x] [Surface Spec 159: Mesh Execution Inventory And Classification (v1.0)](../specifications/surface-159-mesh-execution-inventory-and-classification-v1_0.md)
-- [ ] [Surface Spec 160: Primitive Surface Defaults: Box, Prism, Polyhedron (v1.0)](../specifications/surface-160-primitive-surface-defaults-box-prism-polyhedron-v1_0.md)
+- [x] [Surface Spec 160: Primitive Surface Defaults: Box, Prism, Polyhedron (v1.0)](../specifications/surface-160-primitive-surface-defaults-box-prism-polyhedron-v1_0.md)
 - [ ] [Surface Spec 161: Primitive Surface Defaults: Cylinder, Cone, Ngon (v1.0)](../specifications/surface-161-primitive-surface-defaults-cylinder-cone-ngon-v1_0.md)
 - [ ] [Surface Spec 162: Primitive Surface Defaults: Sphere And Torus (v1.0)](../specifications/surface-162-primitive-surface-defaults-sphere-and-torus-v1_0.md)
 - [ ] [Surface Spec 163: Primitive Mesh Compatibility API Names (v1.0)](../specifications/surface-163-primitive-mesh-compatibility-api-names-v1_0.md)

--- a/src/impression/modeling/primitives.py
+++ b/src/impression/modeling/primitives.py
@@ -29,7 +29,7 @@ def _surface_metadata(*, color: Sequence[float] | str | None) -> dict[str, objec
 def make_box(
     size: Sequence[float] = (1.0, 1.0, 1.0),
     center: Sequence[float] = (0.0, 0.0, 0.0),
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """Axis-aligned box specified by size (dx, dy, dz) and center."""
@@ -130,7 +130,7 @@ def make_polyhedron(
     faces: int = 6,
     radius: float = 0.5,
     center: Sequence[float] = (0.0, 0.0, 0.0),
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """Regular polyhedron specified by number of faces (4, 6, 8, 12, 20)."""
@@ -170,7 +170,7 @@ def make_nhedron(
     faces: int = 6,
     radius: float = 0.5,
     center: Sequence[float] = (0.0, 0.0, 0.0),
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """Compatibility wrapper for make_polyhedron."""
@@ -297,7 +297,7 @@ def make_prism(
     height: float = 1.0,
     center: Sequence[float] = (0.0, 0.0, 0.0),
     direction: Sequence[float] = (0.0, 0.0, 1.0),
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -162,15 +162,16 @@ def _make_closed_cube_body() -> SurfaceBody:
     return make_surface_body([shell])
 
 
-def test_internal_surface_box_builder_is_closed_and_public_box_stays_mesh() -> None:
+def test_internal_surface_box_builder_is_closed_and_public_box_defaults_surface() -> None:
     surface_box = make_surface_box(size=(2.0, 4.0, 6.0), center=(1.0, 2.0, 3.0))
-    mesh_box = make_box(size=(2.0, 4.0, 6.0), center=(1.0, 2.0, 3.0))
+    public_box = make_box(size=(2.0, 4.0, 6.0), center=(1.0, 2.0, 3.0))
 
     assert isinstance(surface_box, SurfaceBody)
+    assert isinstance(public_box, SurfaceBody)
+    assert public_box.stable_identity == surface_box.stable_identity
     assert surface_box.shell_count == 1
     assert surface_box.patch_count == 6
     assert surface_box.bounds_estimate() == (0.0, 2.0, 0.0, 4.0, 0.0, 6.0)
-    assert mesh_box.n_faces > 0
 
     result = tessellate_surface_body(surface_box, export_tessellation_request())
     assert result.classification == "closed"
@@ -350,11 +351,14 @@ def test_internal_surface_ngon_returns_surface_body_and_public_api_stays_mesh() 
     assert result.mesh.n_faces > 0
 
 
-def test_internal_surface_prism_returns_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_prism_returns_surface_body_and_public_api_defaults_surface() -> None:
     surface_prism = make_surface_prism(base_size=(2.0, 1.0), top_size=(1.0, 0.5), height=2.0)
-    mesh_prism = make_prism(base_size=(2.0, 1.0), top_size=(1.0, 0.5), height=2.0)
+    public_prism = make_prism(base_size=(2.0, 1.0), top_size=(1.0, 0.5), height=2.0)
+    mesh_prism = make_prism(base_size=(2.0, 1.0), top_size=(1.0, 0.5), height=2.0, backend="mesh")
 
     assert isinstance(surface_prism, SurfaceBody)
+    assert isinstance(public_prism, SurfaceBody)
+    assert public_prism.stable_identity == surface_prism.stable_identity
     assert surface_prism.shell_count == 1
     assert surface_prism.patch_count == 6
     assert [patch.family for patch in surface_prism.iter_patches(world=False)].count("ruled") == 4
@@ -442,11 +446,14 @@ def test_internal_surface_sphere_respects_center() -> None:
     assert bounds == (4.0, 6.0, 5.0, 7.0, 6.0, 8.0)
 
 
-def test_internal_surface_polyhedron_returns_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_polyhedron_returns_surface_body_and_public_api_defaults_surface() -> None:
     surface_polyhedron = make_surface_polyhedron(faces=6, radius=1.0)
-    mesh_polyhedron = make_polyhedron(faces=6, radius=1.0)
+    public_polyhedron = make_polyhedron(faces=6, radius=1.0)
+    mesh_polyhedron = make_polyhedron(faces=6, radius=1.0, backend="mesh")
 
     assert isinstance(surface_polyhedron, SurfaceBody)
+    assert isinstance(public_polyhedron, SurfaceBody)
+    assert public_polyhedron.stable_identity == surface_polyhedron.stable_identity
     assert surface_polyhedron.shell_count == 1
     assert surface_polyhedron.patch_count == 6
     assert [patch.family for patch in surface_polyhedron.iter_patches(world=False)].count("planar") == 6
@@ -457,11 +464,14 @@ def test_internal_surface_polyhedron_returns_surface_body_and_public_api_stays_m
     assert result.mesh.n_faces > 0
 
 
-def test_internal_surface_nhedron_wraps_polyhedron_and_public_api_stays_mesh() -> None:
+def test_internal_surface_nhedron_wraps_polyhedron_and_public_api_defaults_surface() -> None:
     surface_nhedron = make_surface_nhedron(faces=8, radius=1.0)
-    mesh_nhedron = make_nhedron(faces=8, radius=1.0)
+    public_nhedron = make_nhedron(faces=8, radius=1.0)
+    mesh_nhedron = make_nhedron(faces=8, radius=1.0, backend="mesh")
 
     assert isinstance(surface_nhedron, SurfaceBody)
+    assert isinstance(public_nhedron, SurfaceBody)
+    assert public_nhedron.stable_identity == surface_nhedron.stable_identity
     assert surface_nhedron.shell_count == 1
     assert surface_nhedron.patch_count == 8
     assert [patch.family for patch in surface_nhedron.iter_patches(world=False)].count("planar") == 8


### PR DESCRIPTION
## Summary
- make make_box, make_prism, make_polyhedron, and make_nhedron return SurfaceBody by default
- preserve explicit backend="mesh" compatibility for those primitives
- update focused tests and primitive docs for the new surface-default behavior
- mark Surface Spec 160 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_surface.py tests/test_mesh_tools.py tests/test_modern_geometry_no_deprecations.py tests/test_mesh_deprecations.py -q