### PR TITLE
Promote axial primitives to surface defaults

### DIFF
--- a/docs/modeling/primitives.md
+++ b/docs/modeling/primitives.md
@@ -41,6 +41,7 @@ def build():
 ## Cylinder
 
 - **Function:** `make_cylinder(radius=0.5, height=1.0, center=(0,0,0), direction=(0,0,1), resolution=128)`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Options**
   - `radius` / `height`
   - `direction`: normalized axis vector.
@@ -96,6 +97,7 @@ def build():
 ## Cone / Circular Frustum
 
 - **Function:** `make_cone(bottom_diameter=1.0, top_diameter=0.0, height=1.0, ...)`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - Supports classic cones (`top_diameter=0`) or truncated frustums.
 - **Example:** `docs/examples/primitives/cone_example.py`
 - **Preview:** `impression preview docs/examples/primitives/cone_example.py`
@@ -146,6 +148,7 @@ def build():
 ## N-gon Prism
 
 - **Function:** `make_ngon(sides=6, radius=0.5, height=1.0, center=(0,0,0), direction=(0,0,1))`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Options**
   - `sides`: number of polygon sides (>= 3).
   - `radius`: distance from center to vertices (circumscribed radius).

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -376,7 +376,7 @@ Only final leaf specifications appear here.
 ### Mesh Execution Tessellation Boundary Architecture
 - [x] [Surface Spec 159: Mesh Execution Inventory And Classification (v1.0)](../specifications/surface-159-mesh-execution-inventory-and-classification-v1_0.md)
 - [x] [Surface Spec 160: Primitive Surface Defaults: Box, Prism, Polyhedron (v1.0)](../specifications/surface-160-primitive-surface-defaults-box-prism-polyhedron-v1_0.md)
-- [ ] [Surface Spec 161: Primitive Surface Defaults: Cylinder, Cone, Ngon (v1.0)](../specifications/surface-161-primitive-surface-defaults-cylinder-cone-ngon-v1_0.md)
+- [x] [Surface Spec 161: Primitive Surface Defaults: Cylinder, Cone, Ngon (v1.0)](../specifications/surface-161-primitive-surface-defaults-cylinder-cone-ngon-v1_0.md)
 - [ ] [Surface Spec 162: Primitive Surface Defaults: Sphere And Torus (v1.0)](../specifications/surface-162-primitive-surface-defaults-sphere-and-torus-v1_0.md)
 - [ ] [Surface Spec 163: Primitive Mesh Compatibility API Names (v1.0)](../specifications/surface-163-primitive-mesh-compatibility-api-names-v1_0.md)
 - [ ] [Surface Spec 164: Primitive Planar And Frustum Helper Quarantine (v1.0)](../specifications/surface-164-primitive-planar-and-frustum-helper-quarantine-v1_0.md)

--- a/src/impression/modeling/primitives.py
+++ b/src/impression/modeling/primitives.py
@@ -53,7 +53,7 @@ def make_cylinder(
     direction: Sequence[float] = (0.0, 0.0, 1.0),
     resolution: int = 128,
     capping: bool = True,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """Right circular cylinder aligned with `direction`."""
@@ -87,7 +87,7 @@ def make_ngon(
     height: float = 1.0,
     center: Sequence[float] = (0.0, 0.0, 0.0),
     direction: Sequence[float] = (0.0, 0.0, 1.0),
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
     *,
     side_length: float | None = None,
@@ -252,7 +252,7 @@ def make_cone(
     center: Sequence[float] = (0.0, 0.0, 0.0),
     direction: Sequence[float] = (0.0, 0.0, 1.0),
     resolution: int = 64,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
     *,
     radius: float | None = None,

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -276,11 +276,14 @@ def test_internal_surface_rotate_extrude_rejects_profiles_that_cross_axis() -> N
         make_surface_rotate_extrude(shape, angle_deg=360.0, segments=24)
 
 
-def test_internal_surface_cylinder_returns_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_cylinder_returns_surface_body_and_public_api_defaults_surface() -> None:
     surface_cylinder = make_surface_cylinder(radius=1.0, height=2.0, resolution=32)
-    mesh_cylinder = make_cylinder(radius=1.0, height=2.0, resolution=32)
+    public_cylinder = make_cylinder(radius=1.0, height=2.0, resolution=32)
+    mesh_cylinder = make_cylinder(radius=1.0, height=2.0, resolution=32, backend="mesh")
 
     assert isinstance(surface_cylinder, SurfaceBody)
+    assert isinstance(public_cylinder, SurfaceBody)
+    assert public_cylinder.stable_identity == surface_cylinder.stable_identity
     assert surface_cylinder.shell_count == 1
     assert surface_cylinder.patch_count == 6
     assert [patch.family for patch in surface_cylinder.iter_patches(world=False)].count("revolution") == 4
@@ -305,11 +308,14 @@ def test_internal_surface_cylinder_uses_attached_transform_for_direction_and_cen
     assert bounds == (4.0, 6.0, 5.0, 7.0, 6.0, 8.0)
 
 
-def test_internal_surface_cone_returns_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_cone_returns_surface_body_and_public_api_defaults_surface() -> None:
     surface_cone = make_surface_cone(bottom_diameter=2.0, top_diameter=0.0, height=2.0, resolution=32)
-    mesh_cone = make_cone(bottom_diameter=2.0, top_diameter=0.0, height=2.0, resolution=32)
+    public_cone = make_cone(bottom_diameter=2.0, top_diameter=0.0, height=2.0, resolution=32)
+    mesh_cone = make_cone(bottom_diameter=2.0, top_diameter=0.0, height=2.0, resolution=32, backend="mesh")
 
     assert isinstance(surface_cone, SurfaceBody)
+    assert isinstance(public_cone, SurfaceBody)
+    assert public_cone.stable_identity == surface_cone.stable_identity
     assert surface_cone.shell_count == 1
     assert surface_cone.patch_count == 5
     assert [patch.family for patch in surface_cone.iter_patches(world=False)].count("revolution") == 4
@@ -335,11 +341,14 @@ def test_internal_surface_cone_uses_attached_transform_for_direction_and_center(
     assert bounds == (4.0, 6.0, 5.0, 7.0, 6.0, 8.0)
 
 
-def test_internal_surface_ngon_returns_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_ngon_returns_surface_body_and_public_api_defaults_surface() -> None:
     surface_ngon = make_surface_ngon(sides=6, radius=1.0, height=2.0)
-    mesh_ngon = make_ngon(sides=6, radius=1.0, height=2.0)
+    public_ngon = make_ngon(sides=6, radius=1.0, height=2.0)
+    mesh_ngon = make_ngon(sides=6, radius=1.0, height=2.0, backend="mesh")
 
     assert isinstance(surface_ngon, SurfaceBody)
+    assert isinstance(public_ngon, SurfaceBody)
+    assert public_ngon.stable_identity == surface_ngon.stable_identity
     assert surface_ngon.shell_count == 1
     assert surface_ngon.patch_count == 8
     assert [patch.family for patch in surface_ngon.iter_patches(world=False)].count("ruled") == 6


### PR DESCRIPTION
## Summary
- make make_cylinder, make_cone, and make_ngon return SurfaceBody by default
- preserve explicit backend="mesh" compatibility for these axial/frustum primitives
- update focused tests and primitive docs for the new surface-default behavior
- mark Surface Spec 161 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_surface.py tests/test_mesh_tools.py tests/test_modern_geometry_no_deprecations.py tests/test_mesh_deprecations.py -q