### PR TITLE
Promote curved primitives to surface defaults

### DIFF
--- a/docs/modeling/primitives.md
+++ b/docs/modeling/primitives.md
@@ -61,6 +61,7 @@ def build():
 ## Sphere
 
 - **Function:** `make_sphere(radius=0.5, center=(0,0,0), theta_resolution=64, phi_resolution=64)`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Options:** radius, center, longitudinal (`theta_resolution`) and latitudinal (`phi_resolution`) segment counts.
 - **Example:** `docs/examples/primitives/sphere_example.py`
 - **Preview:** `impression preview docs/examples/primitives/sphere_example.py`
@@ -77,6 +78,7 @@ def build():
 ## Torus
 
 - **Function:** `make_torus(major_radius=1.0, minor_radius=0.25, center=(0,0,0), direction=(0,0,1), n_theta=64, n_phi=32)`
+- **Default output:** `SurfaceBody`; use `backend="mesh"` for explicit mesh compatibility.
 - **Options**
   - `major_radius`: distance from center to tube centerline.
   - `minor_radius`: tube radius.

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -377,7 +377,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 159: Mesh Execution Inventory And Classification (v1.0)](../specifications/surface-159-mesh-execution-inventory-and-classification-v1_0.md)
 - [x] [Surface Spec 160: Primitive Surface Defaults: Box, Prism, Polyhedron (v1.0)](../specifications/surface-160-primitive-surface-defaults-box-prism-polyhedron-v1_0.md)
 - [x] [Surface Spec 161: Primitive Surface Defaults: Cylinder, Cone, Ngon (v1.0)](../specifications/surface-161-primitive-surface-defaults-cylinder-cone-ngon-v1_0.md)
-- [ ] [Surface Spec 162: Primitive Surface Defaults: Sphere And Torus (v1.0)](../specifications/surface-162-primitive-surface-defaults-sphere-and-torus-v1_0.md)
+- [x] [Surface Spec 162: Primitive Surface Defaults: Sphere And Torus (v1.0)](../specifications/surface-162-primitive-surface-defaults-sphere-and-torus-v1_0.md)
 - [ ] [Surface Spec 163: Primitive Mesh Compatibility API Names (v1.0)](../specifications/surface-163-primitive-mesh-compatibility-api-names-v1_0.md)
 - [ ] [Surface Spec 164: Primitive Planar And Frustum Helper Quarantine (v1.0)](../specifications/surface-164-primitive-planar-and-frustum-helper-quarantine-v1_0.md)
 - [ ] [Surface Spec 165: Primitive Curved Helper Quarantine (v1.0)](../specifications/surface-165-primitive-curved-helper-quarantine-v1_0.md)

--- a/src/impression/modeling/primitives.py
+++ b/src/impression/modeling/primitives.py
@@ -189,7 +189,7 @@ def make_sphere(
     center: Sequence[float] = (0.0, 0.0, 0.0),
     theta_resolution: int = 64,
     phi_resolution: int = 64,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     _ensure_backend(backend)
@@ -217,7 +217,7 @@ def make_torus(
     direction: Sequence[float] = (0.0, 0.0, 1.0),
     n_theta: int = 64,
     n_phi: int = 32,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
     color: Sequence[float] | str | None = None,
 ) -> Mesh | SurfaceBody:
     """Generate a torus (donut) with given major/minor radii."""

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -379,11 +379,14 @@ def test_internal_surface_prism_returns_surface_body_and_public_api_defaults_sur
     assert result.mesh.n_faces > 0
 
 
-def test_internal_surface_torus_returns_closed_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_torus_returns_closed_surface_body_and_public_api_defaults_surface() -> None:
     surface_torus = make_surface_torus(major_radius=2.0, minor_radius=0.5, n_theta=32, n_phi=16)
-    mesh_torus = make_torus(major_radius=2.0, minor_radius=0.5, n_theta=32, n_phi=16)
+    public_torus = make_torus(major_radius=2.0, minor_radius=0.5, n_theta=32, n_phi=16)
+    mesh_torus = make_torus(major_radius=2.0, minor_radius=0.5, n_theta=32, n_phi=16, backend="mesh")
 
     assert isinstance(surface_torus, SurfaceBody)
+    assert isinstance(public_torus, SurfaceBody)
+    assert public_torus.stable_identity == surface_torus.stable_identity
     assert surface_torus.shell_count == 1
     assert surface_torus.patch_count == 1
     assert [patch.family for patch in surface_torus.iter_patches(world=False)] == ["revolution"]
@@ -430,11 +433,14 @@ def test_internal_surface_torus_uses_attached_transform_for_direction_and_center
     assert bounds == (4.5, 5.5, 3.5, 8.5, 4.5, 9.5)
 
 
-def test_internal_surface_sphere_returns_closed_surface_body_and_public_api_stays_mesh() -> None:
+def test_internal_surface_sphere_returns_closed_surface_body_and_public_api_defaults_surface() -> None:
     surface_sphere = make_surface_sphere(radius=1.0, center=(0.0, 0.0, 0.0), theta_resolution=32, phi_resolution=16)
-    mesh_sphere = make_sphere(radius=1.0, center=(0.0, 0.0, 0.0), theta_resolution=32, phi_resolution=16)
+    public_sphere = make_sphere(radius=1.0, center=(0.0, 0.0, 0.0), theta_resolution=32, phi_resolution=16)
+    mesh_sphere = make_sphere(radius=1.0, center=(0.0, 0.0, 0.0), theta_resolution=32, phi_resolution=16, backend="mesh")
 
     assert isinstance(surface_sphere, SurfaceBody)
+    assert isinstance(public_sphere, SurfaceBody)
+    assert public_sphere.stable_identity == surface_sphere.stable_identity
     assert surface_sphere.shell_count == 1
     assert surface_sphere.patch_count == 1
     assert [patch.family for patch in surface_sphere.iter_patches(world=False)] == ["revolution"]


### PR DESCRIPTION
## Summary
- make make_sphere and make_torus return SurfaceBody by default
- preserve explicit backend="mesh" compatibility for curved analytic primitives
- update focused tests and primitive docs for the new surface-default behavior
- mark Surface Spec 162 complete in release progression

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_surface.py tests/test_mesh_tools.py tests/test_modern_geometry_no_deprecations.py tests/test_mesh_deprecations.py -q