### PR TITLE
Quarantine curved mesh primitive helpers

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -380,7 +380,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 162: Primitive Surface Defaults: Sphere And Torus (v1.0)](../specifications/surface-162-primitive-surface-defaults-sphere-and-torus-v1_0.md)
 - [x] [Surface Spec 163: Primitive Mesh Compatibility API Names (v1.0)](../specifications/surface-163-primitive-mesh-compatibility-api-names-v1_0.md)
 - [x] [Surface Spec 164: Primitive Planar And Frustum Helper Quarantine (v1.0)](../specifications/surface-164-primitive-planar-and-frustum-helper-quarantine-v1_0.md)
-- [ ] [Surface Spec 165: Primitive Curved Helper Quarantine (v1.0)](../specifications/surface-165-primitive-curved-helper-quarantine-v1_0.md)
+- [x] [Surface Spec 165: Primitive Curved Helper Quarantine (v1.0)](../specifications/surface-165-primitive-curved-helper-quarantine-v1_0.md)
 - [ ] [Surface Spec 166: Primitive Tessellation Helper Relocation (v1.0)](../specifications/surface-166-primitive-tessellation-helper-relocation-v1_0.md)
 - [ ] [Surface Spec 167: Loft Spec 60 Revision Or Retirement (v1.0)](../specifications/surface-167-loft-spec-60-revision-or-retirement-v1_0.md)
 - [ ] [Surface Spec 168: Loft Mesh Emission Relocation (v1.0)](../specifications/surface-168-loft-mesh-emission-relocation-v1_0.md)

--- a/src/impression/modeling/_legacy_mesh_primitives.py
+++ b/src/impression/modeling/_legacy_mesh_primitives.py
@@ -19,6 +19,8 @@ LEGACY_MESH_PRIMITIVE_HELPERS: tuple[LegacyMeshPrimitiveHelperRecord, ...] = (
     LegacyMeshPrimitiveHelperRecord("_box_mesh", __name__),
     LegacyMeshPrimitiveHelperRecord("_circular_frustum_mesh", __name__),
     LegacyMeshPrimitiveHelperRecord("_rectangular_frustum_mesh", __name__),
+    LegacyMeshPrimitiveHelperRecord("_sphere_mesh", __name__),
+    LegacyMeshPrimitiveHelperRecord("_torus_mesh", __name__),
 )
 
 
@@ -190,3 +192,78 @@ def rectangular_frustum_mesh(
 
     faces_arr = triangulate_faces(faces)
     return Mesh(points, faces_arr)
+
+
+def sphere_mesh(radius: float, theta_resolution: int, phi_resolution: int) -> Mesh:
+    theta_steps = max(int(theta_resolution), 3)
+    phi_points = max(int(phi_resolution), 3)
+
+    points = [
+        (0.0, 0.0, radius),
+        (0.0, 0.0, -radius),
+    ]
+
+    ring_count = phi_points - 2
+    for i in range(1, phi_points - 1):
+        phi = np.pi * i / (phi_points - 1)
+        z = radius * np.cos(phi)
+        ring_radius = radius * np.sin(phi)
+        for j in range(theta_steps):
+            theta = 2 * np.pi * j / theta_steps
+            points.append((ring_radius * np.cos(theta), ring_radius * np.sin(theta), z))
+
+    faces: list[list[int]] = []
+    ring_start = 2
+    if ring_count > 0:
+        for j in range(theta_steps):
+            j_next = (j + 1) % theta_steps
+            faces.append([0, ring_start + j, ring_start + j_next])
+
+        for i in range(ring_count - 1):
+            ring0 = ring_start + i * theta_steps
+            ring1 = ring_start + (i + 1) * theta_steps
+            for j in range(theta_steps):
+                j_next = (j + 1) % theta_steps
+                faces.append([ring0 + j, ring1 + j, ring1 + j_next, ring0 + j_next])
+
+        last_ring = ring_start + (ring_count - 1) * theta_steps
+        for j in range(theta_steps):
+            j_next = (j + 1) % theta_steps
+            faces.append([1, last_ring + j_next, last_ring + j])
+
+    points_arr = np.asarray(points, dtype=float)
+    faces_arr = triangulate_faces(faces)
+    return Mesh(points_arr, faces_arr)
+
+
+def torus_mesh(major_radius: float, minor_radius: float, n_theta: int, n_phi: int) -> Mesh:
+    theta_steps = max(int(n_theta), 3)
+    phi_steps = max(int(n_phi), 3)
+    points = []
+    for i in range(theta_steps):
+        u = 2 * np.pi * i / theta_steps
+        cos_u = np.cos(u)
+        sin_u = np.sin(u)
+        for j in range(phi_steps):
+            v = 2 * np.pi * j / phi_steps
+            cos_v = np.cos(v)
+            sin_v = np.sin(v)
+            radial = major_radius + minor_radius * cos_v
+            points.append((radial * cos_u, radial * sin_u, minor_radius * sin_v))
+
+    faces: list[list[int]] = []
+    for i in range(theta_steps):
+        i_next = (i + 1) % theta_steps
+        for j in range(phi_steps):
+            j_next = (j + 1) % phi_steps
+            idx0 = i * phi_steps + j
+            idx1 = i * phi_steps + j_next
+            idx2 = i_next * phi_steps + j_next
+            idx3 = i_next * phi_steps + j
+            faces.append([idx0, idx1, idx2, idx3])
+
+    points_arr = np.asarray(points, dtype=float)
+    faces_arr = triangulate_faces(faces)
+    if faces_arr.size:
+        faces_arr = faces_arr[:, [0, 2, 1]]
+    return Mesh(points_arr, faces_arr)

--- a/src/impression/modeling/primitives.py
+++ b/src/impression/modeling/primitives.py
@@ -209,7 +209,9 @@ def make_sphere(
             phi_resolution=phi_resolution,
             metadata=_surface_metadata(color=color),
         )
-    mesh = _sphere_mesh(radius, theta_resolution, phi_resolution)
+    from ._legacy_mesh_primitives import sphere_mesh
+
+    mesh = sphere_mesh(radius, theta_resolution, phi_resolution)
     mesh.translate(center, inplace=True)
     if color is not None:
         set_mesh_color(mesh, color)
@@ -243,7 +245,9 @@ def make_torus(
         )
 
     direction = _normalize(direction)
-    base = _torus_mesh(major_radius, minor_radius, n_theta, n_phi)
+    from ._legacy_mesh_primitives import torus_mesh
+
+    base = torus_mesh(major_radius, minor_radius, n_theta, n_phi)
     aligned = _orient_mesh(base, direction)
     aligned.translate(center, inplace=True)
     if color is not None:
@@ -554,81 +558,6 @@ def _orient_mesh(mesh: Mesh, direction: Sequence[float]) -> Mesh:
     rotated = mesh.copy()
     rotated.rotate_vector(axis, angle_deg, point=(0.0, 0.0, 0.0), inplace=True)
     return rotated
-
-
-def _sphere_mesh(radius: float, theta_resolution: int, phi_resolution: int) -> Mesh:
-    theta_steps = max(int(theta_resolution), 3)
-    phi_points = max(int(phi_resolution), 3)
-
-    points = [
-        (0.0, 0.0, radius),
-        (0.0, 0.0, -radius),
-    ]
-
-    ring_count = phi_points - 2
-    for i in range(1, phi_points - 1):
-        phi = np.pi * i / (phi_points - 1)
-        z = radius * np.cos(phi)
-        ring_radius = radius * np.sin(phi)
-        for j in range(theta_steps):
-            theta = 2 * np.pi * j / theta_steps
-            points.append((ring_radius * np.cos(theta), ring_radius * np.sin(theta), z))
-
-    faces: list[list[int]] = []
-    ring_start = 2
-    if ring_count > 0:
-        for j in range(theta_steps):
-            j_next = (j + 1) % theta_steps
-            faces.append([0, ring_start + j, ring_start + j_next])
-
-        for i in range(ring_count - 1):
-            ring0 = ring_start + i * theta_steps
-            ring1 = ring_start + (i + 1) * theta_steps
-            for j in range(theta_steps):
-                j_next = (j + 1) % theta_steps
-                faces.append([ring0 + j, ring1 + j, ring1 + j_next, ring0 + j_next])
-
-        last_ring = ring_start + (ring_count - 1) * theta_steps
-        for j in range(theta_steps):
-            j_next = (j + 1) % theta_steps
-            faces.append([1, last_ring + j_next, last_ring + j])
-
-    points_arr = np.asarray(points, dtype=float)
-    faces_arr = triangulate_faces(faces)
-    return Mesh(points_arr, faces_arr)
-
-
-def _torus_mesh(major_radius: float, minor_radius: float, n_theta: int, n_phi: int) -> Mesh:
-    theta_steps = max(int(n_theta), 3)
-    phi_steps = max(int(n_phi), 3)
-    points = []
-    for i in range(theta_steps):
-        u = 2 * np.pi * i / theta_steps
-        cos_u = np.cos(u)
-        sin_u = np.sin(u)
-        for j in range(phi_steps):
-            v = 2 * np.pi * j / phi_steps
-            cos_v = np.cos(v)
-            sin_v = np.sin(v)
-            radial = major_radius + minor_radius * cos_v
-            points.append((radial * cos_u, radial * sin_u, minor_radius * sin_v))
-
-    faces: list[list[int]] = []
-    for i in range(theta_steps):
-        i_next = (i + 1) % theta_steps
-        for j in range(phi_steps):
-            j_next = (j + 1) % phi_steps
-            idx0 = i * phi_steps + j
-            idx1 = i * phi_steps + j_next
-            idx2 = i_next * phi_steps + j_next
-            idx3 = i_next * phi_steps + j
-            faces.append([idx0, idx1, idx2, idx3])
-
-    points_arr = np.asarray(points, dtype=float)
-    faces_arr = triangulate_faces(faces)
-    if faces_arr.size:
-        faces_arr = faces_arr[:, [0, 2, 1]]
-    return Mesh(points_arr, faces_arr)
 
 
 def _orient_faces_outward(vertices: np.ndarray, faces: np.ndarray) -> np.ndarray:

--- a/tests/test_modern_geometry_no_deprecations.py
+++ b/tests/test_modern_geometry_no_deprecations.py
@@ -64,10 +64,14 @@ def test_planar_and_frustum_mesh_helpers_are_quarantined_outside_primitives(proj
     assert "def _box_mesh" not in primitives_text
     assert "def _circular_frustum_mesh" not in primitives_text
     assert "def _rectangular_frustum_mesh" not in primitives_text
+    assert "def _sphere_mesh" not in primitives_text
+    assert "def _torus_mesh" not in primitives_text
     assert {record.legacy_name for record in LEGACY_MESH_PRIMITIVE_HELPERS} == {
         "_box_mesh",
         "_circular_frustum_mesh",
         "_rectangular_frustum_mesh",
+        "_sphere_mesh",
+        "_torus_mesh",
     }
 
 


### PR DESCRIPTION
## Summary
- move sphere and torus mesh-only helper implementations into the legacy mesh primitive quarantine module
- lazy-load curved mesh helpers only on explicit mesh compatibility paths
- expand static quarantine coverage and mark Surface Spec 165 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_surface.py tests/test_mesh_tools.py tests/test_modern_geometry_no_deprecations.py tests/test_mesh_deprecations.py -q