### PR TITLE
Retire loft mesh executor spec as canonical

### DIFF
--- a/project/release-0.1.0a/architecture/architecture-work-tracker.md
+++ b/project/release-0.1.0a/architecture/architecture-work-tracker.md
@@ -189,7 +189,7 @@ These areas had specs, but the architecture changed enough that at least one
 spec required revision, retirement, or replacement. The required reconciliation
 work now has final specification coverage.
 
-### Loft Mesh Executor Correspondence Consumption
+### Loft Legacy Mesh Debug Correspondence Consumption
 
 - Status: `Spec Revision Promoted`
 - [x] Replacement/reconciliation specification created.
@@ -197,7 +197,7 @@ work now has final specification coverage.
   - [Loft Topology Point Correspondence Architecture](loft-topology-point-correspondence-architecture.md)
   - [Mesh Execution To Tessellation Boundary Architecture](mesh-execution-tessellation-boundary-architecture.md)
 - Current downstream spec:
-  - [Loft Spec 60: Mesh Executor Correspondence Consumption](../specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md)
+  - [Loft Spec 60: Legacy Mesh Debug Correspondence Consumption](../specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md)
 
 Issue:
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -320,7 +320,7 @@ Only final leaf specifications appear here.
 - [x] [Loft Spec 57: Point Lifecycle Event Records (v1.0)](../specifications/loft-57-point-lifecycle-event-records-v1_0.md)
 - [x] [Loft Spec 58: Birth/Death Synthetic Support Resolution (v1.0)](../specifications/loft-58-birth-death-synthetic-support-resolution-v1_0.md)
 - [x] [Loft Spec 59: Correspondence-Preserving Resampling Contract (v1.0)](../specifications/loft-59-correspondence-preserving-resampling-contract-v1_0.md)
-- [x] [Loft Spec 60: Mesh Executor Correspondence Consumption (v1.0)](../specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md)
+- [x] [Loft Spec 60: Legacy Mesh Debug Correspondence Consumption (retired canonical posture)](../specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md)
 - [x] [Loft Spec 61: Surface Executor Correspondence Consumption (v1.0)](../specifications/loft-61-surface-executor-correspondence-consumption-v1_0.md)
 
 ## Polish Specifications
@@ -382,7 +382,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 164: Primitive Planar And Frustum Helper Quarantine (v1.0)](../specifications/surface-164-primitive-planar-and-frustum-helper-quarantine-v1_0.md)
 - [x] [Surface Spec 165: Primitive Curved Helper Quarantine (v1.0)](../specifications/surface-165-primitive-curved-helper-quarantine-v1_0.md)
 - [x] [Surface Spec 166: Primitive Tessellation Helper Relocation (v1.0)](../specifications/surface-166-primitive-tessellation-helper-relocation-v1_0.md)
-- [ ] [Surface Spec 167: Loft Spec 60 Revision Or Retirement (v1.0)](../specifications/surface-167-loft-spec-60-revision-or-retirement-v1_0.md)
+- [x] [Surface Spec 167: Loft Spec 60 Revision Or Retirement (v1.0)](../specifications/surface-167-loft-spec-60-revision-or-retirement-v1_0.md)
 - [ ] [Surface Spec 168: Loft Mesh Emission Relocation (v1.0)](../specifications/surface-168-loft-mesh-emission-relocation-v1_0.md)
 - [ ] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
 - [ ] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)

--- a/project/release-0.1.0a/specifications/README.md
+++ b/project/release-0.1.0a/specifications/README.md
@@ -59,7 +59,7 @@
 - [Loft Spec 57: Point Lifecycle Event Records (v1.0)](loft-57-point-lifecycle-event-records-v1_0.md)
 - [Loft Spec 58: Birth/Death Synthetic Support Resolution (v1.0)](loft-58-birth-death-synthetic-support-resolution-v1_0.md)
 - [Loft Spec 59: Correspondence-Preserving Resampling Contract (v1.0)](loft-59-correspondence-preserving-resampling-contract-v1_0.md)
-- [Loft Spec 60: Mesh Executor Correspondence Consumption (v1.0)](loft-60-mesh-executor-correspondence-consumption-v1_0.md)
+- [Loft Spec 60: Legacy Mesh Debug Correspondence Consumption (retired canonical posture)](loft-60-mesh-executor-correspondence-consumption-v1_0.md)
 - [Loft Spec 61: Surface Executor Correspondence Consumption (v1.0)](loft-61-surface-executor-correspondence-consumption-v1_0.md)
 - [Loft Spec 62: Topology Builder Core API (v1.0)](loft-62-topology-builder-core-api-v1_0.md)
 - [Loft Spec 63: Topology Lifecycle Builder API (v1.0)](loft-63-topology-lifecycle-builder-api-v1_0.md)

--- a/project/release-0.1.0a/specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md
+++ b/project/release-0.1.0a/specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md
@@ -1,62 +1,78 @@
-# Loft Spec 60: Mesh Executor Correspondence Consumption (v1.0)
+# Loft Spec 60: Legacy Mesh Debug Correspondence Consumption (v1.1)
 
 Date: 2026-05-25
-Status: Proposed
-Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Mesh Executor Correspondence Consumption`
+Status: Retired as canonical modeled execution; retained only as legacy/debug
+compatibility guidance.
+Parent: `project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md` / `Legacy Mesh Debug Correspondence Consumption`
+
+Revision note: Surface Spec 167 revised this document after the mesh execution
+tessellation-boundary audit. `LoftPlan -> SurfaceBody` is the canonical modeled
+executor contract. Mesh face emission from loft correspondence is not canonical
+authored geometry; it is allowed only as an explicit legacy compatibility,
+debug, or tessellation-boundary route.
 
 ## Purpose
 
-Update the mesh loft executor so it consumes validated sample correspondence
-records instead of assuming equal sample indices represent the same semantic
-point.
+Document the retired mesh loft executor posture so any remaining explicit
+mesh/debug path consumes validated sample correspondence records instead of
+assuming equal sample indices represent the same semantic point.
 
 ## Scope
 
 Owns:
 
-- Mesh executor validation for sample correspondence records.
-- Mesh face emission from correspondence-aligned samples.
-- Executor diagnostics when correspondence records are missing or inconsistent.
+- Legacy/debug mesh executor validation for sample correspondence records.
+- Explicit mesh/debug face emission from correspondence-aligned samples.
+- Diagnostics when correspondence records are missing or inconsistent.
+- The migration note that this document is not canonical modeled execution.
 
 Does not own:
 
 - Planner resampling and sample allocation.
 - Surface patch construction.
 - Mesh fallback behavior for surface execution.
+- Canonical loft execution; Surface Executor Correspondence Consumption owns
+  the modeled `LoftPlan -> SurfaceBody` contract.
+- Tessellation-boundary mesh generation; Surface Spec 168 owns relocation of
+  remaining mesh emission out of canonical loft execution.
 
 ## Implementation Routing
 
 - Primary modules/files:
-  - `src/impression/modeling/loft.py` - update `loft_execute_plan` and mesh
-    executor helpers.
+  - `src/impression/modeling/loft.py` - legacy/debug mesh helper references
+    only until Surface Spec 168 relocates or retires them.
 - Supporting modules/files:
   - `src/impression/modeling/mesh.py` or current mesh emission owner - read
     existing mesh construction primitives.
 - GUI/QML files, if applicable:
   - not applicable.
 - Reusable library/module files:
-  - `src/impression/modeling/loft.py` - executor consumption path.
+  - `src/impression/modeling/loft.py` - legacy/debug consumption path only.
 - Tests:
   - `tests/test_loft_mesh_executor_correspondence.py` - stable
     correspondence, birth/death supports, and missing-record refusal.
 
 ## Chosen Defaults / Parameters
 
-- Mesh executor requires a validated `ResampledLoopCorrespondence`.
+- Any retained explicit mesh/debug route requires a validated
+  `ResampledLoopCorrespondence`.
 - Equal-length sample arrays without sample records are invalid for new
   topology-correspondence plans.
-- Executor trusts planner validation but performs defensive length and id
+- Legacy/debug emission trusts planner validation but performs defensive length and id
   consistency checks.
 - Missing or mismatched correspondence records refuse execution; they do not
   fall back to index-only matching.
+- Public loft APIs must not silently fall back from surface execution to this
+  mesh/debug path.
 
 ## Data Ownership
 
-- Source of truth: planner owns correspondence truth; mesh executor owns emitted
-  mesh geometry.
-- Read ownership: mesh executor reads immutable resampled correspondence.
-- Write ownership: mesh executor writes mesh vertices/faces and executor
-  diagnostics only.
+- Source of truth: planner owns correspondence truth; surface executor owns
+  canonical modeled loft output.
+- Read ownership: retained mesh/debug emission reads immutable resampled
+  correspondence.
+- Write ownership: retained mesh/debug emission writes mesh vertices/faces and
+  diagnostics only; those meshes are not canonical authored model state.
 - Derived/cache data: mesh geometry derives from sample arrays and records.
 - Privacy/logging constraints: diagnostics may log sample indices, track ids,
   lifecycle event ids, and refusal reason.
@@ -78,17 +94,20 @@ Does not own:
 ## Reuse And Extraction Plan
 
 - Existing code to reuse:
-  - Existing mesh face emission path in `loft_execute_plan`.
+  - Existing mesh face emission path only as legacy/debug compatibility until
+    Surface Spec 168 relocates or retires it.
 - Current reuse readiness:
-  - update existing mesh executor path.
+  - retired from canonical execution; only explicit legacy/debug routes may
+    reuse it.
 - Extraction/wrapping needed:
-  - wrap old index-based emission behind a function that accepts sample
-    correspondence records.
+  - wrap or move old index-based emission behind explicit debug/tessellation
+    boundary functions that accept sample correspondence records.
 - Additions to existing library/modules:
   - `emit_mesh_faces_from_sample_correspondence(...)`
   - `validate_mesh_executor_correspondence_input(...)`
 - New reusable modules to expose:
-  - none.
+  - none from this retired spec; Surface Spec 168 owns any tessellation/debug
+    relocation.
 - One-off code justification, if any:
   - none.
 
@@ -109,7 +128,8 @@ Does not own:
 
 ## Performance Contract
 
-- Mesh emission remains O(s) per loop pair, where `s` is sample count.
+- Retained explicit mesh/debug emission remains O(s) per loop pair, where `s`
+  is sample count.
 - Defensive validation is O(s).
 - No correspondence inference or resampling occurs inside the mesh executor.
 
@@ -119,6 +139,8 @@ Does not own:
 - Sample array length mismatch refuses with `sample_count_mismatch`.
 - Record index mismatch refuses with `sample_record_index_mismatch`.
 - Refusal happens before partial mesh emission.
+- Any surface-executor failure must surface as a surface diagnostic, not a
+  successful mesh result.
 
 ## Test Strategy
 
@@ -137,9 +159,13 @@ Does not own:
 
 ## Acceptance Criteria
 
-- Mesh loft execution consumes explicit sample correspondence records.
+- This document is visibly retired as canonical modeled execution.
+- Retained explicit mesh/debug loft emission consumes explicit sample
+  correspondence records.
 - Index-only semantic matching is not used for topology-correspondence plans.
 - Invalid correspondence input refuses with diagnostics before mesh output.
+- Canonical loft execution is documented as `LoftPlan -> SurfaceBody`, with
+  mesh output restricted to legacy/debug/tessellation-boundary routes.
 
 ## Readiness Checklist
 

--- a/tests/test_spec_docs.py
+++ b/tests/test_spec_docs.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+def test_loft_spec_60_is_retired_as_canonical_mesh_execution(project_root) -> None:
+    spec = project_root / "project/release-0.1.0a/specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md"
+    text = spec.read_text()
+    normalized = " ".join(text.split())
+
+    assert "Status: Retired as canonical modeled execution" in text
+    assert "`LoftPlan -> SurfaceBody` is the canonical modeled" in normalized
+    assert "legacy compatibility, debug, or tessellation-boundary" in normalized
+    assert "Status: Proposed" not in text
+    assert "mesh executor owns emitted mesh geometry" not in text


### PR DESCRIPTION
## Summary
- revise Loft Spec 60 as legacy/debug/tessellation-boundary guidance only
- update release indexes and architecture tracker wording to reflect the retired canonical posture
- add a docs regression test for the revised spec language
- mark Surface Spec 167 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_spec_docs.py -q
- ! rg -n "Status: Proposed|mesh executor owns emitted mesh geometry|Mesh Executor Correspondence Consumption" project/release-0.1.0a/specifications/loft-60-mesh-executor-correspondence-consumption-v1_0.md project/release-0.1.0a/specifications/README.md project/release-0.1.0a/planning/progression.md project/release-0.1.0a/architecture/architecture-work-tracker.md