### PR TITLE
Default text APIs to surface bodies

### DIFF
--- a/docs/modeling/text.md
+++ b/docs/modeling/text.md
@@ -1,11 +1,10 @@
 # Modeling - Text
 
-Impression can generate text outlines and turn them into meshes. Under the hood
-the text is converted to 2D profiles and then extruded to 3D.
+Impression can generate text outlines and turn them into surface bodies. Under
+the hood the text is converted to 2D profiles and then extruded to 3D.
 
-The text API also supports a surface-first path with `backend="surface"`, which
-preserves the topology-native outline stage and terminates in surfaced text
-before preview/export tessellation.
+The text API is surface-first by default. Use `backend="mesh"` only for the
+legacy mesh compatibility route.
 
 ```python
 from impression.modeling import make_text, text, text_profiles, text_sections
@@ -19,8 +18,8 @@ from impression.modeling import make_text, text, text_profiles, text_sections
 - glyph outline extraction
 - character/line layout
 - conversion of glyph commands into authored `Path2D` values
-- text-local extrusion assembly for mesh output
-- dispatch to the private surfaced linear-extrude builder for surfaced output
+- dispatch to the private surfaced linear-extrude builder for canonical output
+- text-local extrusion assembly for explicit mesh compatibility output
 
 `text.py` does not own:
 
@@ -51,7 +50,7 @@ text can evolve without inheriting public extrude-module coupling.
 - `font`: family name (defaults to `"Arial"`).
 - `font_path`: explicit font file (recommended for reproducible results).
 - `color`: RGB/RGBA tuple or color string (propagates through previews/exports).
-- `backend`: `"mesh"` for legacy mesh-primary output, or `"surface"` for surfaced output.
+- `backend`: `"surface"` by default, or `"mesh"` for legacy mesh compatibility output.
 
 Text uses FontTools to convert glyph outlines into Bezier segments. The helper
 `text_profiles(...)`/`text_sections(...)` return a list of topology-native `Section` values you
@@ -74,7 +73,6 @@ def build():
         center=(0, -0.35, 0),
         color="#7b8aa6",
         font_path="assets/fonts/NotoSansSymbols2-Regular.ttf",
-        backend="surface",
     )
     tagline = text(
         "Parametric playground",

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -384,7 +384,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 166: Primitive Tessellation Helper Relocation (v1.0)](../specifications/surface-166-primitive-tessellation-helper-relocation-v1_0.md)
 - [x] [Surface Spec 167: Loft Spec 60 Revision Or Retirement (v1.0)](../specifications/surface-167-loft-spec-60-revision-or-retirement-v1_0.md)
 - [x] [Surface Spec 168: Loft Mesh Emission Relocation (v1.0)](../specifications/surface-168-loft-mesh-emission-relocation-v1_0.md)
-- [ ] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
+- [x] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
 - [ ] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
 - [ ] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
 - [ ] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)

--- a/src/impression/modeling/drafting.py
+++ b/src/impression/modeling/drafting.py
@@ -371,6 +371,7 @@ def make_dimension(
                 font=font,
                 font_path=font_path,
                 color=color,
+                backend="mesh",
             )
         except FileNotFoundError:
             return meshes

--- a/src/impression/modeling/text.py
+++ b/src/impression/modeling/text.py
@@ -45,7 +45,7 @@ def make_text(
     font: str = "Arial",
     font_path: str | None = None,
     color: Sequence[float] | str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> Mesh | SurfaceBody:
     """Return 3D text built by extruding text profiles."""
 
@@ -124,7 +124,7 @@ def text(
     font: str = "Arial",
     font_path: str | None = None,
     color: Sequence[float] | str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> Mesh | SurfaceBody:
     """Alias for make_text."""
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from impression.modeling import Section, TessellationRequest, make_text, tessellate_surface_body, text_profiles
+from impression.modeling import Section, SurfaceBody, TessellationRequest, make_text, tessellate_surface_body, text, text_profiles
 from tests.text_font_fixtures import require_glyph_capable_font
 
 
@@ -65,7 +65,7 @@ def test_text_profiles_multiline_line_height_changes_vertical_span() -> None:
 
 def test_make_text_mesh_respects_depth_and_direction_axis() -> None:
     font_path = _require_text_font()
-    mesh = make_text("OO", depth=0.2, font_size=1.0, font_path=str(font_path))
+    mesh = make_text("OO", depth=0.2, font_size=1.0, font_path=str(font_path), backend="mesh")
     xmin, xmax, ymin, ymax, zmin, zmax = mesh.bounds
 
     assert np.isclose(zmin, 0.0, atol=1e-9)
@@ -79,6 +79,7 @@ def test_make_text_mesh_respects_depth_and_direction_axis() -> None:
         direction=(1.0, 0.0, 0.0),
         font_size=1.0,
         font_path=str(font_path),
+        backend="mesh",
     )
     xmin, xmax, ymin, ymax, zmin, zmax = oriented.bounds
 
@@ -103,6 +104,19 @@ def test_surface_text_tessellates_to_expected_depth_and_patch_count() -> None:
     assert body.patch_count > 100
     assert np.isclose(zmin, 0.0, atol=1e-9)
     assert np.isclose(zmax - zmin, 0.2, atol=1e-9)
+
+
+def test_make_text_and_text_alias_default_to_surface_body() -> None:
+    font_path = _require_text_font()
+    body = make_text("OO", depth=0.2, font_size=1.0, font_path=str(font_path))
+    alias = text("OO", depth=0.2, font_size=1.0, font_path=str(font_path))
+
+    assert isinstance(body, SurfaceBody)
+    assert isinstance(alias, SurfaceBody)
+    assert body.stable_identity == alias.stable_identity
+    assert body.patch_count > 100
+    mesh = tessellate_surface_body(body, TessellationRequest(intent="preview")).mesh
+    xmin, xmax, ymin, ymax, *_ = mesh.bounds
     assert xmax > xmin
     assert ymax > ymin
     assert mesh.n_faces > 0


### PR DESCRIPTION
## Summary
- make make_text/text default to the surface backend
- preserve explicit mesh compatibility with backend="mesh"
- update drafting mesh-label calls to remain explicit mesh compatibility
- update text docs/tests and mark Surface Spec 169 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_text.py tests/test_surface_replacements.py tests/test_drafting.py tests/test_mesh_deprecations.py -q