### PR TITLE
Add explicit text mesh compatibility helper

### DIFF
--- a/docs/modeling/text.md
+++ b/docs/modeling/text.md
@@ -7,7 +7,7 @@ The text API is surface-first by default. Use `backend="mesh"` only for the
 legacy mesh compatibility route.
 
 ```python
-from impression.modeling import make_text, text, text_profiles, text_sections
+from impression.modeling import make_text, make_text_mesh, text, text_profiles, text_sections
 ```
 
 ## Ownership Boundary
@@ -53,8 +53,10 @@ text can evolve without inheriting public extrude-module coupling.
 - `backend`: `"surface"` by default, or `"mesh"` for legacy mesh compatibility output.
 
 Text uses FontTools to convert glyph outlines into Bezier segments. The helper
+`make_text_mesh(...)` is the explicit legacy mesh compatibility helper.
 `text_profiles(...)`/`text_sections(...)` return a list of topology-native `Section` values you
-can reuse for custom extrusions or lofts.
+can reuse for custom extrusions or lofts. Empty text returns a hidden surfaced
+placeholder by default and an empty mesh through `make_text_mesh(...)`.
 
 Current regression coverage checks more than non-empty output. The text tests
 verify profile alignment/layout, requested extrusion depth, direction-axis

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -385,7 +385,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 167: Loft Spec 60 Revision Or Retirement (v1.0)](../specifications/surface-167-loft-spec-60-revision-or-retirement-v1_0.md)
 - [x] [Surface Spec 168: Loft Mesh Emission Relocation (v1.0)](../specifications/surface-168-loft-mesh-emission-relocation-v1_0.md)
 - [x] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
-- [ ] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
+- [x] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
 - [ ] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
 - [ ] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
 - [ ] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -215,7 +215,15 @@ from .group import MeshGroup, group
 from .ops import offset, hull
 from .heightmap import heightmap, displace_heightmap
 from .drafting import make_line, make_plane, make_arrow, make_dimension
-from .text import make_text, text, text_profiles, text_sections
+from .text import (
+    TextMeshCompatibilityResult,
+    make_text,
+    make_text_mesh,
+    make_text_mesh_result,
+    text,
+    text_profiles,
+    text_sections,
+)
 from .topology import (
     GeneratedRailProvenance,
     Loop,
@@ -568,7 +576,10 @@ __all__ = [
     "make_plane",
     "make_arrow",
     "make_dimension",
+    "TextMeshCompatibilityResult",
     "make_text",
+    "make_text_mesh",
+    "make_text_mesh_result",
     "text",
     "text_profiles",
     "text_sections",

--- a/src/impression/modeling/text.py
+++ b/src/impression/modeling/text.py
@@ -7,6 +7,7 @@ delegated to ``impression.modeling.topology``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Sequence
 from pathlib import Path
 import math
@@ -30,6 +31,21 @@ if TYPE_CHECKING:
     from .surface import SurfaceBody
 
 Backend = Literal["mesh", "surface"]
+
+
+@dataclass(frozen=True)
+class TextMeshCompatibilityResult:
+    mesh: Mesh
+    boundary: str
+    content_length: int
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "boundary": self.boundary,
+            "content_length": self.content_length,
+            "mesh_vertices": self.mesh.n_vertices,
+            "mesh_faces": self.mesh.n_faces,
+        }
 
 
 def make_text(
@@ -73,7 +89,12 @@ def make_text(
 
             return make_surface_box(
                 size=(1e-6, 1e-6, 1e-6),
-                metadata={"consumer": {"hidden_placeholder": True}},
+                metadata={
+                    "consumer": {
+                        "hidden_placeholder": True,
+                        "text_empty_placeholder_policy": "hidden-non-rendering-placeholder",
+                    }
+                },
             )
         bodies = [_surface_text_extrude(section, height=depth) for section in profiles]
         from .surface import make_surface_body
@@ -91,8 +112,16 @@ def make_text(
     )
     meshes = [_mesh_text_extrude(section, height=depth) for section in profiles]
     if not meshes:
-        return Mesh(np.zeros((0, 3), dtype=float), np.zeros((0, 3), dtype=int))
+        return Mesh(
+            np.zeros((0, 3), dtype=float),
+            np.zeros((0, 3), dtype=int),
+            metadata={
+                "text_mesh_boundary": "explicit-mesh-compatibility",
+                "text_empty_placeholder_policy": "empty-mesh",
+            },
+        )
     mesh = combine_meshes(meshes)
+    mesh.metadata.update({"text_mesh_boundary": "explicit-mesh-compatibility"})
 
     direction_vec = _normalize_vec(direction)
     base_vec = np.array([0.0, 0.0, 1.0], dtype=float)
@@ -109,6 +138,74 @@ def make_text(
     if color is not None:
         set_mesh_color(mesh, color)
     return mesh
+
+
+def make_text_mesh(
+    content: str,
+    depth: float = 0.2,
+    center: Sequence[float] = (0.0, 0.0, 0.0),
+    direction: Sequence[float] = (0.0, 0.0, 1.0),
+    font_size: float = 1.0,
+    justify: str = "center",
+    valign: str = "baseline",
+    letter_spacing: float = 0.0,
+    line_height: float = 1.2,
+    font: str = "Arial",
+    font_path: str | None = None,
+    color: Sequence[float] | str | None = None,
+) -> Mesh:
+    """Explicit mesh compatibility helper for text extrusion."""
+
+    return make_text(
+        content=content,
+        depth=depth,
+        center=center,
+        direction=direction,
+        font_size=font_size,
+        justify=justify,
+        valign=valign,
+        letter_spacing=letter_spacing,
+        line_height=line_height,
+        font=font,
+        font_path=font_path,
+        color=color,
+        backend="mesh",
+    )
+
+
+def make_text_mesh_result(
+    content: str,
+    depth: float = 0.2,
+    center: Sequence[float] = (0.0, 0.0, 0.0),
+    direction: Sequence[float] = (0.0, 0.0, 1.0),
+    font_size: float = 1.0,
+    justify: str = "center",
+    valign: str = "baseline",
+    letter_spacing: float = 0.0,
+    line_height: float = 1.2,
+    font: str = "Arial",
+    font_path: str | None = None,
+    color: Sequence[float] | str | None = None,
+) -> TextMeshCompatibilityResult:
+    mesh = make_text_mesh(
+        content=content,
+        depth=depth,
+        center=center,
+        direction=direction,
+        font_size=font_size,
+        justify=justify,
+        valign=valign,
+        letter_spacing=letter_spacing,
+        line_height=line_height,
+        font=font,
+        font_path=font_path,
+        color=color,
+    )
+    return TextMeshCompatibilityResult(
+        mesh=mesh,
+        boundary="explicit-mesh-compatibility",
+        content_length=len(content),
+    )
 
 
 def text(
@@ -522,4 +619,12 @@ def _orient_cap_faces(
     return oriented
 
 
-__all__ = ["make_text", "text", "text_profiles", "text_sections"]
+__all__ = [
+    "TextMeshCompatibilityResult",
+    "make_text",
+    "make_text_mesh",
+    "make_text_mesh_result",
+    "text",
+    "text_profiles",
+    "text_sections",
+]

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -5,7 +5,18 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from impression.modeling import Section, SurfaceBody, TessellationRequest, make_text, tessellate_surface_body, text, text_profiles
+from impression.modeling import (
+    Section,
+    SurfaceBody,
+    TessellationRequest,
+    TextMeshCompatibilityResult,
+    make_text,
+    make_text_mesh,
+    make_text_mesh_result,
+    tessellate_surface_body,
+    text,
+    text_profiles,
+)
 from tests.text_font_fixtures import require_glyph_capable_font
 
 
@@ -65,7 +76,7 @@ def test_text_profiles_multiline_line_height_changes_vertical_span() -> None:
 
 def test_make_text_mesh_respects_depth_and_direction_axis() -> None:
     font_path = _require_text_font()
-    mesh = make_text("OO", depth=0.2, font_size=1.0, font_path=str(font_path), backend="mesh")
+    mesh = make_text_mesh("OO", depth=0.2, font_size=1.0, font_path=str(font_path))
     xmin, xmax, ymin, ymax, zmin, zmax = mesh.bounds
 
     assert np.isclose(zmin, 0.0, atol=1e-9)
@@ -87,6 +98,7 @@ def test_make_text_mesh_respects_depth_and_direction_axis() -> None:
     assert np.isclose(xmax - xmin, 0.2, atol=1e-9)
     assert ymax > ymin
     assert zmax > zmin
+    assert mesh.metadata["text_mesh_boundary"] == "explicit-mesh-compatibility"
 
 
 def test_surface_text_tessellates_to_expected_depth_and_patch_count() -> None:
@@ -120,6 +132,21 @@ def test_make_text_and_text_alias_default_to_surface_body() -> None:
     assert xmax > xmin
     assert ymax > ymin
     assert mesh.n_faces > 0
+
+
+def test_text_mesh_compatibility_result_and_empty_text_policy_are_explicit() -> None:
+    font_path = _require_text_font()
+    result = make_text_mesh_result("OO", depth=0.2, font_size=1.0, font_path=str(font_path))
+    empty_surface = make_text("", depth=0.2, font_size=1.0, font_path=str(font_path))
+    empty_mesh = make_text_mesh("", depth=0.2, font_size=1.0, font_path=str(font_path))
+
+    assert isinstance(result, TextMeshCompatibilityResult)
+    assert result.boundary == "explicit-mesh-compatibility"
+    assert result.mesh.metadata["text_mesh_boundary"] == "explicit-mesh-compatibility"
+    assert empty_surface.consumer_metadata()["hidden_placeholder"] is True
+    assert empty_surface.consumer_metadata()["text_empty_placeholder_policy"] == "hidden-non-rendering-placeholder"
+    assert empty_mesh.n_faces == 0
+    assert empty_mesh.metadata["text_empty_placeholder_policy"] == "empty-mesh"
 
 
 def test_text_profiles_use_distinct_glyph_geometry_for_distinct_letters() -> None:


### PR DESCRIPTION
## Summary
- add make_text_mesh and make_text_mesh_result for explicit mesh compatibility
- annotate text mesh outputs and empty text policies
- export the compatibility result/helper APIs
- update text docs/tests and mark Surface Spec 170 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_text.py tests/test_surface_replacements.py tests/test_drafting.py tests/test_mesh_deprecations.py -q