### PR TITLE
Default drafting APIs to surfaced annotations

### DIFF
--- a/docs/modeling/drafting.md
+++ b/docs/modeling/drafting.md
@@ -6,16 +6,16 @@ Utilities for creating thin 2.5D geometry useful in annotations, callouts, or te
 from impression.modeling.drafting import make_line, make_plane, make_arrow, make_dimension
 ```
 
-The drafting helpers now support a surface-first path via `backend="surface"`.
-That path returns canonical `SurfaceBody` outputs for line/plane/arrow and a
+The drafting helpers are surface-first by default. They return canonical
+`SurfaceBody` outputs for line/plane/arrow and a
 `SurfaceConsumerCollection` for multi-part dimensions, with tessellation only at
-preview/export boundaries.
+preview/export boundaries. Use `backend="mesh"` for explicit mesh compatibility.
 
 ## Lines
 
 ```python
 line = make_line((0, 0, 0), (1, 0.2, 0.5), thickness=0.03, color="#2d7dff")
-surface_line = make_line((0, 0, 0), (1, 0.2, 0.5), thickness=0.03, color="#2d7dff", backend="surface")
+mesh_line = make_line((0, 0, 0), (1, 0.2, 0.5), thickness=0.03, color="#2d7dff", backend="mesh")
 ```
 
 Creates a rectangular rod between two points. Thickness controls cross-section.
@@ -24,7 +24,7 @@ Creates a rectangular rod between two points. Thickness controls cross-section.
 
 ```python
 plane = make_plane(size=(2, 1), center=(0, 0, 0), normal=(0, 1, 0), color=(0.9, 0.9, 0.95, 0.6))
-surface_plane = make_plane(size=(2, 1), center=(0, 0, 0), normal=(0, 1, 0), color=(0.9, 0.9, 0.95, 0.6), backend="surface")
+mesh_plane = make_plane(size=(2, 1), center=(0, 0, 0), normal=(0, 1, 0), color=(0.9, 0.9, 0.95, 0.6), backend="mesh")
 ```
 
 Generates a quad oriented by `normal`, useful for section markers.
@@ -33,19 +33,20 @@ Generates a quad oriented by `normal`, useful for section markers.
 
 ```python
 arrow = make_arrow((0, 0, 0), (0.8, 0.2, 0.3), shaft_diameter=0.03, color="#ffb703")
-surface_arrow = make_arrow((0, 0, 0), (0.8, 0.2, 0.3), shaft_diameter=0.03, color="#ffb703", backend="surface")
+mesh_arrow = make_arrow((0, 0, 0), (0.8, 0.2, 0.3), shaft_diameter=0.03, color="#ffb703", backend="mesh")
 ```
 
 ## Dimensions
 
 ```python
-meshes = make_dimension((0, 0, 0), (1.5, 0, 0), offset=0.15, text="1.50", color="#ff5a36")
-surface_dimension = make_dimension((0, 0, 0), (1.5, 0, 0), offset=0.15, text="1.50", color="#ff5a36", backend="surface")
+surface_dimension = make_dimension((0, 0, 0), (1.5, 0, 0), offset=0.15, text="1.50", color="#ff5a36")
+meshes = make_dimension((0, 0, 0), (1.5, 0, 0), offset=0.15, text="1.50", color="#ff5a36", backend="mesh")
 ```
 
-Returns a list containing the dimension arrow mesh and, when `text` is set, a text label mesh.
-On the surface path, returns a `SurfaceConsumerCollection` preserving the arrow
-body and optional label body as surfaced items.
+Returns a `SurfaceConsumerCollection` preserving the arrow body and optional
+label body as surfaced items. The explicit mesh compatibility route returns a
+list containing the dimension arrow mesh and, when `text` is set, a text label
+mesh.
 
 Optional label controls:
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -386,7 +386,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 168: Loft Mesh Emission Relocation (v1.0)](../specifications/surface-168-loft-mesh-emission-relocation-v1_0.md)
 - [x] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
 - [x] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
-- [ ] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
+- [x] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
 - [ ] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
 - [ ] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)
 - [ ] [Surface Spec 174: Heightmap Displacement Surface Contract (v1.0)](../specifications/surface-174-heightmap-displacement-surface-contract-v1_0.md)

--- a/src/impression/modeling/drafting.py
+++ b/src/impression/modeling/drafting.py
@@ -60,7 +60,7 @@ def make_line(
     end: Sequence[float],
     thickness: float = 0.02,
     color: Sequence[float] | str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> Mesh | SurfaceBody:
     if backend not in {"mesh", "surface"}:
         raise ValueError("backend must be 'mesh' or 'surface'.")
@@ -119,7 +119,7 @@ def make_plane(
     center: Sequence[float] = (0.0, 0.0, 0.0),
     normal: Sequence[float] = (0.0, 0.0, 1.0),
     color: Sequence[float] | str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> Mesh | SurfaceBody:
     if backend not in {"mesh", "surface"}:
         raise ValueError("backend must be 'mesh' or 'surface'.")
@@ -173,7 +173,7 @@ def make_arrow(
     head_length: float = 0.15,
     head_diameter: float = 0.12,
     color: Sequence[float] | str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> Mesh | SurfaceBody:
     if backend not in {"mesh", "surface"}:
         raise ValueError("backend must be 'mesh' or 'surface'.")
@@ -222,7 +222,13 @@ def make_arrow(
     head_length = min(head_length, length * 0.5)
     shaft_length = length - head_length
 
-    shaft = make_line(start, start + direction * (shaft_length / length), thickness=shaft_diameter, color=color)
+    shaft = make_line(
+        start,
+        start + direction * (shaft_length / length),
+        thickness=shaft_diameter,
+        color=color,
+        backend="mesh",
+    )
     head_height = head_length
     base = np.array(
         [
@@ -258,7 +264,7 @@ def make_dimension(
     color: Sequence[float] | str | None = None,
     font: str = "Arial",
     font_path: str | None = None,
-    backend: Backend = "mesh",
+    backend: Backend = "surface",
 ) -> list[Mesh] | SurfaceConsumerCollection:
     if backend not in {"mesh", "surface"}:
         raise ValueError("backend must be 'mesh' or 'surface'.")
@@ -345,7 +351,7 @@ def make_dimension(
     arrow_start = start + offset_vec
     arrow_end = end + offset_vec
 
-    meshes = [make_arrow(arrow_start, arrow_end, color=color)]
+    meshes = [make_arrow(arrow_start, arrow_end, color=color, backend="mesh")]
     if text:
         label_up = np.cross(right, norm_dir)
         up_norm = np.linalg.norm(label_up)

--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -13,7 +13,7 @@ FONT_PATH = (
 
 
 def test_make_dimension_arrow_only_when_text_missing():
-    meshes = make_dimension((0.0, 0.0, 0.0), (2.0, 0.0, 0.0), offset=0.2, text=None)
+    meshes = make_dimension((0.0, 0.0, 0.0), (2.0, 0.0, 0.0), offset=0.2, text=None, backend="mesh")
     assert len(meshes) == 1
     assert meshes[0].n_faces > 0
 
@@ -25,6 +25,7 @@ def test_make_dimension_with_text_label_mesh():
         offset=0.2,
         text="2.00",
         font_path=str(FONT_PATH),
+        backend="mesh",
     )
     assert len(meshes) == 2
     assert meshes[1].n_faces > 0
@@ -37,6 +38,7 @@ def test_make_dimension_missing_font_keeps_arrow():
         offset=0.2,
         text="2.00",
         font_path="does-not-exist.ttf",
+        backend="mesh",
     )
     assert len(meshes) == 1
     assert meshes[0].n_faces > 0

--- a/tests/test_heightmap.py
+++ b/tests/test_heightmap.py
@@ -36,7 +36,7 @@ def test_heightmap_quality_preview(tmp_path: Path):
 
 
 def test_displace_heightmap_planar():
-    mesh = make_plane(size=(1.0, 1.0), center=(0.0, 0.0, 0.0))
+    mesh = make_plane(size=(1.0, 1.0), center=(0.0, 0.0, 0.0), backend="mesh")
     image = np.ones((2, 2), dtype=float)
 
     displaced = displace_heightmap(mesh, image, height=0.5, plane="xy", direction="z")

--- a/tests/test_mesh_deprecations.py
+++ b/tests/test_mesh_deprecations.py
@@ -43,7 +43,7 @@ def _messages_from(callable_obj) -> list[warnings.WarningMessage]:
 
 
 def test_mesh_only_public_apis_warn() -> None:
-    draft_messages = _messages_from(lambda: make_line((0.0, 0.0, 0.0), (1.0, 0.0, 0.0)))
+    draft_messages = _messages_from(lambda: make_line((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), backend="mesh"))
     heightmap_messages = _messages_from(
         lambda: heightmap(np.asarray([[0.0, 1.0], [1.0, 0.0]], dtype=float))
     )

--- a/tests/test_surface_replacements.py
+++ b/tests/test_surface_replacements.py
@@ -30,8 +30,8 @@ TEXT_MODULE = importlib.import_module("impression.modeling.text")
 
 
 def test_surface_plane_and_line_tessellate_non_empty() -> None:
-    plane = make_plane(size=(2.0, 1.0), center=(0.0, 0.0, 0.0), backend="surface")
-    line = make_line((0.0, 0.0, 0.0), (0.0, 0.0, 2.0), thickness=0.1, backend="surface")
+    plane = make_plane(size=(2.0, 1.0), center=(0.0, 0.0, 0.0))
+    line = make_line((0.0, 0.0, 0.0), (0.0, 0.0, 2.0), thickness=0.1)
     assert isinstance(plane, SurfaceBody)
     assert isinstance(line, SurfaceBody)
     assert tessellate_surface_body(plane, TessellationRequest(intent="preview")).mesh.n_faces > 0
@@ -39,7 +39,7 @@ def test_surface_plane_and_line_tessellate_non_empty() -> None:
 
 
 def test_surface_arrow_returns_surface_body() -> None:
-    arrow = make_arrow((0.0, 0.0, 0.0), (1.0, 0.5, 0.0), backend="surface")
+    arrow = make_arrow((0.0, 0.0, 0.0), (1.0, 0.5, 0.0))
     assert isinstance(arrow, SurfaceBody)
     mesh = tessellate_surface_body(arrow, TessellationRequest(intent="preview")).mesh
     assert mesh.n_faces > 0
@@ -52,7 +52,6 @@ def test_surface_dimension_returns_consumer_collection() -> None:
         offset=0.2,
         text="2.00",
         font_path=str(FONT_PATH),
-        backend="surface",
     )
     assert isinstance(result, SurfaceConsumerCollection)
     assert len(result.items) == 2


### PR DESCRIPTION
## Summary
- make line, plane, arrow, and dimension drafting helpers surface-default
- keep recursive/internal mesh compatibility calls explicit
- update drafting docs and tests for explicit mesh compatibility
- mark Surface Spec 171 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_drafting.py tests/test_surface_replacements.py tests/test_mesh_deprecations.py tests/test_heightmap.py -q