### PR TITLE
Add native sampled heightmap surface payload

### DIFF
--- a/docs/modeling/heightmaps.md
+++ b/docs/modeling/heightmaps.md
@@ -8,9 +8,9 @@ color images, and treats `alpha == 0` as masked.
 from impression.modeling import heightmap, displace_heightmap
 ```
 
-Both APIs support `backend="surface"` for a surface-first path. In the current
-build that surfaced result is emitted as a piecewise-planar `SurfaceBody`,
-which keeps the output canonical before preview/export tessellation.
+`heightmap(..., backend="surface")` creates a native sampled heightmap surface
+payload, which keeps the output canonical before preview/export tessellation.
+Mesh output remains available through `backend="mesh"`.
 
 ## heightmap
 
@@ -34,7 +34,7 @@ Options:
 - `xy_scale`: scalar or `(sx, sy)` spacing between pixels.
 - `center`: world‑space center of the heightfield.
 - `alpha_mode`: `"mask"` (holes) or `"ignore"` (transparent pixels become zero height).
-- `backend`: `"mesh"` for legacy mesh-primary output, or `"surface"` for surfaced output.
+- `backend`: `"mesh"` for legacy mesh-primary output, or `"surface"` for sampled surfaced output.
 
 ## displace_heightmap
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -387,7 +387,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 169: Text Surface Default Public API (v1.0)](../specifications/surface-169-text-surface-default-public-api-v1_0.md)
 - [x] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
 - [x] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
-- [ ] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
+- [x] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
 - [ ] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)
 - [ ] [Surface Spec 174: Heightmap Displacement Surface Contract (v1.0)](../specifications/surface-174-heightmap-displacement-surface-contract-v1_0.md)
 - [ ] [Surface Spec 175: Heightmap Projection Sampling Policy (v1.0)](../specifications/surface-175-heightmap-projection-sampling-policy-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -213,7 +213,7 @@ from .csg import (
 from .paths import Path
 from .group import MeshGroup, group
 from .ops import offset, hull
-from .heightmap import heightmap, displace_heightmap
+from .heightmap import heightmap, displace_heightmap, make_heightmap_surface_patch
 from .drafting import make_line, make_plane, make_arrow, make_dimension
 from .text import (
     TextMeshCompatibilityResult,
@@ -270,6 +270,7 @@ from .surface import (
     assess_implicit_field_security,
     evaluate_implicit_field,
     evaluate_implicit_field_domain,
+    HeightmapSurfacePatch,
     PlanarSurfacePatch,
     RuledSurfacePatch,
     RevolutionSurfacePatch,
@@ -572,6 +573,7 @@ __all__ = [
     "hull",
     "heightmap",
     "displace_heightmap",
+    "make_heightmap_surface_patch",
     "make_line",
     "make_plane",
     "make_arrow",
@@ -626,6 +628,7 @@ __all__ = [
     "assess_implicit_field_security",
     "evaluate_implicit_field",
     "evaluate_implicit_field_domain",
+    "HeightmapSurfacePatch",
     "PlanarSurfacePatch",
     "RuledSurfacePatch",
     "RevolutionSurfacePatch",

--- a/src/impression/modeling/heightmap.py
+++ b/src/impression/modeling/heightmap.py
@@ -195,6 +195,47 @@ def _heightmap_mesh_impl(
     return mesh
 
 
+def make_heightmap_surface_patch(
+    image: str | Path | Image.Image | ArrayLike,
+    *,
+    height: float = 1.0,
+    xy_scale: float | Sequence[float] = 1.0,
+    center: Sequence[float] = (0.0, 0.0, 0.0),
+    alpha_mode: str = "mask",
+    quality: MeshQuality | None = None,
+):
+    from .surface import HeightmapSurfacePatch
+
+    heights, mask = _load_heightmap(image)
+    if quality is not None:
+        quality = apply_lod(quality)
+        if quality.lod == "preview":
+            heights = heights[::2, ::2]
+            mask = mask[::2, ::2]
+    if heights.shape[0] < 2 or heights.shape[1] < 2:
+        raise ValueError("Heightmap surface payload requires at least a 2x2 sample grid.")
+    if alpha_mode == "ignore":
+        heights = np.where(mask, heights, 0.0)
+    elif alpha_mode == "mask":
+        heights = np.where(mask, heights, 0.0)
+    else:
+        raise ValueError("alpha_mode must be 'mask' or 'ignore'.")
+    return HeightmapSurfacePatch(
+        family="heightmap",
+        height_samples=heights,
+        xy_scale=_as_scale(xy_scale),
+        center=np.asarray(center, dtype=float).reshape(3),
+        height_scale=float(height),
+        metadata={
+            "kernel": {
+                "producer": "heightmap",
+                "sample_shape": tuple(int(value) for value in heights.shape),
+                "alpha_mode": alpha_mode,
+            }
+        },
+    )
+
+
 def heightmap(
     image: str | Path | Image.Image | ArrayLike,
     height: float = 1.0,
@@ -213,7 +254,7 @@ def heightmap(
     if backend not in {"mesh", "surface"}:
         raise ValueError("backend must be 'mesh' or 'surface'.")
     if backend == "surface":
-        mesh = _heightmap_mesh_impl(
+        patch = make_heightmap_surface_patch(
             image,
             height=height,
             xy_scale=xy_scale,
@@ -221,8 +262,10 @@ def heightmap(
             alpha_mode=alpha_mode,
             quality=quality,
         )
-        return _triangle_surface_body_from_mesh(
-            mesh,
+        from .surface import make_surface_body, make_surface_shell
+
+        return make_surface_body(
+            (make_surface_shell((patch,), connected=False, metadata={"kernel": {"producer": "heightmap"}}),),
             metadata={"kernel": {"producer": "heightmap"}, "consumer": {"source": "heightmap"}},
         )
 
@@ -492,4 +535,4 @@ def _heightmap_cache_key(
     return None
 
 
-__all__ = ["heightmap", "displace_heightmap"]
+__all__ = ["heightmap", "displace_heightmap", "make_heightmap_surface_patch"]

--- a/src/impression/modeling/surface.py
+++ b/src/impression/modeling/surface.py
@@ -30,6 +30,7 @@ SUPPORTED_SURFACE_PATCH_FAMILIES: tuple[str, ...] = (
     "sweep",
     "subdivision",
     "implicit",
+    "heightmap",
 )
 REQUIRED_V1_PATCH_FAMILIES: tuple[str, ...] = ("planar", "ruled", "revolution")
 PATCH_FAMILY_CAPABILITY_MATRIX: dict[str, PatchFamilyCapabilityRecord] = {
@@ -72,6 +73,11 @@ PATCH_FAMILY_CAPABILITY_MATRIX: dict[str, PatchFamilyCapabilityRecord] = {
         family="implicit",
         support_phase="planned",
         operations=("field-node-payload", "validation-security", "evaluation", "tessellation", ".impress"),
+    ),
+    "heightmap": PatchFamilyCapabilityRecord(
+        family="heightmap",
+        support_phase="planned",
+        operations=("sample-grid-payload", "evaluation", "tessellation"),
     ),
 }
 SURFACE_SPEC_66_RETIREMENT_NOTE = (
@@ -809,6 +815,86 @@ class PlanarSurfacePatch(SurfacePatch):
             _transform_vector(self.transform_matrix, self.u_axis),
             _transform_vector(self.transform_matrix, self.v_axis),
         )
+
+
+@dataclass(frozen=True)
+class HeightmapSurfacePatch(SurfacePatch):
+    """Sampled heightfield patch with bilinear evaluation."""
+
+    height_samples: np.ndarray = field(default_factory=lambda: np.zeros((2, 2), dtype=float))
+    xy_scale: tuple[float, float] = (1.0, 1.0)
+    center: np.ndarray = field(default_factory=lambda: np.zeros(3, dtype=float))
+    height_scale: float = 1.0
+
+    def __post_init__(self) -> None:
+        samples = np.asarray(self.height_samples, dtype=float)
+        if samples.ndim != 2:
+            raise ValueError("HeightmapSurfacePatch.height_samples must be a 2D array.")
+        if samples.shape[0] < 2 or samples.shape[1] < 2:
+            raise ValueError("HeightmapSurfacePatch.height_samples must be at least 2x2.")
+        if not np.all(np.isfinite(samples)):
+            raise ValueError("HeightmapSurfacePatch.height_samples must be finite.")
+        xy_scale = tuple(float(value) for value in self.xy_scale)
+        if len(xy_scale) != 2 or xy_scale[0] <= 0.0 or xy_scale[1] <= 0.0:
+            raise ValueError("HeightmapSurfacePatch.xy_scale must contain two positive values.")
+        center = _as_vec3(self.center, name="center")
+        height_scale = float(self.height_scale)
+        if not np.isfinite(height_scale):
+            raise ValueError("HeightmapSurfacePatch.height_scale must be finite.")
+        domain = ParameterDomain((0.0, float(samples.shape[1] - 1)), (0.0, float(samples.shape[0] - 1)))
+        object.__setattr__(self, "height_samples", samples)
+        object.__setattr__(self, "xy_scale", xy_scale)
+        object.__setattr__(self, "center", center)
+        object.__setattr__(self, "height_scale", height_scale)
+        object.__setattr__(self, "domain", domain)
+        object.__setattr__(self, "family", "heightmap")
+        super().__post_init__()
+
+    def _height_at(self, u: float, v: float) -> float:
+        rows, cols = self.height_samples.shape
+        u_clamped = float(np.clip(u, 0.0, cols - 1))
+        v_clamped = float(np.clip(v, 0.0, rows - 1))
+        c0 = int(np.floor(u_clamped))
+        r0 = int(np.floor(v_clamped))
+        c1 = min(c0 + 1, cols - 1)
+        r1 = min(r0 + 1, rows - 1)
+        du = u_clamped - c0
+        dv = v_clamped - r0
+        h00 = self.height_samples[r0, c0]
+        h10 = self.height_samples[r0, c1]
+        h01 = self.height_samples[r1, c0]
+        h11 = self.height_samples[r1, c1]
+        h0 = h00 * (1.0 - du) + h10 * du
+        h1 = h01 * (1.0 - du) + h11 * du
+        return float((h0 * (1.0 - dv) + h1 * dv) * self.height_scale)
+
+    def geometry_payload(self) -> dict[str, object]:
+        return {
+            "height_samples": self.height_samples,
+            "xy_scale": self.xy_scale,
+            "center": self.center,
+            "height_scale": self.height_scale,
+        }
+
+    def point_at(self, u: float, v: float) -> np.ndarray:
+        self.validate_parameters(u, v)
+        rows, cols = self.height_samples.shape
+        sx, sy = self.xy_scale
+        x = (float(u) - (cols - 1) / 2.0) * sx + self.center[0]
+        y = ((rows - 1 - float(v)) - (rows - 1) / 2.0) * sy + self.center[1]
+        z = self.center[2] + self._height_at(float(u), float(v))
+        return _transform_point(self.transform_matrix, np.array([x, y, z], dtype=float))
+
+    def derivatives_at(self, u: float, v: float) -> tuple[np.ndarray, np.ndarray]:
+        self.validate_parameters(u, v)
+        epsilon = 1e-4
+        u0 = max(self.domain.u_range[0], float(u) - epsilon)
+        u1 = min(self.domain.u_range[1], float(u) + epsilon)
+        v0 = max(self.domain.v_range[0], float(v) - epsilon)
+        v1 = min(self.domain.v_range[1], float(v) + epsilon)
+        du = (self.point_at(u1, v) - self.point_at(u0, v)) / max(u1 - u0, 1e-9)
+        dv = (self.point_at(u, v1) - self.point_at(u, v0)) / max(v1 - v0, 1e-9)
+        return du, dv
 
 
 @dataclass(frozen=True)
@@ -2540,6 +2626,7 @@ __all__ = [
     "SurfaceSeamValidationResult",
     "SurfacePatch",
     "PlanarSurfacePatch",
+    "HeightmapSurfacePatch",
     "RuledSurfacePatch",
     "RevolutionSurfacePatch",
     "BSplineSurfacePatch",

--- a/src/impression/modeling/tessellation.py
+++ b/src/impression/modeling/tessellation.py
@@ -801,6 +801,7 @@ SURFACE_FAMILY_TESSELLATION_ADAPTERS: dict[str, SurfaceFamilyTessellationAdapter
         supports_seam_boundaries=False,
         approximation_boundary="tessellation",
     ),
+    "heightmap": SurfaceFamilyTessellationAdapter("heightmap", "rectangular-grid"),
 }
 
 _missing_surface_tessellation_adapters = set(SUPPORTED_SURFACE_PATCH_FAMILIES) - set(SURFACE_FAMILY_TESSELLATION_ADAPTERS)

--- a/tests/test_heightmap.py
+++ b/tests/test_heightmap.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 
-from impression.modeling import MeshQuality, heightmap, displace_heightmap
+from impression.modeling import HeightmapSurfacePatch, MeshQuality, heightmap, displace_heightmap, make_heightmap_surface_patch
 from impression.modeling.drafting import make_plane
 
 
@@ -33,6 +33,19 @@ def test_heightmap_quality_preview(tmp_path: Path):
     path = _write_test_image(tmp_path / "mask.png", transparent_corner=False)
     mesh = heightmap(path, height=1.0, alpha_mode="ignore", quality=MeshQuality(lod="preview"))
     assert mesh.n_faces >= 0
+
+
+def test_heightmap_surface_backend_uses_sampled_surface_payload():
+    samples = np.asarray([[0.0, 1.0], [0.5, 0.25]], dtype=float)
+
+    patch = make_heightmap_surface_patch(samples, height=2.0, xy_scale=(2.0, 3.0))
+    body = heightmap(samples, height=2.0, xy_scale=(2.0, 3.0), backend="surface")
+
+    assert isinstance(patch, HeightmapSurfacePatch)
+    assert patch.height_samples.shape == (2, 2)
+    assert patch.point_at(1.0, 0.0)[2] == 2.0
+    assert body.patch_count == 1
+    assert isinstance(body.iter_patches()[0], HeightmapSurfacePatch)
 
 
 def test_displace_heightmap_planar():

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -53,6 +53,7 @@ from impression.modeling import (
     export_tessellation_request,
     flatten_surface_scene,
     handoff_surface_scene,
+    HeightmapSurfacePatch,
     IMPLICIT_FIELD_NODE_KINDS,
     ImplicitApproximationMetadata,
     ImplicitFieldEvaluationDomain,
@@ -1303,6 +1304,10 @@ def test_every_surface_family_tessellates_through_family_adapter_metadata() -> N
         "implicit": ImplicitSurfacePatch(
             family="implicit",
             field=make_implicit_field_node("sphere", parameters={"radius": 0.75}),
+        ),
+        "heightmap": HeightmapSurfacePatch(
+            family="heightmap",
+            height_samples=np.asarray([[0.0, 1.0], [0.5, 0.25]], dtype=float),
         ),
     }
 


### PR DESCRIPTION
## Summary
- add HeightmapSurfacePatch as a sampled heightfield surface family
- route heightmap(..., backend="surface") to the sampled payload instead of triangle mesh wrapping
- register heightmap tessellation and export/public API hooks
- update tests/docs and mark Surface Spec 172 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_heightmap.py tests/test_surface_replacements.py tests/test_surface.py -q