### PR TITLE
Add heightmap alpha mask and cache policy

### DIFF
--- a/docs/modeling/heightmaps.md
+++ b/docs/modeling/heightmaps.md
@@ -33,7 +33,7 @@ Options:
 - `height`: vertical scale applied to grayscale values.
 - `xy_scale`: scalar or `(sx, sy)` spacing between pixels.
 - `center`: world‑space center of the heightfield.
-- `alpha_mode`: `"mask"` (holes) or `"ignore"` (transparent pixels become zero height).
+- `alpha_mode`: `"mask"` keeps alpha as a surface payload mask and removes masked cells during tessellation; `"ignore"` keeps the sampled surface continuous and treats transparent samples as zero height.
 - `backend`: `"mesh"` for legacy mesh-primary output, or `"surface"` for sampled surfaced output.
 
 ## displace_heightmap

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -388,7 +388,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 170: Text Mesh Compatibility And Empty Text Behavior (v1.0)](../specifications/surface-170-text-mesh-compatibility-and-empty-text-behavior-v1_0.md)
 - [x] [Surface Spec 171: Drafting Surface Defaults (v1.0)](../specifications/surface-171-drafting-surface-defaults-v1_0.md)
 - [x] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
-- [ ] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)
+- [x] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)
 - [ ] [Surface Spec 174: Heightmap Displacement Surface Contract (v1.0)](../specifications/surface-174-heightmap-displacement-surface-contract-v1_0.md)
 - [ ] [Surface Spec 175: Heightmap Projection Sampling Policy (v1.0)](../specifications/surface-175-heightmap-projection-sampling-policy-v1_0.md)
 - [ ] [Surface Spec 176: Heightmap Mesh Compatibility And Serialization Guard (v1.0)](../specifications/surface-176-heightmap-mesh-compatibility-and-serialization-guard-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -213,7 +213,15 @@ from .csg import (
 from .paths import Path
 from .group import MeshGroup, group
 from .ops import offset, hull
-from .heightmap import heightmap, displace_heightmap, make_heightmap_surface_patch
+from .heightmap import (
+    HeightmapAlphaMaskPolicy,
+    HeightmapCacheKeyRecord,
+    heightmap,
+    displace_heightmap,
+    heightmap_cache_key_record,
+    make_heightmap_surface_patch,
+    resolve_heightmap_alpha_mask_policy,
+)
 from .drafting import make_line, make_plane, make_arrow, make_dimension
 from .text import (
     TextMeshCompatibilityResult,
@@ -573,7 +581,11 @@ __all__ = [
     "hull",
     "heightmap",
     "displace_heightmap",
+    "HeightmapAlphaMaskPolicy",
+    "HeightmapCacheKeyRecord",
+    "heightmap_cache_key_record",
     "make_heightmap_surface_patch",
+    "resolve_heightmap_alpha_mask_policy",
     "make_line",
     "make_plane",
     "make_arrow",

--- a/src/impression/modeling/heightmap.py
+++ b/src/impression/modeling/heightmap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Sequence
 
@@ -20,6 +21,42 @@ ArrayLike = np.ndarray
 Backend = Literal["mesh", "surface"]
 
 _HEIGHTMAP_CACHE = LRUCache(max_size=32)
+
+
+@dataclass(frozen=True)
+class HeightmapAlphaMaskPolicy:
+    alpha_mode: Literal["mask", "ignore"]
+    masked_sample_count: int
+    total_sample_count: int
+
+    @property
+    def has_masked_samples(self) -> bool:
+        return self.masked_sample_count > 0
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "alpha_mode": self.alpha_mode,
+            "masked_sample_count": self.masked_sample_count,
+            "total_sample_count": self.total_sample_count,
+            "has_masked_samples": self.has_masked_samples,
+        }
+
+
+@dataclass(frozen=True)
+class HeightmapCacheKeyRecord:
+    cache_key: tuple | None
+    reason: str
+
+    @property
+    def cacheable(self) -> bool:
+        return self.cache_key is not None
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "cache_key": self.cache_key,
+            "cacheable": self.cacheable,
+            "reason": self.reason,
+        }
 
 
 def _as_scale(value: float | Sequence[float]) -> tuple[float, float]:
@@ -75,6 +112,39 @@ def _load_heightmap(image: str | Path | Image.Image | ArrayLike) -> tuple[np.nda
     if isinstance(image, np.ndarray):
         return _normalize_image_array(image)
     raise TypeError("heightmap expects a file path, PIL image, or numpy array.")
+
+
+def resolve_heightmap_alpha_mask_policy(
+    mask: np.ndarray,
+    *,
+    alpha_mode: str,
+) -> HeightmapAlphaMaskPolicy:
+    mode = str(alpha_mode).lower()
+    if mode not in {"mask", "ignore"}:
+        raise ValueError("alpha_mode must be 'mask' or 'ignore'.")
+    mask_arr = np.asarray(mask, dtype=bool)
+    return HeightmapAlphaMaskPolicy(
+        alpha_mode=mode,  # type: ignore[arg-type]
+        masked_sample_count=int(np.size(mask_arr) - np.count_nonzero(mask_arr)),
+        total_sample_count=int(np.size(mask_arr)),
+    )
+
+
+def heightmap_cache_key_record(
+    image: str | Path | Image.Image | ArrayLike,
+    height: float,
+    xy_scale: float | Sequence[float],
+    center: Sequence[float],
+    alpha_mode: str,
+    quality: MeshQuality | None,
+) -> HeightmapCacheKeyRecord:
+    cache_key = _heightmap_cache_key(image, height, xy_scale, center, alpha_mode, quality)
+    if cache_key is None:
+        reason = "uncacheable-source"
+        if isinstance(image, (str, Path)):
+            reason = "path-stat-unavailable"
+        return HeightmapCacheKeyRecord(cache_key=None, reason=reason)
+    return HeightmapCacheKeyRecord(cache_key=cache_key, reason="cache-key-valid")
 
 
 def _triangle_surface_body_from_mesh(mesh: Mesh, *, metadata: dict[str, object] | None = None) -> "SurfaceBody":
@@ -143,8 +213,8 @@ def _heightmap_mesh_impl(
     alpha_mode: str,
     quality: MeshQuality | None,
 ) -> Mesh:
-    cache_key = _heightmap_cache_key(image, height, xy_scale, center, alpha_mode, quality)
-    cached = _HEIGHTMAP_CACHE.get(cache_key) if cache_key is not None else None
+    cache_record = heightmap_cache_key_record(image, height, xy_scale, center, alpha_mode, quality)
+    cached = _HEIGHTMAP_CACHE.get(cache_record.cache_key) if cache_record.cache_key is not None else None
     if cached is not None:
         return cached.copy()
 
@@ -190,8 +260,9 @@ def _heightmap_mesh_impl(
 
     faces_arr = np.asarray(faces, dtype=int) if faces else np.zeros((0, 3), dtype=int)
     mesh = Mesh(vertices, faces_arr)
-    if cache_key is not None:
-        _HEIGHTMAP_CACHE.set(cache_key, mesh.copy())
+    mesh.metadata.update({"heightmap_cache_key_policy": cache_record.canonical_payload()})
+    if cache_record.cache_key is not None:
+        _HEIGHTMAP_CACHE.set(cache_record.cache_key, mesh.copy())
     return mesh
 
 
@@ -214,6 +285,8 @@ def make_heightmap_surface_patch(
             mask = mask[::2, ::2]
     if heights.shape[0] < 2 or heights.shape[1] < 2:
         raise ValueError("Heightmap surface payload requires at least a 2x2 sample grid.")
+    alpha_policy = resolve_heightmap_alpha_mask_policy(mask, alpha_mode=alpha_mode)
+    cache_record = heightmap_cache_key_record(image, height, xy_scale, center, alpha_mode, quality)
     if alpha_mode == "ignore":
         heights = np.where(mask, heights, 0.0)
     elif alpha_mode == "mask":
@@ -223,6 +296,8 @@ def make_heightmap_surface_patch(
     return HeightmapSurfacePatch(
         family="heightmap",
         height_samples=heights,
+        alpha_mask=mask,
+        alpha_mode=alpha_policy.alpha_mode,
         xy_scale=_as_scale(xy_scale),
         center=np.asarray(center, dtype=float).reshape(3),
         height_scale=float(height),
@@ -230,7 +305,8 @@ def make_heightmap_surface_patch(
             "kernel": {
                 "producer": "heightmap",
                 "sample_shape": tuple(int(value) for value in heights.shape),
-                "alpha_mode": alpha_mode,
+                "alpha_policy": alpha_policy.canonical_payload(),
+                "cache_key_policy": cache_record.canonical_payload(),
             }
         },
     )
@@ -535,4 +611,12 @@ def _heightmap_cache_key(
     return None
 
 
-__all__ = ["heightmap", "displace_heightmap", "make_heightmap_surface_patch"]
+__all__ = [
+    "HeightmapAlphaMaskPolicy",
+    "HeightmapCacheKeyRecord",
+    "heightmap",
+    "displace_heightmap",
+    "heightmap_cache_key_record",
+    "make_heightmap_surface_patch",
+    "resolve_heightmap_alpha_mask_policy",
+]

--- a/src/impression/modeling/surface.py
+++ b/src/impression/modeling/surface.py
@@ -822,6 +822,8 @@ class HeightmapSurfacePatch(SurfacePatch):
     """Sampled heightfield patch with bilinear evaluation."""
 
     height_samples: np.ndarray = field(default_factory=lambda: np.zeros((2, 2), dtype=float))
+    alpha_mask: np.ndarray = field(default_factory=lambda: np.ones((2, 2), dtype=bool))
+    alpha_mode: Literal["mask", "ignore"] = "mask"
     xy_scale: tuple[float, float] = (1.0, 1.0)
     center: np.ndarray = field(default_factory=lambda: np.zeros(3, dtype=float))
     height_scale: float = 1.0
@@ -834,6 +836,12 @@ class HeightmapSurfacePatch(SurfacePatch):
             raise ValueError("HeightmapSurfacePatch.height_samples must be at least 2x2.")
         if not np.all(np.isfinite(samples)):
             raise ValueError("HeightmapSurfacePatch.height_samples must be finite.")
+        alpha_mask = np.asarray(self.alpha_mask, dtype=bool)
+        if alpha_mask.shape != samples.shape:
+            raise ValueError("HeightmapSurfacePatch.alpha_mask must match height_samples shape.")
+        alpha_mode = str(self.alpha_mode).lower()
+        if alpha_mode not in {"mask", "ignore"}:
+            raise ValueError("HeightmapSurfacePatch.alpha_mode must be 'mask' or 'ignore'.")
         xy_scale = tuple(float(value) for value in self.xy_scale)
         if len(xy_scale) != 2 or xy_scale[0] <= 0.0 or xy_scale[1] <= 0.0:
             raise ValueError("HeightmapSurfacePatch.xy_scale must contain two positive values.")
@@ -843,6 +851,8 @@ class HeightmapSurfacePatch(SurfacePatch):
             raise ValueError("HeightmapSurfacePatch.height_scale must be finite.")
         domain = ParameterDomain((0.0, float(samples.shape[1] - 1)), (0.0, float(samples.shape[0] - 1)))
         object.__setattr__(self, "height_samples", samples)
+        object.__setattr__(self, "alpha_mask", alpha_mask)
+        object.__setattr__(self, "alpha_mode", alpha_mode)
         object.__setattr__(self, "xy_scale", xy_scale)
         object.__setattr__(self, "center", center)
         object.__setattr__(self, "height_scale", height_scale)
@@ -871,6 +881,8 @@ class HeightmapSurfacePatch(SurfacePatch):
     def geometry_payload(self) -> dict[str, object]:
         return {
             "height_samples": self.height_samples,
+            "alpha_mask": self.alpha_mask,
+            "alpha_mode": self.alpha_mode,
             "xy_scale": self.xy_scale,
             "center": self.center,
             "height_scale": self.height_scale,

--- a/src/impression/modeling/tessellation.py
+++ b/src/impression/modeling/tessellation.py
@@ -11,6 +11,7 @@ from ._legacy_mesh_deprecation import warn_mesh_primary_api
 from .surface import (
     ImplicitFieldEvaluationDomain,
     ImplicitSurfacePatch,
+    HeightmapSurfacePatch,
     RevolutionSurfacePatch,
     RuledSurfacePatch,
     SUPPORTED_SURFACE_PATCH_FAMILIES,
@@ -458,6 +459,40 @@ def _rectangular_grid_patch_mesh(patch: SurfacePatch, request: NormalizedTessell
     )
 
 
+def _heightmap_patch_mesh(patch: HeightmapSurfacePatch, request: NormalizedTessellationRequest) -> Mesh:
+    rows, cols = patch.height_samples.shape
+    uv_vertices = np.asarray([(float(c), float(r)) for r in range(rows) for c in range(cols)], dtype=float)
+    vertices = np.asarray([patch.point_at(float(u), float(v)) for u, v in uv_vertices], dtype=float)
+    faces: list[list[int]] = []
+    for r in range(rows - 1):
+        for c in range(cols - 1):
+            if patch.alpha_mode == "mask" and not (
+                patch.alpha_mask[r, c]
+                and patch.alpha_mask[r, c + 1]
+                and patch.alpha_mask[r + 1, c]
+                and patch.alpha_mask[r + 1, c + 1]
+            ):
+                continue
+            i0 = r * cols + c
+            i1 = r * cols + c + 1
+            i2 = (r + 1) * cols + c + 1
+            i3 = (r + 1) * cols + c
+            faces.append([i0, i1, i2])
+            faces.append([i0, i2, i3])
+    mesh = Mesh(
+        vertices=vertices,
+        faces=np.asarray(faces, dtype=int) if faces else np.zeros((0, 3), dtype=int),
+        metadata={
+            "surface_family": patch.family,
+            "surface_patch_id": patch.stable_identity,
+            "heightmap_alpha_mode": patch.alpha_mode,
+            "heightmap_masked_sample_count": int(np.size(patch.alpha_mask) - np.count_nonzero(patch.alpha_mask)),
+            "heightmap_tessellation_request": request.cache_key,
+        },
+    )
+    return mesh
+
+
 def _tessellate_patch_with_family_adapter(
     patch: SurfacePatch,
     request: NormalizedTessellationRequest,
@@ -471,6 +506,8 @@ def _tessellate_patch_with_family_adapter(
         if not isinstance(patch, SubdivisionSurfacePatch):
             raise ValueError("Subdivision tessellation adapter requires a SubdivisionSurfacePatch.")
         mesh = _subdivision_patch_mesh(patch, request)
+    elif isinstance(patch, HeightmapSurfacePatch):
+        mesh = _heightmap_patch_mesh(patch, request)
     elif adapter.sampling_kind == "rectangular-grid":
         mesh = _rectangular_grid_patch_mesh(patch, request)
     else:
@@ -801,7 +838,7 @@ SURFACE_FAMILY_TESSELLATION_ADAPTERS: dict[str, SurfaceFamilyTessellationAdapter
         supports_seam_boundaries=False,
         approximation_boundary="tessellation",
     ),
-    "heightmap": SurfaceFamilyTessellationAdapter("heightmap", "rectangular-grid"),
+    "heightmap": SurfaceFamilyTessellationAdapter("heightmap", "rectangular-grid", supports_seam_boundaries=False),
 }
 
 _missing_surface_tessellation_adapters = set(SUPPORTED_SURFACE_PATCH_FAMILIES) - set(SURFACE_FAMILY_TESSELLATION_ADAPTERS)

--- a/tests/test_heightmap.py
+++ b/tests/test_heightmap.py
@@ -5,7 +5,19 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 
-from impression.modeling import HeightmapSurfacePatch, MeshQuality, heightmap, displace_heightmap, make_heightmap_surface_patch
+from impression.modeling import (
+    HeightmapAlphaMaskPolicy,
+    HeightmapCacheKeyRecord,
+    HeightmapSurfacePatch,
+    MeshQuality,
+    heightmap,
+    displace_heightmap,
+    heightmap_cache_key_record,
+    make_heightmap_surface_patch,
+    resolve_heightmap_alpha_mask_policy,
+    tessellate_surface_body,
+    tessellate_surface_patch,
+)
 from impression.modeling.drafting import make_plane
 
 
@@ -46,6 +58,45 @@ def test_heightmap_surface_backend_uses_sampled_surface_payload():
     assert patch.point_at(1.0, 0.0)[2] == 2.0
     assert body.patch_count == 1
     assert isinstance(body.iter_patches()[0], HeightmapSurfacePatch)
+
+
+def test_heightmap_surface_alpha_policy_and_tessellation_preserve_mask(tmp_path: Path):
+    path = _write_test_image(tmp_path / "mask.png", transparent_corner=True)
+
+    masked_body = heightmap(path, height=1.0, alpha_mode="mask", backend="surface")
+    ignored_body = heightmap(path, height=1.0, alpha_mode="ignore", backend="surface")
+    masked_patch = masked_body.iter_patches()[0]
+    ignored_patch = ignored_body.iter_patches()[0]
+    masked_mesh = tessellate_surface_body(masked_body).mesh
+    ignored_mesh = tessellate_surface_body(ignored_body).mesh
+    ignored_patch_mesh = tessellate_surface_patch(ignored_patch)
+
+    assert isinstance(masked_patch, HeightmapSurfacePatch)
+    assert isinstance(ignored_patch, HeightmapSurfacePatch)
+    assert masked_patch.alpha_mode == "mask"
+    assert ignored_patch.alpha_mode == "ignore"
+    assert masked_patch.kernel_metadata()["alpha_policy"]["masked_sample_count"] == 1
+    assert masked_patch.kernel_metadata()["cache_key_policy"]["cacheable"] is True
+    assert masked_mesh.n_faces == 0
+    assert ignored_mesh.n_faces == 2
+    assert ignored_patch_mesh.metadata["heightmap_alpha_mode"] == "ignore"
+
+
+def test_heightmap_alpha_and_cache_policy_records_are_explicit(tmp_path: Path):
+    path = _write_test_image(tmp_path / "cache.png", transparent_corner=True)
+    mask = np.asarray([[False, True], [True, True]], dtype=bool)
+
+    policy = resolve_heightmap_alpha_mask_policy(mask, alpha_mode="mask")
+    cache_record = heightmap_cache_key_record(path, 1.0, 1.0, (0.0, 0.0, 0.0), "mask", None)
+    array_cache_record = heightmap_cache_key_record(mask.astype(float), 1.0, 1.0, (0.0, 0.0, 0.0), "mask", None)
+
+    assert isinstance(policy, HeightmapAlphaMaskPolicy)
+    assert policy.has_masked_samples is True
+    assert policy.canonical_payload()["masked_sample_count"] == 1
+    assert isinstance(cache_record, HeightmapCacheKeyRecord)
+    assert cache_record.cacheable is True
+    assert array_cache_record.cacheable is False
+    assert array_cache_record.reason == "uncacheable-source"
 
 
 def test_displace_heightmap_planar():


### PR DESCRIPTION
## Summary
- add explicit heightmap alpha mask and cache key policy records
- carry alpha masks in HeightmapSurfacePatch payloads
- tessellate heightmap patches with mask-aware cell removal
- document mask/ignore semantics and mark Surface Spec 173 complete

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_heightmap.py tests/test_surface_replacements.py tests/test_surface.py -q