### PR TITLE
Implement heightmap projection sampling policy

### DIFF
--- a/docs/modeling/heightmaps.md
+++ b/docs/modeling/heightmaps.md
@@ -61,16 +61,17 @@ carved = displace_heightmap(
 Options:
 
 - `projection`: currently only `"planar"` is supported.
-- `plane`: `"xy"` for surface displacement in this build; the mesh compatibility route also accepts `"xz"` and `"yz"`.
+- `plane`: `"xy"`, `"xz"`, or `"yz"` for planar projection sampling on both surface and mesh routes.
 - `direction`: `"normal"`, `"x"`, `"y"`, `"z"`, or a custom vector.
 - `alpha_mode`: `"ignore"` (no displacement where alpha == 0) or `"mask"` (drop faces).
-- `bounds`: optional `(umin, umax, vmin, vmax)` to override projection bounds on the mesh compatibility route.
+- `bounds`: optional `(umin, umax, vmin, vmax)` to override projection bounds. Surface displacement derives bounds from each authored patch corner when omitted and refuses degenerate projected bounds.
 - `backend`: `"mesh"` or `"surface"`.
 
 ## Notes
 
 - Transparency is treated as a mask when `alpha_mode="mask"`.
 - For basic stamping onto objects, planar projection + `direction="normal"` works well.
+- Unsupported projections refuse explicitly; only planar projection is implemented.
 - UV‑based or triplanar projection is not implemented yet.
 
 ## Examples

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -390,7 +390,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 172: Heightmap Sampled Surface Payload (v1.0)](../specifications/surface-172-heightmap-sampled-surface-payload-v1_0.md)
 - [x] [Surface Spec 173: Heightmap Alpha Mask And Cache Policy (v1.0)](../specifications/surface-173-heightmap-alpha-mask-and-cache-policy-v1_0.md)
 - [x] [Surface Spec 174: Heightmap Displacement Surface Contract (v1.0)](../specifications/surface-174-heightmap-displacement-surface-contract-v1_0.md)
-- [ ] [Surface Spec 175: Heightmap Projection Sampling Policy (v1.0)](../specifications/surface-175-heightmap-projection-sampling-policy-v1_0.md)
+- [x] [Surface Spec 175: Heightmap Projection Sampling Policy (v1.0)](../specifications/surface-175-heightmap-projection-sampling-policy-v1_0.md)
 - [ ] [Surface Spec 176: Heightmap Mesh Compatibility And Serialization Guard (v1.0)](../specifications/surface-176-heightmap-mesh-compatibility-and-serialization-guard-v1_0.md)
 - [ ] [Surface Spec 177: Thread Surface Representation Defaults (v1.0)](../specifications/surface-177-thread-surface-representation-defaults-v1_0.md)
 - [ ] [Surface Spec 178: Thread Assembly To SurfaceBody Lowering (v1.0)](../specifications/surface-178-thread-assembly-to-surfacebody-lowering-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -216,10 +216,14 @@ from .ops import offset, hull
 from .heightmap import (
     HeightmapAlphaMaskPolicy,
     HeightmapCacheKeyRecord,
+    HeightmapProjectionBoundsPolicy,
+    HeightmapSampleCoordinateRecord,
     heightmap,
     displace_heightmap,
     heightmap_cache_key_record,
+    heightmap_sample_coordinate_record,
     make_heightmap_surface_patch,
+    resolve_heightmap_projection_bounds_policy,
     resolve_heightmap_alpha_mask_policy,
 )
 from .drafting import make_line, make_plane, make_arrow, make_dimension
@@ -584,8 +588,12 @@ __all__ = [
     "displace_heightmap",
     "HeightmapAlphaMaskPolicy",
     "HeightmapCacheKeyRecord",
+    "HeightmapProjectionBoundsPolicy",
+    "HeightmapSampleCoordinateRecord",
     "heightmap_cache_key_record",
+    "heightmap_sample_coordinate_record",
     "make_heightmap_surface_patch",
+    "resolve_heightmap_projection_bounds_policy",
     "resolve_heightmap_alpha_mask_policy",
     "make_line",
     "make_plane",

--- a/src/impression/modeling/heightmap.py
+++ b/src/impression/modeling/heightmap.py
@@ -59,6 +59,49 @@ class HeightmapCacheKeyRecord:
         }
 
 
+@dataclass(frozen=True)
+class HeightmapProjectionBoundsPolicy:
+    projection: Literal["planar"]
+    plane: Literal["xy", "xz", "yz"]
+    bounds: tuple[float, float, float, float]
+    source: Literal["explicit", "source-bounds"]
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "projection": self.projection,
+            "plane": self.plane,
+            "bounds": self.bounds,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class HeightmapSampleCoordinateRecord:
+    projection: Literal["planar"]
+    plane: Literal["xy", "xz", "yz"]
+    bounds: tuple[float, float, float, float]
+    u: np.ndarray
+    v: np.ndarray
+    u_normalized: np.ndarray
+    v_normalized: np.ndarray
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "projection": self.projection,
+            "plane": self.plane,
+            "bounds": self.bounds,
+            "sample_count": int(np.size(self.u_normalized)),
+            "u_normalized_range": (
+                float(np.min(self.u_normalized)) if self.u_normalized.size else 0.0,
+                float(np.max(self.u_normalized)) if self.u_normalized.size else 0.0,
+            ),
+            "v_normalized_range": (
+                float(np.min(self.v_normalized)) if self.v_normalized.size else 0.0,
+                float(np.max(self.v_normalized)) if self.v_normalized.size else 0.0,
+            ),
+        }
+
+
 def _as_scale(value: float | Sequence[float]) -> tuple[float, float]:
     if isinstance(value, (int, float)):
         return float(value), float(value)
@@ -145,6 +188,95 @@ def heightmap_cache_key_record(
             reason = "path-stat-unavailable"
         return HeightmapCacheKeyRecord(cache_key=None, reason=reason)
     return HeightmapCacheKeyRecord(cache_key=cache_key, reason="cache-key-valid")
+
+
+def _as_planar_projection(projection: str) -> Literal["planar"]:
+    projection_name = str(projection).lower()
+    if projection_name != "planar":
+        raise ValueError("Only planar projection is supported in this build.")
+    return "planar"
+
+
+def _as_projection_plane(plane: str) -> Literal["xy", "xz", "yz"]:
+    plane_name = str(plane).lower()
+    if plane_name not in {"xy", "xz", "yz"}:
+        raise ValueError("plane must be 'xy', 'xz', or 'yz'.")
+    return plane_name  # type: ignore[return-value]
+
+
+def _project_bounds_from_source(
+    source_bounds: Sequence[float],
+    plane: Literal["xy", "xz", "yz"],
+) -> tuple[float, float, float, float]:
+    values = tuple(float(value) for value in np.asarray(source_bounds, dtype=float).ravel())
+    if len(values) == 4:
+        return values
+    if len(values) != 6:
+        raise ValueError("source_bounds must contain 4 projected values or 6 xyz bounds values.")
+    xmin, xmax, ymin, ymax, zmin, zmax = values
+    if plane == "xy":
+        return xmin, xmax, ymin, ymax
+    if plane == "xz":
+        return xmin, xmax, zmin, zmax
+    return ymin, ymax, zmin, zmax
+
+
+def resolve_heightmap_projection_bounds_policy(
+    *,
+    projection: str = "planar",
+    plane: str = "xy",
+    bounds: Sequence[float] | None = None,
+    source_bounds: Sequence[float] | None = None,
+) -> HeightmapProjectionBoundsPolicy:
+    projection_name = _as_planar_projection(projection)
+    plane_name = _as_projection_plane(plane)
+    source: Literal["explicit", "source-bounds"]
+    if bounds is None:
+        if source_bounds is None:
+            raise ValueError("projection bounds are required when source bounds are unavailable.")
+        resolved = _project_bounds_from_source(source_bounds, plane_name)
+        source = "source-bounds"
+    else:
+        resolved = tuple(float(value) for value in np.asarray(bounds, dtype=float).reshape(4))
+        source = "explicit"
+    if not np.all(np.isfinite(np.asarray(resolved, dtype=float))):
+        raise ValueError("projection bounds must be finite.")
+    umin, umax, vmin, vmax = resolved
+    if np.isclose(umax, umin) or np.isclose(vmax, vmin):
+        raise ValueError("projection bounds are degenerate.")
+    return HeightmapProjectionBoundsPolicy(projection_name, plane_name, resolved, source)
+
+
+def heightmap_sample_coordinate_record(
+    points: np.ndarray,
+    policy: HeightmapProjectionBoundsPolicy,
+) -> HeightmapSampleCoordinateRecord:
+    point_arr = np.asarray(points, dtype=float)
+    if point_arr.size == 0:
+        point_arr = point_arr.reshape(0, 3)
+    if point_arr.ndim != 2 or point_arr.shape[1] != 3:
+        raise ValueError("heightmap sample coordinates require Nx3 points.")
+    if policy.plane == "xy":
+        u = point_arr[:, 0]
+        v = point_arr[:, 1]
+    elif policy.plane == "xz":
+        u = point_arr[:, 0]
+        v = point_arr[:, 2]
+    else:
+        u = point_arr[:, 1]
+        v = point_arr[:, 2]
+    umin, umax, vmin, vmax = policy.bounds
+    u_norm = (u - umin) / (umax - umin)
+    v_norm = (v - vmin) / (vmax - vmin)
+    return HeightmapSampleCoordinateRecord(
+        projection=policy.projection,
+        plane=policy.plane,
+        bounds=policy.bounds,
+        u=u,
+        v=v,
+        u_normalized=u_norm,
+        v_normalized=v_norm,
+    )
 
 
 def _triangle_surface_body_from_mesh(mesh: Mesh, *, metadata: dict[str, object] | None = None) -> "SurfaceBody":
@@ -519,10 +651,8 @@ def _displace_heightmap_surface_body(
     bounds: Sequence[float] | None,
     quality: MeshQuality | None,
 ) -> "SurfaceBody":
-    if bounds is not None:
-        raise ValueError("Surface displacement bounds are not supported until projection sampling policy lands.")
-    if plane.lower() != "xy":
-        raise ValueError("Surface displacement currently supports plane='xy'; projection sampling policy owns other planes.")
+    projection_name = _as_planar_projection(projection)
+    plane_name = _as_projection_plane(plane)
     heights, mask = _load_heightmap(image)
     if quality is not None:
         quality = apply_lod(quality)
@@ -542,30 +672,40 @@ def _displace_heightmap_surface_body(
 
     displaced_shells = []
     for shell in body.iter_shells(world=True):
-        patches = tuple(
-            DisplacementSurfacePatch(
-                family="displacement",
-                source_patch=patch,
-                displacement_samples=heights,
-                alpha_mask=mask,
-                alpha_mode=alpha_policy.alpha_mode,
-                height_scale=float(height),
-                direction=direction,
-                projection=projection,
-                metadata={
-                    "kernel": {
-                        "producer": "heightmap",
-                        "operation": "displace",
-                        "alpha_policy": alpha_policy.canonical_payload(),
-                        "cache_key_policy": cache_record.canonical_payload(),
-                    }
-                },
+        patches = []
+        for patch in shell.iter_patches(world=True):
+            policy = resolve_heightmap_projection_bounds_policy(
+                projection=projection_name,
+                plane=plane_name,
+                bounds=bounds,
+                source_bounds=_surface_patch_projection_source_bounds(patch, plane_name) if bounds is None else None,
             )
-            for patch in shell.iter_patches(world=True)
-        )
+            patches.append(
+                DisplacementSurfacePatch(
+                    family="displacement",
+                    source_patch=patch,
+                    displacement_samples=heights,
+                    alpha_mask=mask,
+                    alpha_mode=alpha_policy.alpha_mode,
+                    height_scale=float(height),
+                    direction=direction,
+                    projection=policy.projection,
+                    plane=policy.plane,
+                    projection_bounds=policy.bounds,
+                    metadata={
+                        "kernel": {
+                            "producer": "heightmap",
+                            "operation": "displace",
+                            "projection_policy": policy.canonical_payload(),
+                            "alpha_policy": alpha_policy.canonical_payload(),
+                            "cache_key_policy": cache_record.canonical_payload(),
+                        }
+                    },
+                )
+            )
         displaced_shells.append(
             make_surface_shell(
-                patches,
+                tuple(patches),
                 connected=shell.connected,
                 metadata={"kernel": {"producer": "heightmap", "operation": "displace"}},
             )
@@ -573,6 +713,34 @@ def _displace_heightmap_surface_body(
     return make_surface_body(
         tuple(displaced_shells),
         metadata={"kernel": {"producer": "heightmap", "operation": "displace"}, "consumer": {"source": "heightmap"}},
+    )
+
+
+def _surface_patch_projection_source_bounds(
+    patch: object,
+    plane: Literal["xy", "xz", "yz"],
+) -> tuple[float, float, float, float]:
+    domain = getattr(patch, "domain")
+    u0, u1 = domain.u_range
+    v0, v1 = domain.v_range
+    points = np.asarray(
+        [
+            patch.point_at(u0, v0),
+            patch.point_at(u1, v0),
+            patch.point_at(u1, v1),
+            patch.point_at(u0, v1),
+        ],
+        dtype=float,
+    )
+    coord_record = heightmap_sample_coordinate_record(
+        points,
+        HeightmapProjectionBoundsPolicy("planar", plane, (0.0, 1.0, 0.0, 1.0), "source-bounds"),
+    )
+    return (
+        float(np.min(coord_record.u)),
+        float(np.max(coord_record.u)),
+        float(np.min(coord_record.v)),
+        float(np.max(coord_record.v)),
     )
 
 
@@ -588,12 +756,6 @@ def _displace_heightmap_mesh_impl(
     bounds: Sequence[float] | None,
     quality: MeshQuality | None,
 ) -> Mesh:
-    if projection != "planar":
-        raise ValueError("Only planar projection is supported in this build.")
-    plane = plane.lower()
-    if plane not in {"xy", "xz", "yz"}:
-        raise ValueError("plane must be 'xy', 'xz', or 'yz'.")
-
     heights, mask = _load_heightmap(image)
     if quality is not None:
         quality = apply_lod(quality)
@@ -604,33 +766,15 @@ def _displace_heightmap_mesh_impl(
         return mesh.copy()
 
     verts = mesh.vertices.copy()
-    if plane == "xy":
-        u = verts[:, 0]
-        v = verts[:, 1]
-        if bounds is None:
-            xmin, xmax, ymin, ymax, _, _ = mesh.bounds
-            bounds = (xmin, xmax, ymin, ymax)
-    elif plane == "xz":
-        u = verts[:, 0]
-        v = verts[:, 2]
-        if bounds is None:
-            xmin, xmax, _, _, zmin, zmax = mesh.bounds
-            bounds = (xmin, xmax, zmin, zmax)
-    else:
-        u = verts[:, 1]
-        v = verts[:, 2]
-        if bounds is None:
-            _, _, ymin, ymax, zmin, zmax = mesh.bounds
-            bounds = (ymin, ymax, zmin, zmax)
+    policy = resolve_heightmap_projection_bounds_policy(
+        projection=projection,
+        plane=plane,
+        bounds=bounds,
+        source_bounds=mesh.bounds if bounds is None else None,
+    )
+    coord_record = heightmap_sample_coordinate_record(verts, policy)
 
-    umin, umax, vmin, vmax = np.asarray(bounds, dtype=float).reshape(4)
-    if np.isclose(umax, umin) or np.isclose(vmax, vmin):
-        raise ValueError("projection bounds are degenerate.")
-
-    u_norm = (u - umin) / (umax - umin)
-    v_norm = (v - vmin) / (vmax - vmin)
-
-    sampled, masked = _sample_heightmap(heights, mask, u_norm, v_norm)
+    sampled, masked = _sample_heightmap(heights, mask, coord_record.u_normalized, coord_record.v_normalized)
     if alpha_mode == "ignore":
         sampled = np.where(masked, 0.0, sampled)
     elif alpha_mode != "mask":
@@ -678,9 +822,13 @@ def _heightmap_cache_key(
 __all__ = [
     "HeightmapAlphaMaskPolicy",
     "HeightmapCacheKeyRecord",
+    "HeightmapProjectionBoundsPolicy",
+    "HeightmapSampleCoordinateRecord",
     "heightmap",
     "displace_heightmap",
     "heightmap_cache_key_record",
+    "heightmap_sample_coordinate_record",
     "make_heightmap_surface_patch",
+    "resolve_heightmap_projection_bounds_policy",
     "resolve_heightmap_alpha_mask_policy",
 ]

--- a/src/impression/modeling/surface.py
+++ b/src/impression/modeling/surface.py
@@ -926,6 +926,8 @@ class DisplacementSurfacePatch(SurfacePatch):
     height_scale: float = 1.0
     direction: str | tuple[float, float, float] = "normal"
     projection: str = "planar"
+    plane: str = "xy"
+    projection_bounds: tuple[float, float, float, float] | None = None
 
     def __post_init__(self) -> None:
         if self.source_patch is None:
@@ -948,6 +950,17 @@ class DisplacementSurfacePatch(SurfacePatch):
         projection = str(self.projection).lower()
         if projection != "planar":
             raise ValueError("Only planar displacement projection is supported in this build.")
+        plane = str(self.plane).lower()
+        if plane not in {"xy", "xz", "yz"}:
+            raise ValueError("DisplacementSurfacePatch.plane must be 'xy', 'xz', or 'yz'.")
+        if self.projection_bounds is None:
+            raise ValueError("DisplacementSurfacePatch.projection_bounds is required.")
+        projection_bounds = tuple(float(value) for value in np.asarray(self.projection_bounds, dtype=float).reshape(4))
+        if not np.all(np.isfinite(np.asarray(projection_bounds, dtype=float))):
+            raise ValueError("DisplacementSurfacePatch.projection_bounds must be finite.")
+        umin, umax, vmin, vmax = projection_bounds
+        if np.isclose(umax, umin) or np.isclose(vmax, vmin):
+            raise ValueError("DisplacementSurfacePatch.projection_bounds are degenerate.")
         height_scale = float(self.height_scale)
         if not np.isfinite(height_scale):
             raise ValueError("DisplacementSurfacePatch.height_scale must be finite.")
@@ -969,14 +982,26 @@ class DisplacementSurfacePatch(SurfacePatch):
         object.__setattr__(self, "height_scale", height_scale)
         object.__setattr__(self, "direction", direction)
         object.__setattr__(self, "projection", projection)
+        object.__setattr__(self, "plane", plane)
+        object.__setattr__(self, "projection_bounds", projection_bounds)
         super().__post_init__()
 
     def _sample_height(self, u: float, v: float) -> tuple[float, bool]:
+        from .heightmap import HeightmapProjectionBoundsPolicy, heightmap_sample_coordinate_record
+
         rows, cols = self.displacement_samples.shape
-        u0, u1 = self.source_patch.domain.u_range
-        v0, v1 = self.source_patch.domain.v_range
-        u_norm = 0.0 if np.isclose(u1, u0) else (float(u) - u0) / (u1 - u0)
-        v_norm = 0.0 if np.isclose(v1, v0) else (float(v) - v0) / (v1 - v0)
+        base = self.source_patch.point_at(u, v)
+        coord_record = heightmap_sample_coordinate_record(
+            np.asarray([base], dtype=float),
+            HeightmapProjectionBoundsPolicy(
+                projection="planar",
+                plane=self.plane,
+                bounds=self.projection_bounds,
+                source="explicit",
+            ),
+        )
+        u_norm = float(coord_record.u_normalized[0])
+        v_norm = float(coord_record.v_normalized[0])
         x = np.clip(u_norm, 0.0, 1.0) * (cols - 1)
         y = (1.0 - np.clip(v_norm, 0.0, 1.0)) * (rows - 1)
         x0 = int(np.floor(x))
@@ -1022,6 +1047,8 @@ class DisplacementSurfacePatch(SurfacePatch):
             "height_scale": self.height_scale,
             "direction": self.direction,
             "projection": self.projection,
+            "plane": self.plane,
+            "projection_bounds": self.projection_bounds,
         }
 
     def point_at(self, u: float, v: float) -> np.ndarray:

--- a/tests/test_heightmap.py
+++ b/tests/test_heightmap.py
@@ -9,14 +9,22 @@ from PIL import Image
 from impression.modeling import (
     HeightmapAlphaMaskPolicy,
     HeightmapCacheKeyRecord,
+    HeightmapProjectionBoundsPolicy,
+    HeightmapSampleCoordinateRecord,
     HeightmapSurfacePatch,
     DisplacementSurfacePatch,
     MeshQuality,
+    ParameterDomain,
+    PlanarSurfacePatch,
     heightmap,
     displace_heightmap,
     heightmap_cache_key_record,
+    heightmap_sample_coordinate_record,
+    make_surface_body,
+    make_surface_shell,
     make_heightmap_surface_patch,
     resolve_heightmap_alpha_mask_policy,
+    resolve_heightmap_projection_bounds_policy,
     tessellate_surface_body,
     tessellate_surface_patch,
 )
@@ -130,6 +138,106 @@ def test_displace_heightmap_surface_backend_uses_displacement_payload():
     assert patch_mesh.metadata["heightmap_displacement_boundary"] == "surface-payload"
     assert np.isclose(mesh.bounds[5] - mesh.bounds[4], 0.0, atol=1e-9)
     assert np.isclose(mesh.bounds[4], 0.5, atol=1e-9)
+
+
+def test_heightmap_projection_policy_resolves_planes_and_bounds():
+    xy = resolve_heightmap_projection_bounds_policy(plane="xy", source_bounds=(0.0, 2.0, 10.0, 14.0, -1.0, 1.0))
+    xz = resolve_heightmap_projection_bounds_policy(plane="xz", source_bounds=(0.0, 2.0, 10.0, 14.0, -1.0, 1.0))
+    yz = resolve_heightmap_projection_bounds_policy(plane="yz", bounds=(10.0, 14.0, -1.0, 1.0))
+    record = heightmap_sample_coordinate_record(
+        np.asarray([[1.0, 12.0, 0.0]], dtype=float),
+        yz,
+    )
+
+    assert isinstance(xy, HeightmapProjectionBoundsPolicy)
+    assert xy.bounds == (0.0, 2.0, 10.0, 14.0)
+    assert xz.bounds == (0.0, 2.0, -1.0, 1.0)
+    assert yz.source == "explicit"
+    assert isinstance(record, HeightmapSampleCoordinateRecord)
+    assert np.allclose(record.u_normalized, [0.5])
+    assert np.allclose(record.v_normalized, [0.5])
+    assert record.canonical_payload()["sample_count"] == 1
+
+
+def test_heightmap_projection_policy_refuses_degenerate_and_unsupported_projection():
+    with pytest.raises(ValueError, match="projection bounds are degenerate"):
+        resolve_heightmap_projection_bounds_policy(bounds=(0.0, 0.0, 0.0, 1.0))
+
+    with pytest.raises(ValueError, match="Only planar projection"):
+        resolve_heightmap_projection_bounds_policy(projection="cylindrical", bounds=(0.0, 1.0, 0.0, 1.0))
+
+    with pytest.raises(ValueError, match="plane must be"):
+        resolve_heightmap_projection_bounds_policy(plane="uv", bounds=(0.0, 1.0, 0.0, 1.0))
+
+
+def test_displace_heightmap_surface_projection_planes_and_explicit_bounds():
+    source_patch = PlanarSurfacePatch(
+        family="planar",
+        domain=ParameterDomain((0.0, 1.0), (0.0, 1.0)),
+        origin=np.asarray([0.0, 0.0, 0.0], dtype=float),
+        u_axis=np.asarray([1.0, 0.0, 0.0], dtype=float),
+        v_axis=np.asarray([0.0, 0.0, 1.0], dtype=float),
+    )
+    surface = make_surface_body((make_surface_shell((source_patch,), connected=False),))
+    image = np.asarray([[0.0, 0.0], [1.0, 1.0]], dtype=float)
+
+    displaced = displace_heightmap(
+        surface,
+        image,
+        height=0.25,
+        plane="xz",
+        direction="y",
+        backend="surface",
+    )
+    patch = displaced.iter_patches()[0]
+
+    assert isinstance(patch, DisplacementSurfacePatch)
+    assert patch.plane == "xz"
+    assert patch.projection_bounds == (0.0, 1.0, 0.0, 1.0)
+    assert patch.kernel_metadata()["projection_policy"]["plane"] == "xz"
+    assert np.isclose(patch.point_at(0.5, 0.0)[1], 0.25)
+    assert np.isclose(patch.point_at(0.5, 1.0)[1], 0.0)
+
+
+def test_displace_heightmap_surface_projection_bounds_refusal_and_mask():
+    surface = make_plane(size=(1.0, 1.0), center=(0.0, 0.0, 0.0))
+    image = np.ones((2, 2, 4), dtype=np.uint8) * 255
+    image[0, 0, 3] = 0
+
+    with pytest.raises(ValueError, match="projection bounds are degenerate"):
+        displace_heightmap(
+            surface,
+            image,
+            height=0.5,
+            plane="xz",
+            direction="z",
+            backend="surface",
+        )
+
+    masked = displace_heightmap(
+        surface,
+        image,
+        height=0.5,
+        plane="xz",
+        direction="z",
+        bounds=(-0.5, 0.5, -0.5, 0.5),
+        alpha_mode="mask",
+        backend="surface",
+    )
+    ignored = displace_heightmap(
+        surface,
+        image,
+        height=0.5,
+        plane="xz",
+        direction="z",
+        bounds=(-0.5, 0.5, -0.5, 0.5),
+        alpha_mode="ignore",
+        backend="surface",
+    )
+    mesh = tessellate_surface_body(masked).mesh
+
+    assert masked.iter_patches()[0].alpha_mode == "mask"
+    assert mesh.n_faces < tessellate_surface_body(ignored).mesh.n_faces
 
 
 def test_displace_heightmap_surface_backend_rejects_mesh_input() -> None:

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -1315,6 +1315,7 @@ def test_every_surface_family_tessellates_through_family_adapter_metadata() -> N
             source_patch=PlanarSurfacePatch(family="planar"),
             displacement_samples=np.asarray([[0.0, 1.0], [0.5, 0.25]], dtype=float),
             direction="z",
+            projection_bounds=(0.0, 1.0, 0.0, 1.0),
         ),
     }
 


### PR DESCRIPTION
## Summary
- add explicit heightmap projection bounds and sample coordinate records
- route mesh and surface heightmap displacement through shared planar projection validation
- persist displacement plane/bounds in surface patch payloads and cover xy/xz/yz policy behavior

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_heightmap.py tests/test_surface_replacements.py tests/test_surface.py -q