### PR TITLE
Default thread helpers to surface outputs

### DIFF
--- a/docs/modeling/threading.md
+++ b/docs/modeling/threading.md
@@ -34,10 +34,12 @@ Threading is in an active surface-first migration. The legacy mesh generators st
 from impression.modeling import lookup_standard_thread, make_external_thread
 
 spec = lookup_standard_thread("metric", "M6x1", length=12.0)
-thread = make_external_thread(spec, backend="surface")
+thread = make_external_thread(spec)
 ```
 
-That surfaced result is a `ThreadSurfaceRepresentation`, not a tessellated mesh. It captures:
+`make_external_thread(...)` and `make_internal_thread(...)` default to surfaced
+results. The surfaced result is a `ThreadSurfaceRepresentation`, not a
+tessellated mesh. It captures:
 
 - normalized axis origin, direction, and orthonormal basis
 - major diameter, minor diameter, pitch, and resolved thread depth
@@ -47,15 +49,24 @@ That surfaced result is a `ThreadSurfaceRepresentation`, not a tessellated mesh.
 
 This keeps thread truth explicit before any future surfaced thread executor turns it into patches or tessellation.
 
-Surface convenience builders are also starting to migrate. Today, `backend="surface"` on:
+Surface convenience builders are also starting to migrate. Today, the default
+route for:
 
 - `make_threaded_rod(...)`
 - `make_tapped_hole_cutter(...)`
+
+returns a `ThreadSurfaceAssembly`. The same surfaced assembly route remains
+available explicitly with `backend="surface"`.
+
+The broader convenience builders also expose `backend="surface"`:
+
 - `make_hex_nut(...)`
 - `make_round_nut(...)`
 - `make_runout_relief(...)`
 
-returns a `ThreadSurfaceAssembly`. That assembly records surfaced primitive and thread operands plus the intended composition (`standalone`, `union`, or `difference`) without collapsing back to mesh-first truth.
+That assembly records surfaced primitive and thread operands plus the intended
+composition (`standalone`, `union`, or `difference`) without collapsing back to
+mesh-first truth.
 
 Fit presets still change canonical geometry on the surfaced path, because they change the actual compensated thread dimensions. Mesh-quality controls do not: they are currently ignored by surfaced thread preparation and only matter on the legacy mesh generator path.
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -392,7 +392,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 174: Heightmap Displacement Surface Contract (v1.0)](../specifications/surface-174-heightmap-displacement-surface-contract-v1_0.md)
 - [x] [Surface Spec 175: Heightmap Projection Sampling Policy (v1.0)](../specifications/surface-175-heightmap-projection-sampling-policy-v1_0.md)
 - [x] [Surface Spec 176: Heightmap Mesh Compatibility And Serialization Guard (v1.0)](../specifications/surface-176-heightmap-mesh-compatibility-and-serialization-guard-v1_0.md)
-- [ ] [Surface Spec 177: Thread Surface Representation Defaults (v1.0)](../specifications/surface-177-thread-surface-representation-defaults-v1_0.md)
+- [x] [Surface Spec 177: Thread Surface Representation Defaults (v1.0)](../specifications/surface-177-thread-surface-representation-defaults-v1_0.md)
 - [ ] [Surface Spec 178: Thread Assembly To SurfaceBody Lowering (v1.0)](../specifications/surface-178-thread-assembly-to-surfacebody-lowering-v1_0.md)
 - [ ] [Surface Spec 179: Thread Mesh Compatibility And Quality Budget (v1.0)](../specifications/surface-179-thread-mesh-compatibility-and-quality-budget-v1_0.md)
 - [ ] [Surface Spec 180: Traditional Hinge Surface Lowering (v1.0)](../specifications/surface-180-traditional-hinge-surface-lowering-v1_0.md)

--- a/src/impression/modeling/threading.py
+++ b/src/impression/modeling/threading.py
@@ -29,3 +29,29 @@ def _load_extension() -> ModuleType:
 _extension = _load_extension()
 __all__ = list(getattr(_extension, "__all__", ()))
 globals().update({name: getattr(_extension, name) for name in __all__})
+
+
+def make_external_thread(spec, *args, backend="surface", **kwargs):
+    return _extension.make_external_thread(spec, *args, backend=backend, **kwargs)
+
+
+def make_internal_thread(spec, *args, backend="surface", **kwargs):
+    return _extension.make_internal_thread(spec, *args, backend=backend, **kwargs)
+
+
+def make_threaded_rod(spec, *args, backend="surface", **kwargs):
+    return _extension.make_threaded_rod(spec, *args, backend=backend, **kwargs)
+
+
+def make_tapped_hole_cutter(spec, *args, backend="surface", **kwargs):
+    return _extension.make_tapped_hole_cutter(spec, *args, backend=backend, **kwargs)
+
+
+globals().update(
+    {
+        "make_external_thread": make_external_thread,
+        "make_internal_thread": make_internal_thread,
+        "make_threaded_rod": make_threaded_rod,
+        "make_tapped_hole_cutter": make_tapped_hole_cutter,
+    }
+)

--- a/tests/test_surface_threading.py
+++ b/tests/test_surface_threading.py
@@ -132,6 +132,24 @@ def test_surface_thread_convenience_builders_return_structured_assemblies() -> N
     assert rod.stable_identity == make_threaded_rod(spec, backend="surface").stable_identity
 
 
+def test_thread_helpers_default_to_surface_representations_and_assemblies() -> None:
+    spec = lookup_standard_thread("metric", "M6x1", length=8.0)
+
+    external = make_external_thread(spec)
+    internal = make_internal_thread(spec)
+    rod = make_threaded_rod(spec)
+    cutter = make_tapped_hole_cutter(spec, overshoot=0.5)
+
+    assert isinstance(external, ThreadSurfaceRepresentation)
+    assert external.kind == "external"
+    assert isinstance(internal, ThreadSurfaceRepresentation)
+    assert internal.kind == "internal"
+    assert isinstance(rod, ThreadSurfaceAssembly)
+    assert rod.assembly_type == "threaded_rod"
+    assert isinstance(cutter, ThreadSurfaceAssembly)
+    assert cutter.assembly_type == "tapped_hole_cutter"
+
+
 def test_surface_thread_fit_changes_canonical_geometry_explicitly() -> None:
     base = lookup_standard_thread("metric", "M6x1", length=10.0)
     fitted = apply_fit(base, "fdm_default", kind="external")


### PR DESCRIPTION
## Summary
- make the Impression threading shim default external/internal thread and rod/cutter helpers to surfaced outputs
- keep explicit backend='mesh' routed to the sibling threading implementation
- add default-output regression coverage and update threading docs

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_surface_threading.py tests/test_surface_threading_docs.py -q