### PR TITLE
Default traditional hinges to surface lowering

### DIFF
--- a/docs/modeling/hinges.md
+++ b/docs/modeling/hinges.md
@@ -18,15 +18,15 @@ from impression.modeling import (
 
 Hinges are now on an explicit surface-first migration path.
 
-The legacy mesh builders still exist, but `backend="surface"` now exposes
-deterministic surfaced hinge contracts instead of silently collapsing back to
-mesh-first truth.
+The legacy mesh builders still exist through `backend="mesh"`, but traditional
+hinge helpers now default to deterministic surfaced hinge contracts instead of
+silently collapsing back to mesh-first truth.
 
 Today the surfaced path is split into two layers:
 
-- direct surfaced leaf geometry for `make_traditional_hinge_leaf(..., backend="surface")`
+- direct surfaced leaf geometry for `make_traditional_hinge_leaf(...)`
 - structured surfaced assemblies for:
-  - `make_traditional_hinge_pair(..., backend="surface")`
+  - `make_traditional_hinge_pair(...)`
   - `make_living_hinge(..., backend="surface")`
   - `make_bistable_hinge(..., backend="surface")`
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -395,7 +395,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 177: Thread Surface Representation Defaults (v1.0)](../specifications/surface-177-thread-surface-representation-defaults-v1_0.md)
 - [x] [Surface Spec 178: Thread Assembly To SurfaceBody Lowering (v1.0)](../specifications/surface-178-thread-assembly-to-surfacebody-lowering-v1_0.md)
 - [x] [Surface Spec 179: Thread Mesh Compatibility And Quality Budget (v1.0)](../specifications/surface-179-thread-mesh-compatibility-and-quality-budget-v1_0.md)
-- [ ] [Surface Spec 180: Traditional Hinge Surface Lowering (v1.0)](../specifications/surface-180-traditional-hinge-surface-lowering-v1_0.md)
+- [x] [Surface Spec 180: Traditional Hinge Surface Lowering (v1.0)](../specifications/surface-180-traditional-hinge-surface-lowering-v1_0.md)
 - [ ] [Surface Spec 181: Living And Bistable Hinge Surface Lowering (v1.0)](../specifications/surface-181-living-and-bistable-hinge-surface-lowering-v1_0.md)
 - [ ] [Surface Spec 182: Surface Transform API Defaults (v1.0)](../specifications/surface-182-surface-transform-api-defaults-v1_0.md)
 - [ ] [Surface Spec 183: Surface Composition Public Type (v1.0)](../specifications/surface-183-surface-composition-public-type-v1_0.md)

--- a/src/impression/modeling/hinges.py
+++ b/src/impression/modeling/hinges.py
@@ -29,3 +29,54 @@ def _load_extension() -> ModuleType:
 _extension = _load_extension()
 __all__ = list(getattr(_extension, "__all__", ()))
 globals().update({name: getattr(_extension, name) for name in __all__})
+
+
+def make_traditional_hinge_leaf(*args, backend="surface", **kwargs):
+    if backend == "mesh":
+        return _call_with_legacy_mesh_primitives(_extension.make_traditional_hinge_leaf, *args, backend=backend, **kwargs)
+    return _extension.make_traditional_hinge_leaf(*args, backend=backend, **kwargs)
+
+
+def make_traditional_hinge_pair(*args, backend="surface", **kwargs):
+    if backend == "mesh":
+        return _call_with_legacy_mesh_primitives(_extension.make_traditional_hinge_pair, *args, backend=backend, **kwargs)
+    return _extension.make_traditional_hinge_pair(*args, backend=backend, **kwargs)
+
+
+def make_living_hinge(*args, backend="mesh", **kwargs):
+    if backend == "mesh":
+        return _call_with_legacy_mesh_primitives(_extension.make_living_hinge, *args, backend=backend, **kwargs)
+    return _extension.make_living_hinge(*args, backend=backend, **kwargs)
+
+
+def make_bistable_hinge(*args, backend="mesh", **kwargs):
+    if backend == "mesh":
+        return _call_with_legacy_mesh_primitives(_extension.make_bistable_hinge, *args, backend=backend, **kwargs)
+    return _extension.make_bistable_hinge(*args, backend=backend, **kwargs)
+
+
+def _call_with_legacy_mesh_primitives(fn, *args, **kwargs):
+    from .primitives import make_box_mesh, make_cylinder_mesh
+
+    globals_dict = getattr(fn, "__globals__", {})
+    original_box = globals_dict.get("make_box")
+    original_cylinder = globals_dict.get("make_cylinder")
+    globals_dict["make_box"] = make_box_mesh
+    globals_dict["make_cylinder"] = make_cylinder_mesh
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        if original_box is not None:
+            globals_dict["make_box"] = original_box
+        if original_cylinder is not None:
+            globals_dict["make_cylinder"] = original_cylinder
+
+
+globals().update(
+    {
+        "make_traditional_hinge_leaf": make_traditional_hinge_leaf,
+        "make_traditional_hinge_pair": make_traditional_hinge_pair,
+        "make_living_hinge": make_living_hinge,
+        "make_bistable_hinge": make_bistable_hinge,
+    }
+)

--- a/tests/test_hinges.py
+++ b/tests/test_hinges.py
@@ -12,7 +12,7 @@ from impression.modeling import (
 
 
 def test_traditional_hinge_leaf_generates_mesh() -> None:
-    mesh = make_traditional_hinge_leaf(width=24.0, knuckle_count=5)
+    mesh = make_traditional_hinge_leaf(width=24.0, knuckle_count=5, backend="mesh")
     analysis = analyze_mesh(mesh)
     assert mesh.n_vertices > 0
     assert mesh.n_faces > 0
@@ -20,7 +20,7 @@ def test_traditional_hinge_leaf_generates_mesh() -> None:
 
 
 def test_traditional_hinge_pair_parts() -> None:
-    assembly = make_traditional_hinge_pair(width=24.0, include_pin=True, opened_angle_deg=35.0)
+    assembly = make_traditional_hinge_pair(width=24.0, include_pin=True, opened_angle_deg=35.0, backend="mesh")
     parts = assembly.to_meshes()
     assert len(parts) == 3
     assert all(mesh.n_faces > 0 for mesh in parts)

--- a/tests/test_surface_hinges.py
+++ b/tests/test_surface_hinges.py
@@ -35,6 +35,19 @@ def test_surface_traditional_hinge_leaf_returns_surface_body_without_deprecation
     assert not [item for item in caught if issubclass(item.category, DeprecationWarning)]
 
 
+def test_traditional_hinge_defaults_lower_to_surface_outputs() -> None:
+    leaf = make_traditional_hinge_leaf(width=24.0, knuckle_count=5)
+    pair = make_traditional_hinge_pair(width=24.0, knuckle_count=5, include_pin=True)
+
+    assert isinstance(leaf, SurfaceBody)
+    assert tessellate_surface_body(leaf).mesh.n_faces > 0
+    assert isinstance(pair, HingeSurfaceAssembly)
+    assert pair.assembly_type == "traditional_hinge_pair"
+    collection = handoff_hinge_surface(pair)
+    assert len(collection.items) == 3
+    assert _combined_collection_mesh(collection).n_faces > 0
+
+
 def test_surface_hinge_paths_preserve_consumer_color_metadata() -> None:
     leaf = make_traditional_hinge_leaf(width=24.0, knuckle_count=5, color="#7f8fa6", backend="surface")
     pair = make_traditional_hinge_pair(


### PR DESCRIPTION
## Summary
- default traditional hinge leaf and pair helpers to surfaced outputs through the Impression shim
- preserve explicit backend='mesh' compatibility despite surface-first primitive defaults
- add default surfaced traditional hinge regression coverage and update docs

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_hinges.py tests/test_surface_hinges.py tests/test_surface_hinges_docs.py -q