### PR TITLE
Default flexure hinges to surface assemblies

### DIFF
--- a/docs/modeling/hinges.md
+++ b/docs/modeling/hinges.md
@@ -27,8 +27,8 @@ Today the surfaced path is split into two layers:
 - direct surfaced leaf geometry for `make_traditional_hinge_leaf(...)`
 - structured surfaced assemblies for:
   - `make_traditional_hinge_pair(...)`
-  - `make_living_hinge(..., backend="surface")`
-  - `make_bistable_hinge(..., backend="surface")`
+  - `make_living_hinge(...)`
+  - `make_bistable_hinge(...)`
 
 Those structured results are returned as `HingeSurfaceAssembly`, which preserves:
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -396,7 +396,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 178: Thread Assembly To SurfaceBody Lowering (v1.0)](../specifications/surface-178-thread-assembly-to-surfacebody-lowering-v1_0.md)
 - [x] [Surface Spec 179: Thread Mesh Compatibility And Quality Budget (v1.0)](../specifications/surface-179-thread-mesh-compatibility-and-quality-budget-v1_0.md)
 - [x] [Surface Spec 180: Traditional Hinge Surface Lowering (v1.0)](../specifications/surface-180-traditional-hinge-surface-lowering-v1_0.md)
-- [ ] [Surface Spec 181: Living And Bistable Hinge Surface Lowering (v1.0)](../specifications/surface-181-living-and-bistable-hinge-surface-lowering-v1_0.md)
+- [x] [Surface Spec 181: Living And Bistable Hinge Surface Lowering (v1.0)](../specifications/surface-181-living-and-bistable-hinge-surface-lowering-v1_0.md)
 - [ ] [Surface Spec 182: Surface Transform API Defaults (v1.0)](../specifications/surface-182-surface-transform-api-defaults-v1_0.md)
 - [ ] [Surface Spec 183: Surface Composition Public Type (v1.0)](../specifications/surface-183-surface-composition-public-type-v1_0.md)
 - [ ] [Surface Spec 184: Surface Composition Traversal And Tessellation Handoff (v1.0)](../specifications/surface-184-surface-composition-traversal-and-tessellation-handoff-v1_0.md)

--- a/src/impression/modeling/hinges.py
+++ b/src/impression/modeling/hinges.py
@@ -43,13 +43,13 @@ def make_traditional_hinge_pair(*args, backend="surface", **kwargs):
     return _extension.make_traditional_hinge_pair(*args, backend=backend, **kwargs)
 
 
-def make_living_hinge(*args, backend="mesh", **kwargs):
+def make_living_hinge(*args, backend="surface", **kwargs):
     if backend == "mesh":
         return _call_with_legacy_mesh_primitives(_extension.make_living_hinge, *args, backend=backend, **kwargs)
     return _extension.make_living_hinge(*args, backend=backend, **kwargs)
 
 
-def make_bistable_hinge(*args, backend="mesh", **kwargs):
+def make_bistable_hinge(*args, backend="surface", **kwargs):
     if backend == "mesh":
         return _call_with_legacy_mesh_primitives(_extension.make_bistable_hinge, *args, backend=backend, **kwargs)
     return _extension.make_bistable_hinge(*args, backend=backend, **kwargs)

--- a/tests/test_hinges.py
+++ b/tests/test_hinges.py
@@ -27,14 +27,14 @@ def test_traditional_hinge_pair_parts() -> None:
 
 
 def test_living_hinge_generates_cut_pattern() -> None:
-    living = make_living_hinge(width=48.0, height=20.0, hinge_band_width=12.0, slit_pitch=1.8)
+    living = make_living_hinge(width=48.0, height=20.0, hinge_band_width=12.0, slit_pitch=1.8, backend="mesh")
     assert living.n_faces > 12
     xmin, xmax, _, _, _, _ = living.bounds
     assert (xmax - xmin) == pytest.approx(48.0)
 
 
 def test_bistable_hinge_generates_mesh() -> None:
-    mesh = make_bistable_hinge(width=40.0, preload_offset=2.0)
+    mesh = make_bistable_hinge(width=40.0, preload_offset=2.0, backend="mesh")
     assert mesh.n_vertices > 0
     assert mesh.n_faces > 0
 

--- a/tests/test_surface_hinges.py
+++ b/tests/test_surface_hinges.py
@@ -107,7 +107,6 @@ def test_surface_living_hinge_handoff_returns_structured_surface_collection() ->
         height=20.0,
         hinge_band_width=12.0,
         slit_pitch=1.8,
-        backend="surface",
     )
 
     assert isinstance(assembly, HingeSurfaceAssembly)
@@ -126,7 +125,6 @@ def test_surface_bistable_hinge_handoff_returns_structured_surface_collection() 
     assembly = make_bistable_hinge(
         width=40.0,
         preload_offset=2.0,
-        backend="surface",
     )
 
     assert isinstance(assembly, HingeSurfaceAssembly)


### PR DESCRIPTION
## Summary
- default living and bistable hinge helpers to surfaced assemblies
- keep legacy mesh tests on explicit backend='mesh'
- update hinge docs for surface-first defaults

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_hinges.py tests/test_surface_hinges.py tests/test_surface_hinges_docs.py -q