### PR TITLE
Implement surface transform defaults

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -397,7 +397,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 179: Thread Mesh Compatibility And Quality Budget (v1.0)](../specifications/surface-179-thread-mesh-compatibility-and-quality-budget-v1_0.md)
 - [x] [Surface Spec 180: Traditional Hinge Surface Lowering (v1.0)](../specifications/surface-180-traditional-hinge-surface-lowering-v1_0.md)
 - [x] [Surface Spec 181: Living And Bistable Hinge Surface Lowering (v1.0)](../specifications/surface-181-living-and-bistable-hinge-surface-lowering-v1_0.md)
-- [ ] [Surface Spec 182: Surface Transform API Defaults (v1.0)](../specifications/surface-182-surface-transform-api-defaults-v1_0.md)
+- [x] [Surface Spec 182: Surface Transform API Defaults (v1.0)](../specifications/surface-182-surface-transform-api-defaults-v1_0.md)
 - [ ] [Surface Spec 183: Surface Composition Public Type (v1.0)](../specifications/surface-183-surface-composition-public-type-v1_0.md)
 - [ ] [Surface Spec 184: Surface Composition Traversal And Tessellation Handoff (v1.0)](../specifications/surface-184-surface-composition-traversal-and-tessellation-handoff-v1_0.md)
 - [ ] [Surface Spec 185: MeshGroup Explicit Compatibility API (v1.0)](../specifications/surface-185-meshgroup-explicit-compatibility-api-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from .transform import rotate, translate, scale, resize, mirror, multmatrix, rotate_euler
+from .transform import (
+    TransformMeshCompatibilityResult,
+    rotate,
+    translate,
+    scale,
+    resize,
+    mirror,
+    multmatrix,
+    rotate_euler,
+)
 from .primitives import (
     make_box,
     make_box_mesh,
@@ -583,6 +592,7 @@ __all__ = [
     "Path",
     "MeshGroup",
     "group",
+    "TransformMeshCompatibilityResult",
     "rotate",
     "translate",
     "scale",

--- a/src/impression/modeling/group.py
+++ b/src/impression/modeling/group.py
@@ -111,6 +111,7 @@ class MeshGroup:
 
     meshes: List[Mesh] = field(default_factory=list)
     _transform: np.ndarray = field(default_factory=lambda: np.eye(4))
+    metadata: dict[str, object] = field(default_factory=dict)
 
     def add(self, mesh: Mesh) -> "MeshGroup":
         self.meshes.append(mesh)

--- a/src/impression/modeling/transform.py
+++ b/src/impression/modeling/transform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Sequence
 
 import numpy as np
 
@@ -8,29 +9,52 @@ from impression.mesh import Mesh
 from impression.modeling.group import MeshGroup
 
 
-def translate(mesh: Mesh | MeshGroup, offset: Sequence[float]) -> Mesh | MeshGroup:
-    """Translate the mesh/group in-place and return it."""
-    if isinstance(mesh, MeshGroup):
-        mesh.translate(offset)
-        return mesh
+@dataclass(frozen=True)
+class TransformMeshCompatibilityResult:
+    """Explicit record for transform operations applied to mesh compatibility data."""
+
+    target_type: str
+    operation: str
+    boundary: str = "explicit-mesh-compatibility"
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "boundary": self.boundary,
+            "operation": self.operation,
+            "target_type": self.target_type,
+        }
+
+
+def translate(target, offset: Sequence[float]):
+    """Translate a surface body by attached transform, or mutate explicit mesh inputs."""
+    if _is_surface_body(target):
+        mat = np.eye(4, dtype=float)
+        mat[:3, 3] = np.asarray(offset, dtype=float).reshape(3)
+        return target.with_transform(mat)
+    if isinstance(target, MeshGroup):
+        target.translate(offset)
+        _mark_mesh_compatibility(target, "translate")
+        return target
     vec = np.asarray(offset, dtype=float).reshape(3)
-    mesh.translate(vec, inplace=True)
-    return mesh
+    target.translate(vec, inplace=True)
+    _mark_mesh_compatibility(target, "translate")
+    return target
 
 
 def rotate(
-    mesh: Mesh | MeshGroup,
+    target,
     axis: Sequence[float],
     angle_deg: float | None = None,
     origin: Sequence[float] = (0.0, 0.0, 0.0),
     order: str = "xyz",
-) -> Mesh:
+):
     """Rotate around an axis or Euler angles (degrees)."""
     if angle_deg is None:
-        return rotate_euler(mesh, angles_deg=axis, origin=origin, order=order)
-    if isinstance(mesh, MeshGroup):
-        mesh.rotate(axis=axis, angle_deg=angle_deg, origin=origin)
-        return mesh
+        return rotate_euler(target, angles_deg=axis, origin=origin, order=order)
+    if isinstance(target, MeshGroup):
+        target.rotate(axis=axis, angle_deg=angle_deg, origin=origin)
+        _mark_mesh_compatibility(target, "rotate")
+        return target
     axis_vec = np.asarray(axis, dtype=float).reshape(3)
     norm = np.linalg.norm(axis_vec)
     if norm == 0:
@@ -38,16 +62,20 @@ def rotate(
     axis_vec = axis_vec / norm
     center = np.asarray(origin, dtype=float).reshape(3)
 
-    mesh.rotate_vector(axis_vec, angle_deg, point=tuple(center), inplace=True)
-    return mesh
+    mat = _apply_about_origin(_axis_rotation_matrix(axis_vec, angle_deg), center)
+    if _is_surface_body(target):
+        return target.with_transform(mat)
+    target.rotate_vector(axis_vec, angle_deg, point=tuple(center), inplace=True)
+    _mark_mesh_compatibility(target, "rotate")
+    return target
 
 
 def rotate_euler(
-    mesh: Mesh | MeshGroup,
+    target,
     angles_deg: Sequence[float],
     origin: Sequence[float] = (0.0, 0.0, 0.0),
     order: str = "xyz",
-) -> Mesh | MeshGroup:
+):
     """Rotate by Euler angles in degrees (default order: X then Y then Z)."""
     angles = np.asarray(angles_deg, dtype=float).reshape(3)
     origin = np.asarray(origin, dtype=float).reshape(3)
@@ -65,14 +93,14 @@ def rotate_euler(
         mat = matrices[axis] @ mat
     mat = _apply_about_origin(mat, origin)
 
-    return multmatrix(mesh, mat)
+    return multmatrix(target, mat)
 
 
 def scale(
-    mesh: Mesh | MeshGroup,
+    target,
     factors: Sequence[float],
     origin: Sequence[float] = (0.0, 0.0, 0.0),
-) -> Mesh | MeshGroup:
+):
     """Scale the mesh/group in-place about an origin."""
     sx, sy, sz = np.asarray(factors, dtype=float).reshape(3)
     mat = np.eye(4)
@@ -80,18 +108,18 @@ def scale(
     mat[1, 1] = sy
     mat[2, 2] = sz
     mat = _apply_about_origin(mat, np.asarray(origin, dtype=float).reshape(3))
-    return multmatrix(mesh, mat)
+    return multmatrix(target, mat)
 
 
 def resize(
-    mesh: Mesh | MeshGroup,
+    target,
     size: Sequence[float],
     auto: bool | Sequence[bool] = False,
-) -> Mesh | MeshGroup:
+):
     """Resize mesh/group to the target size, preserving aspect on auto axes."""
-    target = np.asarray(size, dtype=float).reshape(3)
+    requested_size = np.asarray(size, dtype=float).reshape(3)
     auto_mask = _normalize_auto(auto)
-    bounds = _bounds(mesh)
+    bounds = _bounds(target)
     extents = np.array(
         [bounds[1] - bounds[0], bounds[3] - bounds[2], bounds[5] - bounds[4]],
         dtype=float,
@@ -99,25 +127,25 @@ def resize(
 
     scales = np.ones(3, dtype=float)
     for i in range(3):
-        if target[i] <= 0 or auto_mask[i]:
+        if requested_size[i] <= 0 or auto_mask[i]:
             continue
         if extents[i] == 0:
             raise ValueError("Cannot resize along axis with zero extent.")
-        scales[i] = target[i] / extents[i]
+        scales[i] = requested_size[i] / extents[i]
 
-    anchor = next((scales[i] for i in range(3) if not auto_mask[i] and target[i] > 0), 1.0)
+    anchor = next((scales[i] for i in range(3) if not auto_mask[i] and requested_size[i] > 0), 1.0)
     for i in range(3):
-        if target[i] <= 0 or auto_mask[i]:
+        if requested_size[i] <= 0 or auto_mask[i]:
             scales[i] = anchor
 
     center = np.array(
         [(bounds[0] + bounds[1]) / 2.0, (bounds[2] + bounds[3]) / 2.0, (bounds[4] + bounds[5]) / 2.0],
         dtype=float,
     )
-    return scale(mesh, scales, origin=center)
+    return scale(target, scales, origin=center)
 
 
-def mirror(mesh: Mesh | MeshGroup, axis: Sequence[float]) -> Mesh | MeshGroup:
+def mirror(target, axis: Sequence[float]):
     """Mirror across the plane through the origin with the given normal."""
     axis_vec = np.asarray(axis, dtype=float).reshape(3)
     norm = np.linalg.norm(axis_vec)
@@ -126,19 +154,23 @@ def mirror(mesh: Mesh | MeshGroup, axis: Sequence[float]) -> Mesh | MeshGroup:
     axis_vec = axis_vec / norm
     mat = np.eye(4)
     mat[:3, :3] -= 2.0 * np.outer(axis_vec, axis_vec)
-    return multmatrix(mesh, mat)
+    return multmatrix(target, mat)
 
 
-def multmatrix(mesh: Mesh | MeshGroup, matrix: Sequence[Sequence[float]]) -> Mesh | MeshGroup:
+def multmatrix(target, matrix: Sequence[Sequence[float]]):
     """Apply a 4x4 transform matrix."""
     mat = np.asarray(matrix, dtype=float)
     if mat.shape != (4, 4):
         raise ValueError("multmatrix requires a 4x4 matrix.")
-    if isinstance(mesh, MeshGroup):
-        mesh.multmatrix(mat)
-        return mesh
-    mesh.transform(mat, inplace=True)
-    return mesh
+    if _is_surface_body(target):
+        return target.with_transform(mat)
+    if isinstance(target, MeshGroup):
+        target.multmatrix(mat)
+        _mark_mesh_compatibility(target, "multmatrix")
+        return target
+    target.transform(mat, inplace=True)
+    _mark_mesh_compatibility(target, "multmatrix")
+    return target
 
 
 def _axis_rotation_matrix(axis: Sequence[float], angle_deg: float) -> np.ndarray:
@@ -181,10 +213,25 @@ def _normalize_auto(auto: bool | Sequence[bool]) -> np.ndarray:
     return np.array([bool(auto)] * 3, dtype=bool)
 
 
-def _bounds(mesh: Mesh | MeshGroup) -> tuple[float, float, float, float, float, float]:
-    if isinstance(mesh, Mesh):
-        return mesh.bounds
-    meshes = mesh.to_meshes()
+def _is_surface_body(target: object) -> bool:
+    from .surface import SurfaceBody
+
+    return isinstance(target, SurfaceBody)
+
+
+def _mark_mesh_compatibility(target: object, operation: str) -> None:
+    record = TransformMeshCompatibilityResult(type(target).__name__, operation).canonical_payload()
+    metadata = getattr(target, "metadata", None)
+    if isinstance(metadata, dict):
+        metadata.setdefault("transform_mesh_compatibility", []).append(record)
+
+
+def _bounds(target) -> tuple[float, float, float, float, float, float]:
+    if _is_surface_body(target):
+        return target.bounds_estimate()
+    if isinstance(target, Mesh):
+        return target.bounds
+    meshes = target.to_meshes()
     if not meshes:
         return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     mins = np.array([np.inf, np.inf, np.inf], dtype=float)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 
 from impression.modeling import (
+    SurfaceBody,
+    TransformMeshCompatibilityResult,
     make_box,
     translate,
     rotate,
@@ -11,6 +13,7 @@ from impression.modeling import (
     resize,
     mirror,
     multmatrix,
+    tessellate_surface_body,
 )
 
 
@@ -19,13 +22,13 @@ def _bounds(mesh):
 
 
 def test_translate_bounds():
-    base = make_box(size=(2.0, 4.0, 6.0))
+    base = make_box(size=(2.0, 4.0, 6.0), backend="mesh")
     moved = translate(base.copy(), (1.0, 2.0, 3.0))
     assert np.allclose(_bounds(moved), np.array([0.0, 2.0, 0.0, 4.0, 0.0, 6.0]))
 
 
 def test_rotate_axis_z_90():
-    base = make_box(size=(2.0, 4.0, 1.0))
+    base = make_box(size=(2.0, 4.0, 1.0), backend="mesh")
     turned = rotate(base.copy(), axis=(0.0, 0.0, 1.0), angle_deg=90.0)
     bounds = _bounds(turned)
     assert np.allclose(bounds[[0, 1]], [-2.0, 2.0], atol=1e-6)
@@ -33,7 +36,7 @@ def test_rotate_axis_z_90():
 
 
 def test_rotate_euler_matches_sequential():
-    base = make_box(size=(1.0, 2.0, 3.0))
+    base = make_box(size=(1.0, 2.0, 3.0), backend="mesh")
     sequential = rotate(base.copy(), axis=(1.0, 0.0, 0.0), angle_deg=10.0)
     sequential = rotate(sequential, axis=(0.0, 1.0, 0.0), angle_deg=20.0)
     sequential = rotate(sequential, axis=(0.0, 0.0, 1.0), angle_deg=30.0)
@@ -43,26 +46,69 @@ def test_rotate_euler_matches_sequential():
 
 
 def test_scale_bounds():
-    base = make_box(size=(2.0, 4.0, 6.0))
+    base = make_box(size=(2.0, 4.0, 6.0), backend="mesh")
     scaled = scale(base.copy(), (2.0, 0.5, 1.0))
     assert np.allclose(_bounds(scaled), np.array([-2.0, 2.0, -1.0, 1.0, -3.0, 3.0]))
 
 
 def test_resize_auto_axes():
-    base = make_box(size=(2.0, 4.0, 6.0))
+    base = make_box(size=(2.0, 4.0, 6.0), backend="mesh")
     resized = resize(base.copy(), (4.0, 0.0, 0.0), auto=[False, True, True])
     assert np.allclose(_bounds(resized), np.array([-2.0, 2.0, -4.0, 4.0, -6.0, 6.0]))
 
 
 def test_mirror_flips_axis():
-    base = make_box(size=(2.0, 2.0, 2.0), center=(2.0, 0.0, 0.0))
+    base = make_box(size=(2.0, 2.0, 2.0), center=(2.0, 0.0, 0.0), backend="mesh")
     flipped = mirror(base.copy(), (1.0, 0.0, 0.0))
     assert np.allclose(_bounds(flipped)[[0, 1]], [-3.0, -1.0])
 
 
 def test_multmatrix_translation():
-    base = make_box(size=(2.0, 2.0, 2.0))
+    base = make_box(size=(2.0, 2.0, 2.0), backend="mesh")
     mat = np.eye(4)
     mat[:3, 3] = [1.0, 2.0, 3.0]
     moved = multmatrix(base.copy(), mat)
     assert np.allclose(_bounds(moved), np.array([0.0, 2.0, 1.0, 3.0, 2.0, 4.0]))
+
+
+def test_translate_surface_body_preserves_native_body_until_tessellation():
+    base = make_box(size=(2.0, 2.0, 2.0))
+    moved = translate(base, (1.0, 2.0, 3.0))
+
+    assert isinstance(base, SurfaceBody)
+    assert isinstance(moved, SurfaceBody)
+    assert moved is not base
+    assert np.allclose(base.transform_matrix, np.eye(4))
+    assert np.allclose(moved.transform_matrix[:3, 3], [1.0, 2.0, 3.0])
+
+    mesh = tessellate_surface_body(moved).mesh
+    assert np.allclose(_bounds(mesh), np.array([0.0, 2.0, 1.0, 3.0, 2.0, 4.0]))
+
+
+def test_surface_transform_family_returns_surface_bodies():
+    base = make_box(size=(2.0, 2.0, 2.0))
+    mat = np.eye(4)
+    mat[:3, 3] = [0.5, 0.0, 0.0]
+
+    transformed = [
+        rotate(base, axis=(0.0, 0.0, 1.0), angle_deg=45.0),
+        rotate_euler(base, angles_deg=(5.0, 10.0, 15.0)),
+        scale(base, (2.0, 1.0, 1.0)),
+        resize(base, (4.0, 0.0, 0.0), auto=[False, True, True]),
+        mirror(base, (1.0, 0.0, 0.0)),
+        multmatrix(base, mat),
+    ]
+
+    assert all(isinstance(body, SurfaceBody) for body in transformed)
+    assert all(not np.allclose(body.transform_matrix, np.eye(4)) for body in transformed)
+
+
+def test_mesh_transform_records_explicit_compatibility_boundary():
+    mesh = make_box(size=(1.0, 1.0, 1.0), backend="mesh")
+
+    moved = translate(mesh, (1.0, 0.0, 0.0))
+
+    assert moved is mesh
+    assert mesh.metadata["transform_mesh_compatibility"] == [
+        TransformMeshCompatibilityResult("Mesh", "translate").canonical_payload()
+    ]


### PR DESCRIPTION
## Summary
- route transform helpers through SurfaceBody transform state by default
- keep explicit mesh inputs on the compatibility path with metadata records
- add surface-native transform and tessellation-boundary coverage

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_transforms.py -q
- PYTHONPATH=src .venv/bin/pytest tests/test_transforms.py tests/test_surface.py tests/test_surface_replacements.py -q

Note: a broader run including tests/test_surface_kernel.py hit an existing trim-boundary validation timing expectation unrelated to this branch.