### PR TITLE
Mark MeshGroup as explicit compatibility API

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -400,7 +400,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 182: Surface Transform API Defaults (v1.0)](../specifications/surface-182-surface-transform-api-defaults-v1_0.md)
 - [x] [Surface Spec 183: Surface Composition Public Type (v1.0)](../specifications/surface-183-surface-composition-public-type-v1_0.md)
 - [x] [Surface Spec 184: Surface Composition Traversal And Tessellation Handoff (v1.0)](../specifications/surface-184-surface-composition-traversal-and-tessellation-handoff-v1_0.md)
-- [ ] [Surface Spec 185: MeshGroup Explicit Compatibility API (v1.0)](../specifications/surface-185-meshgroup-explicit-compatibility-api-v1_0.md)
+- [x] [Surface Spec 185: MeshGroup Explicit Compatibility API (v1.0)](../specifications/surface-185-meshgroup-explicit-compatibility-api-v1_0.md)
 - [ ] [Surface Spec 186: MeshGroup Import Boundary Enforcement (v1.0)](../specifications/surface-186-meshgroup-import-boundary-enforcement-v1_0.md)
 - [ ] [Surface Spec 187: Mesh Utility Quarantine (v1.0)](../specifications/surface-187-mesh-utility-quarantine-v1_0.md)
 - [ ] [Surface Spec 188: No Hidden Mesh Fallback Enforcement (v1.0)](../specifications/surface-188-no-hidden-mesh-fallback-enforcement-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -220,7 +220,15 @@ from .csg import (
     union_meshes,
 )
 from .paths import Path
-from .group import MeshGroup, group
+from .group import (
+    MESH_GROUP_COMPATIBILITY_BOUNDARY,
+    MESH_GROUP_COMPATIBILITY_CLASSIFICATION,
+    MeshGroup,
+    MeshGroupCompatibilityDiagnostic,
+    MeshGroupCompatibilityError,
+    group,
+    mesh_group_compatibility_diagnostic,
+)
 from .ops import offset, hull
 from .heightmap import (
     HeightmapAlphaMaskPolicy,
@@ -604,8 +612,13 @@ __all__ = [
     "surface_boolean_result",
     "union_meshes",
     "Path",
+    "MESH_GROUP_COMPATIBILITY_BOUNDARY",
+    "MESH_GROUP_COMPATIBILITY_CLASSIFICATION",
     "MeshGroup",
+    "MeshGroupCompatibilityDiagnostic",
+    "MeshGroupCompatibilityError",
     "group",
+    "mesh_group_compatibility_diagnostic",
     "TransformMeshCompatibilityResult",
     "rotate",
     "translate",

--- a/src/impression/modeling/group.py
+++ b/src/impression/modeling/group.py
@@ -7,6 +7,9 @@ import numpy as np
 
 from impression.mesh import Mesh, combine_meshes
 
+MESH_GROUP_COMPATIBILITY_CLASSIFICATION = "mesh-compatibility"
+MESH_GROUP_COMPATIBILITY_BOUNDARY = "explicit-mesh-group-compatibility"
+
 
 def _normalize_axis(axis: Sequence[float]) -> np.ndarray:
     vec = np.asarray(axis, dtype=float).reshape(3)
@@ -105,6 +108,34 @@ def _rotation_euler_matrix(angles_deg: Sequence[float], origin: Sequence[float],
     return back @ mat @ to_origin
 
 
+@dataclass(frozen=True)
+class MeshGroupCompatibilityDiagnostic:
+    """Diagnostic proving MeshGroup is an explicit mesh compatibility boundary."""
+
+    target_type: str
+    reason: str = "MeshGroup accepts mesh inputs only"
+    boundary: str = MESH_GROUP_COMPATIBILITY_BOUNDARY
+    classification: str = MESH_GROUP_COMPATIBILITY_CLASSIFICATION
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "boundary": self.boundary,
+            "classification": self.classification,
+            "reason": self.reason,
+            "target_type": self.target_type,
+        }
+
+
+class MeshGroupCompatibilityError(TypeError):
+    """Raised when a non-mesh value crosses into MeshGroup compatibility APIs."""
+
+    def __init__(self, diagnostic: MeshGroupCompatibilityDiagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(
+            f"Unsupported {diagnostic.target_type} at MeshGroup compatibility boundary: {diagnostic.reason}."
+        )
+
+
 @dataclass
 class MeshGroup:
     """Hold multiple meshes and apply shared transforms."""
@@ -113,7 +144,22 @@ class MeshGroup:
     _transform: np.ndarray = field(default_factory=lambda: np.eye(4))
     metadata: dict[str, object] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self._transform = np.asarray(self._transform, dtype=float).reshape(4, 4)
+        self.metadata = dict(self.metadata)
+        self.metadata.setdefault("mesh_group_compatibility", self.compatibility_diagnostic().canonical_payload())
+        for mesh in self.meshes:
+            _ensure_mesh_input(mesh)
+
+    @property
+    def classification(self) -> str:
+        return MESH_GROUP_COMPATIBILITY_CLASSIFICATION
+
+    def compatibility_diagnostic(self) -> MeshGroupCompatibilityDiagnostic:
+        return MeshGroupCompatibilityDiagnostic(target_type=type(self).__name__)
+
     def add(self, mesh: Mesh) -> "MeshGroup":
+        _ensure_mesh_input(mesh)
         self.meshes.append(mesh)
         return self
 
@@ -164,3 +210,20 @@ def group(meshes: Iterable[Mesh]) -> MeshGroup:
     for m in meshes:
         grp.add(m)
     return grp
+
+
+def mesh_group_compatibility_diagnostic(target: object) -> MeshGroupCompatibilityDiagnostic:
+    if isinstance(target, MeshGroup):
+        return target.compatibility_diagnostic()
+    if isinstance(target, Mesh):
+        return MeshGroupCompatibilityDiagnostic(target_type=type(target).__name__)
+    return MeshGroupCompatibilityDiagnostic(
+        target_type=type(target).__name__,
+        reason="surface-authored values must use SurfaceComposition instead of MeshGroup",
+    )
+
+
+def _ensure_mesh_input(target: object) -> None:
+    if isinstance(target, Mesh):
+        return
+    raise MeshGroupCompatibilityError(mesh_group_compatibility_diagnostic(target))

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from impression.modeling import (
+    MESH_GROUP_COMPATIBILITY_BOUNDARY,
+    MESH_GROUP_COMPATIBILITY_CLASSIFICATION,
+    MeshGroupCompatibilityError,
     SurfaceBody,
     TransformMeshCompatibilityResult,
+    group,
     make_box,
     translate,
     rotate,
@@ -112,3 +117,26 @@ def test_mesh_transform_records_explicit_compatibility_boundary():
     assert mesh.metadata["transform_mesh_compatibility"] == [
         TransformMeshCompatibilityResult("Mesh", "translate").canonical_payload()
     ]
+
+
+def test_mesh_group_is_explicit_compatibility_api():
+    mesh = make_box(size=(1.0, 1.0, 1.0), backend="mesh")
+
+    grp = group([mesh])
+
+    assert grp.classification == MESH_GROUP_COMPATIBILITY_CLASSIFICATION
+    assert grp.metadata["mesh_group_compatibility"]["boundary"] == MESH_GROUP_COMPATIBILITY_BOUNDARY
+    assert grp.metadata["mesh_group_compatibility"]["classification"] == MESH_GROUP_COMPATIBILITY_CLASSIFICATION
+    assert grp.to_mesh().vertices.shape[0] == mesh.vertices.shape[0]
+
+
+def test_mesh_group_rejects_surface_body_inputs_with_diagnostic():
+    body = make_box(size=(1.0, 1.0, 1.0))
+
+    with pytest.raises(MeshGroupCompatibilityError) as exc:
+        group([body])
+
+    diagnostic = exc.value.diagnostic
+    assert diagnostic.boundary == MESH_GROUP_COMPATIBILITY_BOUNDARY
+    assert diagnostic.target_type == "SurfaceBody"
+    assert "SurfaceComposition" in diagnostic.reason


### PR DESCRIPTION
## Summary
- classify MeshGroup as an explicit mesh compatibility boundary
- add MeshGroup diagnostics and errors for non-mesh inputs
- test mesh grouping behavior and surface API separation

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_transforms.py tests/test_surface.py -q