### PR TITLE
Quarantine retained mesh utilities

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -402,5 +402,5 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 184: Surface Composition Traversal And Tessellation Handoff (v1.0)](../specifications/surface-184-surface-composition-traversal-and-tessellation-handoff-v1_0.md)
 - [x] [Surface Spec 185: MeshGroup Explicit Compatibility API (v1.0)](../specifications/surface-185-meshgroup-explicit-compatibility-api-v1_0.md)
 - [x] [Surface Spec 186: MeshGroup Import Boundary Enforcement (v1.0)](../specifications/surface-186-meshgroup-import-boundary-enforcement-v1_0.md)
-- [ ] [Surface Spec 187: Mesh Utility Quarantine (v1.0)](../specifications/surface-187-mesh-utility-quarantine-v1_0.md)
+- [x] [Surface Spec 187: Mesh Utility Quarantine (v1.0)](../specifications/surface-187-mesh-utility-quarantine-v1_0.md)
 - [ ] [Surface Spec 188: No Hidden Mesh Fallback Enforcement (v1.0)](../specifications/surface-188-no-hidden-mesh-fallback-enforcement-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -230,6 +230,12 @@ from .group import (
     mesh_group_compatibility_diagnostic,
 )
 from .ops import offset, hull
+from .mesh_tools import (
+    MESH_TOOL_BOUNDARY,
+    MESH_TOOL_CLASSIFICATION,
+    MeshUtilityClassification,
+    classify_mesh_utility,
+)
 from .heightmap import (
     HeightmapAlphaMaskPolicy,
     HeightmapCacheKeyRecord,
@@ -629,6 +635,10 @@ __all__ = [
     "rotate_euler",
     "offset",
     "hull",
+    "MESH_TOOL_BOUNDARY",
+    "MESH_TOOL_CLASSIFICATION",
+    "MeshUtilityClassification",
+    "classify_mesh_utility",
     "heightmap",
     "displace_heightmap",
     "HeightmapAlphaMaskPolicy",

--- a/src/impression/modeling/mesh_tools/__init__.py
+++ b/src/impression/modeling/mesh_tools/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from impression.mesh import Mesh, MeshAnalysis, analyze_mesh, repair_mesh, section_mesh_with_plane
+from impression.modeling._ops_mesh import hull_mesh, manifold_from_mesh_group, mesh_from_manifold
+
+MESH_TOOL_BOUNDARY = "explicit-mesh-tool"
+MESH_TOOL_CLASSIFICATION = "mesh-utility-quarantine"
+
+
+@dataclass(frozen=True)
+class MeshUtilityClassification:
+    """Classification record for retained mesh utilities."""
+
+    symbol: str
+    module: str
+    purpose: str = "analysis-repair-debugging"
+    boundary: str = MESH_TOOL_BOUNDARY
+    classification: str = MESH_TOOL_CLASSIFICATION
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "boundary": self.boundary,
+            "classification": self.classification,
+            "module": self.module,
+            "purpose": self.purpose,
+            "symbol": self.symbol,
+        }
+
+
+def classify_mesh_utility(symbol: str, *, module: str = "impression.modeling.mesh_tools") -> MeshUtilityClassification:
+    return MeshUtilityClassification(symbol=str(symbol), module=str(module))
+
+
+__all__ = [
+    "MESH_TOOL_BOUNDARY",
+    "MESH_TOOL_CLASSIFICATION",
+    "Mesh",
+    "MeshAnalysis",
+    "MeshUtilityClassification",
+    "analyze_mesh",
+    "classify_mesh_utility",
+    "hull_mesh",
+    "manifold_from_mesh_group",
+    "mesh_from_manifold",
+    "repair_mesh",
+    "section_mesh_with_plane",
+]

--- a/src/impression/modeling/ops.py
+++ b/src/impression/modeling/ops.py
@@ -7,7 +7,7 @@ from impression.modeling.drawing2d import Path2D
 from impression.modeling.group import MeshGroup
 from impression.modeling.topology import Region, Section
 
-from ._ops_mesh import hull_mesh
+from .mesh_tools import hull_mesh
 from ._ops_planar import hull_planar, is_planar_shape, offset_planar
 
 
@@ -45,7 +45,7 @@ def hull(shapes: Iterable[Mesh | MeshGroup | Section | Region | Path2D]) -> Mesh
     Dispatches to internal domain modules:
 
     - planar inputs (`Section`, `Region`, `Path2D`) -> `_ops_planar`
-    - mesh inputs (`Mesh`, `MeshGroup`) -> `_ops_mesh`
+    - mesh inputs (`Mesh`, `MeshGroup`) -> `modeling.mesh_tools`
 
     Mesh hull behavior is retained as an explicit standalone utility. It is not
     canonical surfaced modeling truth.

--- a/tests/test_mesh_utility_quarantine.py
+++ b/tests/test_mesh_utility_quarantine.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from impression.modeling import (
+    MESH_TOOL_BOUNDARY,
+    MESH_TOOL_CLASSIFICATION,
+    MeshUtilityClassification,
+    classify_mesh_utility,
+    make_box,
+)
+from impression.modeling import mesh_tools
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MODELING_ROOT = PROJECT_ROOT / "src" / "impression" / "modeling"
+
+MESH_TOOL_ALLOWED_MODULES = {
+    "_ops_mesh.py",
+    "mesh_tools/__init__.py",
+}
+
+
+@dataclass(frozen=True)
+class MeshUtilityImportBoundaryViolation:
+    """Diagnostic for modules importing retained mesh tools outside quarantine."""
+
+    path: str
+    imported_module: str
+    line: int
+    boundary: str = "mesh-utility-quarantine"
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "boundary": self.boundary,
+            "imported_module": self.imported_module,
+            "line": self.line,
+            "path": self.path,
+        }
+
+
+def _mesh_utility_import_violations() -> list[MeshUtilityImportBoundaryViolation]:
+    violations: list[MeshUtilityImportBoundaryViolation] = []
+    for path in sorted(MODELING_ROOT.rglob("*.py")):
+        relative = path.relative_to(MODELING_ROOT).as_posix()
+        if relative in MESH_TOOL_ALLOWED_MODULES:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = node.module or ""
+            imports_legacy_ops = module == "impression.modeling._ops_mesh" or (
+                node.level == 1 and module == "_ops_mesh"
+            )
+            if imports_legacy_ops:
+                violations.append(
+                    MeshUtilityImportBoundaryViolation(
+                        path=f"src/impression/modeling/{relative}",
+                        imported_module=module,
+                        line=node.lineno,
+                    )
+                )
+    return violations
+
+
+def test_mesh_utility_namespace_classifies_retained_tools() -> None:
+    classification = classify_mesh_utility("hull_mesh")
+
+    assert isinstance(classification, MeshUtilityClassification)
+    assert classification.boundary == MESH_TOOL_BOUNDARY
+    assert classification.classification == MESH_TOOL_CLASSIFICATION
+    assert classification.canonical_payload()["symbol"] == "hull_mesh"
+
+
+def test_mesh_tools_namespace_re_exports_retained_mesh_analysis_tooling() -> None:
+    mesh = make_box(size=(1.0, 1.0, 1.0), backend="mesh")
+
+    analysis = mesh_tools.analyze_mesh(mesh)
+
+    assert analysis.n_vertices == mesh.n_vertices
+    assert analysis.n_faces == mesh.n_faces
+
+
+def test_modeling_modules_route_mesh_utilities_through_quarantine_namespace() -> None:
+    violations = _mesh_utility_import_violations()
+
+    assert [violation.canonical_payload() for violation in violations] == []
+
+
+def test_public_hull_route_imports_mesh_tools_namespace() -> None:
+    ops_source = (MODELING_ROOT / "ops.py").read_text()
+
+    assert "from .mesh_tools import hull_mesh" in ops_source
+    assert "from ._ops_mesh import hull_mesh" not in ops_source


### PR DESCRIPTION
## Summary
- add modeling.mesh_tools as the explicit mesh utility quarantine namespace
- route public hull mesh utility imports through mesh_tools
- add static import-boundary and classification tests

## Verification
- PYTHONPATH=src .venv/bin/pytest tests/test_mesh_utility_quarantine.py tests/test_meshgroup_import_boundary.py tests/test_transforms.py tests/test_surface.py -q