### PR TITLE
Implement spline spline surface intersections

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -486,7 +486,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 268: Intersection Request And Solver Registry (v1.0)](../specifications/surface-268-intersection-request-and-solver-registry-v1_0.md)
 - [x] [Surface Spec 269: Intersection Curve Result And Degeneracy Records (v1.0)](../specifications/surface-269-intersection-curve-result-and-degeneracy-records-v1_0.md)
 - [x] [Surface Spec 270: Analytic To Spline Surface Intersection Solvers (v1.0)](../specifications/surface-270-analytic-to-spline-surface-intersection-solvers-v1_0.md)
-- [ ] [Surface Spec 271: Spline To Spline Surface Intersection Solvers (v1.0)](../specifications/surface-271-spline-to-spline-surface-intersection-solvers-v1_0.md)
+- [x] [Surface Spec 271: Spline To Spline Surface Intersection Solvers (v1.0)](../specifications/surface-271-spline-to-spline-surface-intersection-solvers-v1_0.md)
 - [ ] [Surface Spec 272: Subdivision Surface Intersection Adapter (v1.0)](../specifications/surface-272-subdivision-surface-intersection-adapter-v1_0.md)
 - [ ] [Surface Spec 273: Implicit Intersection Safety And Budget Policy (v1.0)](../specifications/surface-273-implicit-intersection-safety-and-budget-policy-v1_0.md)
 - [ ] [Surface Spec 274: Bounded Implicit Contour Extraction Adapter (v1.0)](../specifications/surface-274-bounded-implicit-contour-extraction-adapter-v1_0.md)

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -542,6 +542,8 @@ from .surface_intersections import (
     SurfaceIntersectionSolverRegistryRecord,
     SurfaceIntersectionSupportDiagnostic,
     SurfaceIntersectionTolerancePolicy,
+    SurfaceSplineSplineResidualReport,
+    SurfaceSplineSplineSolverIterationRecord,
     assert_surface_intersection_solver_registry_complete,
     build_surface_intersection_solver_registry,
     classify_surface_intersection_degeneracy,
@@ -549,6 +551,7 @@ from .surface_intersections import (
     make_surface_intersection_request,
     normalize_surface_intersection_result,
     solve_analytic_spline_surface_intersection,
+    solve_spline_spline_surface_intersection,
 )
 from .tessellation import (
     AdapterLossiness,
@@ -1133,6 +1136,8 @@ __all__ = [
     "SurfaceIntersectionSolverRegistryRecord",
     "SurfaceIntersectionSupportDiagnostic",
     "SurfaceIntersectionTolerancePolicy",
+    "SurfaceSplineSplineResidualReport",
+    "SurfaceSplineSplineSolverIterationRecord",
     "assert_surface_intersection_solver_registry_complete",
     "build_surface_intersection_solver_registry",
     "classify_surface_intersection_degeneracy",
@@ -1140,6 +1145,7 @@ __all__ = [
     "make_surface_intersection_request",
     "normalize_surface_intersection_result",
     "solve_analytic_spline_surface_intersection",
+    "solve_spline_spline_surface_intersection",
     "AdapterLossiness",
     "CrossModeDriftReport",
     "FeatureSurfaceHandoffDiagnostic",

--- a/src/impression/modeling/surface_intersections.py
+++ b/src/impression/modeling/surface_intersections.py
@@ -220,6 +220,47 @@ class SurfaceAnalyticSplineResidualReport:
 
 
 @dataclass(frozen=True)
+class SurfaceSplineSplineSolverIterationRecord:
+    """Bounded pairing/refinement witness for spline-to-spline solves."""
+
+    first_sample_count: int
+    second_sample_count: int
+    accepted_pair_count: int
+    max_residual: float
+    converged: bool
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "accepted_pair_count": self.accepted_pair_count,
+            "converged": self.converged,
+            "first_sample_count": self.first_sample_count,
+            "max_residual": self.max_residual,
+            "second_sample_count": self.second_sample_count,
+        }
+
+
+@dataclass(frozen=True)
+class SurfaceSplineSplineResidualReport:
+    """Residual and diagnostic report for a spline-to-spline solve."""
+
+    solver_id: str
+    iterations: tuple[SurfaceSplineSplineSolverIterationRecord, ...]
+    diagnostics: tuple[SurfaceIntersectionSupportDiagnostic, ...] = ()
+
+    @property
+    def converged(self) -> bool:
+        return bool(self.iterations) and self.iterations[-1].converged and not self.diagnostics
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "converged": self.converged,
+            "diagnostics": [diagnostic.canonical_payload() for diagnostic in self.diagnostics],
+            "iterations": [iteration.canonical_payload() for iteration in self.iterations],
+            "solver_id": self.solver_id,
+        }
+
+
+@dataclass(frozen=True)
 class SurfaceIntersectionCurveRecord:
     """One normalized intersection curve or sampled curve segment."""
 
@@ -635,6 +676,122 @@ def solve_analytic_spline_surface_intersection(
     )
 
 
+def _sample_spline_surface_points(
+    patch: SurfacePatch,
+    sample_count: int,
+) -> tuple[tuple[tuple[float, float, float], tuple[float, float]], ...]:
+    u0, u1 = patch.domain.u_range
+    v0, v1 = patch.domain.v_range
+    return tuple(
+        (
+            tuple(float(component) for component in patch.point_at(float(u), float(v))),
+            (float(u), float(v)),
+        )
+        for u in np.linspace(u0, u1, sample_count)
+        for v in np.linspace(v0, v1, sample_count)
+    )
+
+
+def solve_spline_spline_surface_intersection(
+    request: SurfaceIntersectionRequest,
+    *,
+    sample_count: int = 13,
+) -> tuple[SurfaceIntersectionResultRecord, SurfaceSplineSplineResidualReport]:
+    """Solve B-spline/NURBS pairs by bounded declared-tolerance closest sample pairing."""
+
+    dispatch = lookup_surface_intersection_solver(request)
+    if not dispatch.supported or dispatch.solver is None or dispatch.solver.solver_id != "spline-spline-declared-tolerance":
+        diagnostic = SurfaceIntersectionSupportDiagnostic(
+            code="unsupported-family-pair",
+            consumer=request.consumer,
+            family_pair=request.normalized_family_pair,
+            message="spline-to-spline solver requires a declared-tolerance spline/spline registry dispatch",
+        )
+        return (
+            normalize_surface_intersection_result(request, quality="unsupported"),
+            SurfaceSplineSplineResidualReport(
+                solver_id="spline-spline-declared-tolerance",
+                iterations=(),
+                diagnostics=(diagnostic,),
+            ),
+        )
+    if not (_surface_intersection_is_spline_family(request.first_patch) and _surface_intersection_is_spline_family(request.second_patch)):
+        diagnostic = SurfaceIntersectionSupportDiagnostic(
+            code="unsupported-family-pair",
+            consumer=request.consumer,
+            family_pair=request.normalized_family_pair,
+            message="spline-to-spline solver requires two B-spline or NURBS surfaces",
+        )
+        return (
+            normalize_surface_intersection_result(request, quality="unsupported"),
+            SurfaceSplineSplineResidualReport(
+                solver_id=dispatch.solver.solver_id,
+                iterations=(),
+                diagnostics=(diagnostic,),
+            ),
+        )
+
+    sample_count = max(3, int(sample_count))
+    first_samples = _sample_spline_surface_points(request.first_patch, sample_count)
+    second_samples = _sample_spline_surface_points(request.second_patch, sample_count)
+    threshold = max(request.tolerance_policy.position_tolerance * 10.0, request.tolerance_policy.degeneracy_tolerance)
+    accepted: list[tuple[tuple[float, float, float], tuple[float, float], tuple[float, float], float]] = []
+    for first_point, first_uv in first_samples:
+        first_array = np.asarray(first_point, dtype=float)
+        nearest_point, nearest_uv = min(
+            second_samples,
+            key=lambda sample: float(np.linalg.norm(first_array - np.asarray(sample[0], dtype=float))),
+        )
+        residual = float(np.linalg.norm(first_array - np.asarray(nearest_point, dtype=float)))
+        if residual <= threshold:
+            midpoint = tuple(float(component) for component in ((first_array + np.asarray(nearest_point, dtype=float)) * 0.5))
+            accepted.append((midpoint, first_uv, nearest_uv, residual))
+
+    accepted = sorted(set(accepted), key=lambda item: (item[1], item[2], item[0]))
+    max_residual = max((item[3] for item in accepted), default=float("inf"))
+    converged = len(accepted) >= 2 and max_residual <= threshold
+    iteration = SurfaceSplineSplineSolverIterationRecord(
+        first_sample_count=len(first_samples),
+        second_sample_count=len(second_samples),
+        accepted_pair_count=len(accepted),
+        max_residual=max_residual if np.isfinite(max_residual) else 0.0,
+        converged=converged,
+    )
+    diagnostics: tuple[SurfaceIntersectionSupportDiagnostic, ...] = ()
+    if not converged:
+        diagnostics = (
+            SurfaceIntersectionSupportDiagnostic(
+                code="unsupported-family-pair",
+                consumer=request.consumer,
+                family_pair=request.normalized_family_pair,
+                message="spline-to-spline solver did not converge within declared tolerance sampling budget",
+            ),
+        )
+        result = normalize_surface_intersection_result(request, quality="unsupported")
+    else:
+        curve = SurfaceIntersectionCurveRecord(
+            curve_id="spline-spline-curve-0",
+            kind="sampled",
+            points_3d=tuple(item[0] for item in accepted),
+            first_parameters=tuple(item[1] for item in accepted),
+            second_parameters=tuple(item[2] for item in accepted),
+        )
+        result = normalize_surface_intersection_result(
+            request,
+            curves=(curve,),
+            max_residual=iteration.max_residual,
+            quality="within-tolerance",
+        )
+    return (
+        result,
+        SurfaceSplineSplineResidualReport(
+            solver_id=dispatch.solver.solver_id,
+            iterations=(iteration,),
+            diagnostics=diagnostics,
+        ),
+    )
+
+
 def _promoted_surface_family_names() -> tuple[str, ...]:
     return tuple(sorted(PATCH_FAMILY_CAPABILITY_MATRIX))
 
@@ -648,8 +805,11 @@ def _default_surface_intersection_solver_records() -> tuple[SurfaceIntersectionS
     }
     declared_tolerance_pairs = {
         ("bspline", "planar"): "analytic-spline-declared-tolerance",
+        ("bspline", "bspline"): "spline-spline-declared-tolerance",
+        ("bspline", "nurbs"): "spline-spline-declared-tolerance",
         ("bspline", "revolution"): "analytic-spline-declared-tolerance",
         ("bspline", "ruled"): "analytic-spline-declared-tolerance",
+        ("nurbs", "nurbs"): "spline-spline-declared-tolerance",
         ("nurbs", "planar"): "analytic-spline-declared-tolerance",
         ("nurbs", "revolution"): "analytic-spline-declared-tolerance",
         ("nurbs", "ruled"): "analytic-spline-declared-tolerance",
@@ -815,6 +975,8 @@ __all__ = [
     "SurfaceIntersectionSupportDiagnostic",
     "SurfaceIntersectionSupportState",
     "SurfaceIntersectionTolerancePolicy",
+    "SurfaceSplineSplineResidualReport",
+    "SurfaceSplineSplineSolverIterationRecord",
     "assert_surface_intersection_solver_registry_complete",
     "build_surface_intersection_solver_registry",
     "classify_surface_intersection_degeneracy",
@@ -822,4 +984,5 @@ __all__ = [
     "make_surface_intersection_request",
     "normalize_surface_intersection_result",
     "solve_analytic_spline_surface_intersection",
+    "solve_spline_spline_surface_intersection",
 ]

--- a/tests/test_surface_intersections.py
+++ b/tests/test_surface_intersections.py
@@ -19,6 +19,8 @@ from impression.modeling import (
     SurfaceIntersectionSolverRegistryRecord,
     SurfaceIntersectionSupportDiagnostic,
     SurfaceIntersectionTolerancePolicy,
+    SurfaceSplineSplineResidualReport,
+    SurfaceSplineSplineSolverIterationRecord,
     assert_surface_intersection_solver_registry_complete,
     build_surface_intersection_solver_registry,
     classify_surface_intersection_degeneracy,
@@ -26,6 +28,7 @@ from impression.modeling import (
     make_surface_intersection_request,
     normalize_surface_intersection_result,
     solve_analytic_spline_surface_intersection,
+    solve_spline_spline_surface_intersection,
 )
 
 
@@ -245,4 +248,55 @@ def test_analytic_spline_solver_refuses_non_analytic_spline_pairs() -> None:
     assert result.classification == "unsupported"
     assert report.converged is False
     assert all(isinstance(diagnostic, SurfaceIntersectionSupportDiagnostic) for diagnostic in report.diagnostics)
+    assert report.diagnostics[0].code == "unsupported-family-pair"
+
+
+def test_spline_spline_solver_intersects_bspline_nurbs_with_declared_tolerance() -> None:
+    first = BSplineSurfacePatch(family="bspline")
+    second = NURBSSurfacePatch(family="nurbs")
+    request = make_surface_intersection_request(first, second, consumer="csg")
+
+    result, report = solve_spline_spline_surface_intersection(request, sample_count=5)
+
+    assert result.supported is True
+    assert result.classification == "curves"
+    assert result.curves[0].first_parameters
+    assert result.curves[0].second_parameters
+    assert isinstance(report, SurfaceSplineSplineResidualReport)
+    assert report.converged is True
+    assert all(isinstance(iteration, SurfaceSplineSplineSolverIterationRecord) for iteration in report.iterations)
+    assert report.iterations[0].accepted_pair_count >= 2
+
+
+def test_spline_spline_solver_reports_overlap_degeneracy_for_identical_surfaces() -> None:
+    request = make_surface_intersection_request(
+        BSplineSurfacePatch(family="bspline"),
+        BSplineSurfacePatch(family="bspline"),
+        consumer="seam",
+    )
+
+    result, report = solve_spline_spline_surface_intersection(request, sample_count=3)
+
+    assert report.converged is True
+    assert result.quality in {"within-tolerance", "degenerate"}
+    assert result.curves
+    assert result.max_residual == pytest.approx(0.0)
+
+
+def test_spline_spline_solver_refuses_non_convergent_spline_pair() -> None:
+    first = BSplineSurfacePatch(family="bspline")
+    second = BSplineSurfacePatch(
+        family="bspline",
+        control_net=[
+            [(10.0, 0.0, 0.0), (10.0, 1.0, 0.0)],
+            [(11.0, 0.0, 0.0), (11.0, 1.0, 0.0)],
+        ],
+    )
+    request = make_surface_intersection_request(first, second, consumer="loft")
+
+    result, report = solve_spline_spline_surface_intersection(request, sample_count=5)
+
+    assert result.supported is False
+    assert result.classification == "unsupported"
+    assert report.converged is False
     assert report.diagnostics[0].code == "unsupported-family-pair"


### PR DESCRIPTION
## Summary
- promote B-spline/NURBS pairs in the shared surface intersection registry as declared-tolerance solvers
- add bounded spline-to-spline closest-sample residual report and solver helper
- cover B-spline/NURBS convergence, identical-surface behavior, and non-convergence refusal
- mark Surface Spec 271 complete

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_surface_intersections.py -q
- git diff --check