### PR TITLE
Implement dirty promoted reference gate

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -492,7 +492,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 274: Bounded Implicit Contour Extraction Adapter (v1.0)](../specifications/surface-274-bounded-implicit-contour-extraction-adapter-v1_0.md)
 - [x] [Surface Spec 275: Implicit Intersection Residual And Result Classification (v1.0)](../specifications/surface-275-implicit-intersection-residual-and-result-classification-v1_0.md)
 - [x] [Surface Spec 276: Surface Reference Requirement Matrix (v1.0)](../specifications/surface-276-surface-reference-requirement-matrix-v1_0.md)
-- [ ] [Surface Spec 277: Dirty Versus Promoted Reference Artifact Gate (v1.0)](../specifications/surface-277-dirty-versus-promoted-reference-artifact-gate-v1_0.md)
+- [x] [Surface Spec 277: Dirty Versus Promoted Reference Artifact Gate (v1.0)](../specifications/surface-277-dirty-versus-promoted-reference-artifact-gate-v1_0.md)
 - [ ] [Surface Spec 278: Diagnostic Snapshot Normalization (v1.0)](../specifications/surface-278-diagnostic-snapshot-normalization-v1_0.md)
 - [ ] [Surface Spec 279: Negative Diagnostic Fixture Matrix Core (v1.0)](../specifications/surface-279-negative-diagnostic-fixture-matrix-core-v1_0.md)
 - [ ] [Surface Spec 280: .impress Unsafe Payload Negative Fixtures (v1.0)](../specifications/surface-280-impress-unsafe-payload-negative-fixtures-v1_0.md)

--- a/tests/reference_images.py
+++ b/tests/reference_images.py
@@ -88,6 +88,35 @@ class ReferenceFixturePairState:
 
 
 @dataclass(frozen=True)
+class ReferenceFixtureContractVersionRecord:
+    fixture_id: str
+    contract_version: str
+
+    def __post_init__(self) -> None:
+        if not self.fixture_id.strip():
+            raise ValueError("ReferenceFixtureContractVersionRecord.fixture_id must be non-empty.")
+        if not self.contract_version.strip():
+            raise ValueError("ReferenceFixtureContractVersionRecord.contract_version must be non-empty.")
+
+
+@dataclass(frozen=True)
+class ReferencePromotionDiagnostic:
+    code: Literal["missing-artifact", "dirty-artifact", "partial-fixture", "invalidated-contract"]
+    fixture_id: str
+    artifact_kind: ReferenceArtifactKind | Literal["fixture"]
+    message: str
+
+
+@dataclass(frozen=True)
+class ReferenceArtifactPromotionGateReport:
+    fixture_id: str
+    promoted: bool
+    state: ReferenceFixturePairState
+    contract: ReferenceFixtureContractVersionRecord
+    diagnostics: tuple[ReferencePromotionDiagnostic, ...]
+
+
+@dataclass(frozen=True)
 class CvFixtureContract:
     fixture_id: str
     lane: str
@@ -574,6 +603,33 @@ def reference_artifact_state(
     )
 
 
+def reference_artifact_contract_version_path(state: ReferenceArtifactState) -> Path:
+    return state.clean_path.with_suffix(state.clean_path.suffix + ".contract")
+
+
+def write_reference_artifact_contract_version(
+    state: ReferenceArtifactState,
+    contract: ReferenceFixtureContractVersionRecord,
+) -> Path:
+    path = reference_artifact_contract_version_path(state)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{contract.fixture_id}\n{contract.contract_version}\n", encoding="utf-8")
+    return path
+
+
+def reference_artifact_contract_version_matches(
+    state: ReferenceArtifactState,
+    contract: ReferenceFixtureContractVersionRecord,
+) -> bool:
+    if state.selected_tier != "clean":
+        return False
+    path = reference_artifact_contract_version_path(state)
+    if not path.exists():
+        return False
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return lines[:2] == [contract.fixture_id, contract.contract_version]
+
+
 def reference_fixture_pair_state(
     *,
     reference_image_root: Path,
@@ -583,6 +639,68 @@ def reference_fixture_pair_state(
     return ReferenceFixturePairState(
         image=reference_artifact_state(reference_image_root, name, kind="image"),
         stl=reference_artifact_state(reference_stl_root, name, kind="stl"),
+    )
+
+
+def classify_reference_fixture_pair_promotion_gate(
+    *,
+    reference_image_root: Path,
+    reference_stl_root: Path,
+    name: str,
+    contract_version: str = "v1",
+) -> ReferenceArtifactPromotionGateReport:
+    """Classify whether a reference fixture pair is promoted clean evidence."""
+
+    state = reference_fixture_pair_state(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name=name,
+    )
+    contract = ReferenceFixtureContractVersionRecord(fixture_id=name, contract_version=contract_version)
+    diagnostics: list[ReferencePromotionDiagnostic] = []
+    if state.has_partial_group:
+        diagnostics.append(
+            ReferencePromotionDiagnostic(
+                code="partial-fixture",
+                fixture_id=name,
+                artifact_kind="fixture",
+                message=f"{name} has a partial reference fixture group.",
+            )
+        )
+    for artifact_kind, artifact_state in (("image", state.image), ("stl", state.stl)):
+        if artifact_state.selected_tier == "missing":
+            diagnostics.append(
+                ReferencePromotionDiagnostic(
+                    code="missing-artifact",
+                    fixture_id=name,
+                    artifact_kind=artifact_kind,
+                    message=f"{name} is missing a promoted {artifact_kind} reference artifact.",
+                )
+            )
+        elif artifact_state.selected_tier == "dirty":
+            diagnostics.append(
+                ReferencePromotionDiagnostic(
+                    code="dirty-artifact",
+                    fixture_id=name,
+                    artifact_kind=artifact_kind,
+                    message=f"{name} has only a dirty {artifact_kind} reference artifact.",
+                )
+            )
+        elif not reference_artifact_contract_version_matches(artifact_state, contract):
+            diagnostics.append(
+                ReferencePromotionDiagnostic(
+                    code="invalidated-contract",
+                    fixture_id=name,
+                    artifact_kind=artifact_kind,
+                    message=f"{name} promoted {artifact_kind} reference artifact has no matching contract version.",
+                )
+            )
+    return ReferenceArtifactPromotionGateReport(
+        fixture_id=name,
+        promoted=not diagnostics,
+        state=state,
+        contract=contract,
+        diagnostics=tuple(diagnostics),
     )
 
 

--- a/tests/test_reference_images.py
+++ b/tests/test_reference_images.py
@@ -45,6 +45,7 @@ from tests.reference_images import (
     DiagnosticPanelContract,
     assess_cv_result,
     canonical_object_view_camera_contracts,
+    classify_reference_fixture_pair_promotion_gate,
     classify_handedness_from_silhouettes,
     clean_reference_path,
     clean_reference_stl_path,
@@ -66,7 +67,9 @@ from tests.reference_images import (
     HandednessSpaceAnchorContract,
     planar_loop_bounds,
     reference_artifact_state,
+    reference_artifact_contract_version_path,
     reference_fixture_pair_state,
+    write_reference_artifact_contract_version,
     required_reference_fixture_pair_failures,
     render_canonical_object_view_bundle,
     render_mesh_image_with_camera_contract,
@@ -337,6 +340,82 @@ def test_reference_fixture_pair_prefers_clean_baselines(tmp_path: Path) -> None:
 
     assert image_reference == clean_image
     assert stl_reference == clean_stl
+
+
+def test_reference_fixture_pair_promotion_gate_accepts_clean_contract_version(tmp_path: Path) -> None:
+    reference_image_root = tmp_path / "reference-images"
+    reference_stl_root = tmp_path / "reference-stl"
+    name = "demo/fixture"
+    _write_small_image(clean_reference_path(reference_image_root, name), color=(40, 50, 60))
+    _write_text_fixture(clean_reference_stl_path(reference_stl_root, name), "solid clean\nendsolid clean\n")
+    image_state = reference_artifact_state(reference_image_root, name, kind="image")
+    stl_state = reference_artifact_state(reference_stl_root, name, kind="stl")
+    write_reference_artifact_contract_version(
+        image_state,
+        classify_reference_fixture_pair_promotion_gate(
+            reference_image_root=reference_image_root,
+            reference_stl_root=reference_stl_root,
+            name=name,
+        ).contract,
+    )
+    write_reference_artifact_contract_version(
+        stl_state,
+        classify_reference_fixture_pair_promotion_gate(
+            reference_image_root=reference_image_root,
+            reference_stl_root=reference_stl_root,
+            name=name,
+        ).contract,
+    )
+
+    report = classify_reference_fixture_pair_promotion_gate(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name=name,
+    )
+
+    assert report.promoted is True
+    assert report.diagnostics == ()
+    assert reference_artifact_contract_version_path(image_state).exists()
+
+
+def test_reference_fixture_pair_promotion_gate_rejects_dirty_missing_partial_and_invalidated_contracts(tmp_path: Path) -> None:
+    reference_image_root = tmp_path / "reference-images"
+    reference_stl_root = tmp_path / "reference-stl"
+    dirty_name = "demo/dirty"
+    partial_name = "demo/partial"
+    invalid_name = "demo/invalid"
+    _write_small_image(dirty_reference_path(reference_image_root, dirty_name), color=(10, 20, 30))
+    _write_text_fixture(dirty_reference_stl_path(reference_stl_root, dirty_name), "solid dirty\nendsolid dirty\n")
+    _write_small_image(clean_reference_path(reference_image_root, partial_name), color=(40, 50, 60))
+    _write_small_image(clean_reference_path(reference_image_root, invalid_name), color=(70, 80, 90))
+    _write_text_fixture(clean_reference_stl_path(reference_stl_root, invalid_name), "solid invalid\nendsolid invalid\n")
+
+    dirty_report = classify_reference_fixture_pair_promotion_gate(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name=dirty_name,
+    )
+    missing_report = classify_reference_fixture_pair_promotion_gate(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name="demo/missing",
+    )
+    partial_report = classify_reference_fixture_pair_promotion_gate(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name=partial_name,
+    )
+    invalid_report = classify_reference_fixture_pair_promotion_gate(
+        reference_image_root=reference_image_root,
+        reference_stl_root=reference_stl_root,
+        name=invalid_name,
+    )
+
+    assert dirty_report.promoted is False
+    assert {diagnostic.code for diagnostic in dirty_report.diagnostics} == {"dirty-artifact"}
+    assert {diagnostic.code for diagnostic in missing_report.diagnostics} == {"missing-artifact"}
+    assert any(diagnostic.code == "partial-fixture" for diagnostic in partial_report.diagnostics)
+    assert {diagnostic.code for diagnostic in invalid_report.diagnostics} == {"invalidated-contract"}
 
 
 def test_reference_fixture_pair_fails_for_partial_existing_group(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add reference fixture contract version records and promotion diagnostics
- classify clean, dirty, missing, partial, and invalidated reference fixture states
- add focused gate tests and mark Surface Spec 277 complete

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_reference_images.py -q -k "promotion_gate_accepts or promotion_gate_rejects"
- git diff --check

## Note
- A broader `-k "promotion_gate or reference_fixture_pair"` run also selected an existing CSG reference matrix test that currently reports missing `csg_union_box_post` local reference artifacts.