### PR TITLE
Implement diagnostic snapshot normalization

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -493,7 +493,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 275: Implicit Intersection Residual And Result Classification (v1.0)](../specifications/surface-275-implicit-intersection-residual-and-result-classification-v1_0.md)
 - [x] [Surface Spec 276: Surface Reference Requirement Matrix (v1.0)](../specifications/surface-276-surface-reference-requirement-matrix-v1_0.md)
 - [x] [Surface Spec 277: Dirty Versus Promoted Reference Artifact Gate (v1.0)](../specifications/surface-277-dirty-versus-promoted-reference-artifact-gate-v1_0.md)
-- [ ] [Surface Spec 278: Diagnostic Snapshot Normalization (v1.0)](../specifications/surface-278-diagnostic-snapshot-normalization-v1_0.md)
+- [x] [Surface Spec 278: Diagnostic Snapshot Normalization (v1.0)](../specifications/surface-278-diagnostic-snapshot-normalization-v1_0.md)
 - [ ] [Surface Spec 279: Negative Diagnostic Fixture Matrix Core (v1.0)](../specifications/surface-279-negative-diagnostic-fixture-matrix-core-v1_0.md)
 - [ ] [Surface Spec 280: .impress Unsafe Payload Negative Fixtures (v1.0)](../specifications/surface-280-impress-unsafe-payload-negative-fixtures-v1_0.md)
 - [ ] [Surface Spec 281: Mesh Boundary Negative Fixtures (v1.0)](../specifications/surface-281-mesh-boundary-negative-fixtures-v1_0.md)

--- a/tests/reference_images.py
+++ b/tests/reference_images.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
 from pathlib import Path
+import re
 import shutil
 from typing import Literal, Sequence
 
@@ -50,6 +52,7 @@ TextCvResultClass = Literal[
     "unreadable",
 ]
 DiagnosticPanelLabel = Literal["left", "result", "right", "expected", "actual", "diff"]
+DiagnosticSnapshotDriftKind = Literal["matches", "changed"]
 
 
 @dataclass(frozen=True)
@@ -114,6 +117,48 @@ class ReferenceArtifactPromotionGateReport:
     state: ReferenceFixturePairState
     contract: ReferenceFixtureContractVersionRecord
     diagnostics: tuple[ReferencePromotionDiagnostic, ...]
+
+
+@dataclass(frozen=True)
+class DiagnosticSnapshotKeyPolicy:
+    """Stable diagnostic snapshot key policy that excludes volatile details."""
+
+    ignored_keys: tuple[str, ...] = ("traceback", "stack", "stack_trace", "cwd", "tmp_path", "temporary_path")
+    path_keys: tuple[str, ...] = ("path", "file", "filename", "implementation_owner")
+
+    def __post_init__(self) -> None:
+        _validate_unique_nonempty_strings("ignored_keys", self.ignored_keys)
+        _validate_unique_nonempty_strings("path_keys", self.path_keys)
+
+
+@dataclass(frozen=True)
+class DiagnosticSnapshotRecord:
+    fixture_id: str
+    diagnostic_type: str
+    payload: dict[str, object]
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "diagnostic_type": self.diagnostic_type,
+            "fixture_id": self.fixture_id,
+            "payload": self.payload,
+        }
+
+    def stable_json(self) -> str:
+        return json.dumps(self.canonical_payload(), sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class DiagnosticSnapshotComparison:
+    fixture_id: str
+    drift_kind: DiagnosticSnapshotDriftKind
+    expected: DiagnosticSnapshotRecord
+    actual: DiagnosticSnapshotRecord
+    message: str = ""
+
+    @property
+    def matches(self) -> bool:
+        return self.drift_kind == "matches"
 
 
 @dataclass(frozen=True)
@@ -701,6 +746,87 @@ def classify_reference_fixture_pair_promotion_gate(
         state=state,
         contract=contract,
         diagnostics=tuple(diagnostics),
+    )
+
+
+_PATH_FRAGMENT_RE = re.compile(r"(?P<path>(?:~|/)[^\s:]+)")
+
+
+def _normalize_snapshot_string(value: str) -> str:
+    def replace_path(match: re.Match[str]) -> str:
+        path = match.group("path")
+        name = Path(path).name
+        return f"<path:{name}>" if name else "<path>"
+
+    return _PATH_FRAGMENT_RE.sub(replace_path, value)
+
+
+def _normalize_diagnostic_snapshot_value(value: object, policy: DiagnosticSnapshotKeyPolicy) -> object:
+    if hasattr(value, "canonical_payload") and callable(value.canonical_payload):
+        value = value.canonical_payload()
+    if isinstance(value, BaseException):
+        return {"message": _normalize_snapshot_string(str(value)), "type": type(value).__name__}
+    if isinstance(value, Path):
+        return f"<path:{value.name}>"
+    if isinstance(value, dict):
+        normalized: dict[str, object] = {}
+        for raw_key in sorted(value, key=lambda item: str(item)):
+            key = str(raw_key)
+            if key in policy.ignored_keys:
+                continue
+            raw_value = value[raw_key]
+            if key in policy.path_keys and isinstance(raw_value, (str, Path)):
+                normalized[key] = _normalize_snapshot_string(str(raw_value))
+            else:
+                normalized[key] = _normalize_diagnostic_snapshot_value(raw_value, policy)
+        return normalized
+    if isinstance(value, (list, tuple, set)):
+        return tuple(_normalize_diagnostic_snapshot_value(item, policy) for item in value)
+    if isinstance(value, str):
+        return _normalize_snapshot_string(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return repr(value)
+
+
+def normalize_diagnostic_snapshot(
+    diagnostic: object,
+    *,
+    fixture_id: str,
+    policy: DiagnosticSnapshotKeyPolicy | None = None,
+) -> DiagnosticSnapshotRecord:
+    """Normalize a refusal diagnostic into a stable, portable snapshot."""
+
+    snapshot_policy = DiagnosticSnapshotKeyPolicy() if policy is None else policy
+    payload = _normalize_diagnostic_snapshot_value(diagnostic, snapshot_policy)
+    if not isinstance(payload, dict):
+        payload = {"value": payload}
+    return DiagnosticSnapshotRecord(
+        fixture_id=fixture_id,
+        diagnostic_type=type(diagnostic).__name__,
+        payload=payload,
+    )
+
+
+def compare_diagnostic_snapshots(
+    expected: DiagnosticSnapshotRecord,
+    actual: DiagnosticSnapshotRecord,
+) -> DiagnosticSnapshotComparison:
+    """Compare normalized diagnostic snapshots without incidental formatting drift."""
+
+    if expected.stable_json() == actual.stable_json():
+        return DiagnosticSnapshotComparison(
+            fixture_id=actual.fixture_id,
+            drift_kind="matches",
+            expected=expected,
+            actual=actual,
+        )
+    return DiagnosticSnapshotComparison(
+        fixture_id=actual.fixture_id,
+        drift_kind="changed",
+        expected=expected,
+        actual=actual,
+        message=f"Diagnostic snapshot drift for {actual.fixture_id}.",
     )
 
 

--- a/tests/test_reference_images.py
+++ b/tests/test_reference_images.py
@@ -43,6 +43,7 @@ from tests.reference_images import (
     CvArtifactBundleContract,
     CvFixtureContract,
     DiagnosticPanelContract,
+    DiagnosticSnapshotKeyPolicy,
     assess_cv_result,
     canonical_object_view_camera_contracts,
     classify_reference_fixture_pair_promotion_gate,
@@ -65,6 +66,8 @@ from tests.reference_images import (
     invalidate_reference_image_bundle,
     initial_text_cv_scope_support,
     HandednessSpaceAnchorContract,
+    compare_diagnostic_snapshots,
+    normalize_diagnostic_snapshot,
     planar_loop_bounds,
     reference_artifact_state,
     reference_artifact_contract_version_path,
@@ -416,6 +419,52 @@ def test_reference_fixture_pair_promotion_gate_rejects_dirty_missing_partial_and
     assert {diagnostic.code for diagnostic in missing_report.diagnostics} == {"missing-artifact"}
     assert any(diagnostic.code == "partial-fixture" for diagnostic in partial_report.diagnostics)
     assert {diagnostic.code for diagnostic in invalid_report.diagnostics} == {"invalidated-contract"}
+
+
+def test_diagnostic_snapshot_normalization_strips_paths_and_volatile_keys(tmp_path: Path) -> None:
+    diagnostic = {
+        "code": "unsafe-payload",
+        "message": f"Refused file {tmp_path / 'nested' / 'payload.impress'}",
+        "path": tmp_path / "nested" / "payload.impress",
+        "stack_trace": "machine specific stack",
+        "details": {"b": 2, "a": f"{tmp_path}/scratch.txt"},
+    }
+
+    snapshot = normalize_diagnostic_snapshot(diagnostic, fixture_id="unsafe/impress")
+
+    assert snapshot.payload == {
+        "code": "unsafe-payload",
+        "details": {"a": "<path:scratch.txt>", "b": 2},
+        "message": "Refused file <path:payload.impress>",
+        "path": "<path:payload.impress>",
+    }
+    assert "stack_trace" not in snapshot.stable_json()
+    assert str(tmp_path) not in snapshot.stable_json()
+
+
+def test_diagnostic_snapshot_comparator_uses_stable_payload_ordering() -> None:
+    policy = DiagnosticSnapshotKeyPolicy(ignored_keys=("traceback",), path_keys=("file",))
+    expected = normalize_diagnostic_snapshot(
+        {"b": 2, "a": 1, "file": "/tmp/demo/thing.json", "traceback": "ignored"},
+        fixture_id="diagnostic/order",
+        policy=policy,
+    )
+    actual = normalize_diagnostic_snapshot(
+        {"file": "/private/tmp/other/thing.json", "a": 1, "b": 2},
+        fixture_id="diagnostic/order",
+        policy=policy,
+    )
+    drift = normalize_diagnostic_snapshot(
+        {"file": "/private/tmp/other/thing.json", "a": 3, "b": 2},
+        fixture_id="diagnostic/order",
+        policy=policy,
+    )
+
+    assert compare_diagnostic_snapshots(expected, actual).matches is True
+    comparison = compare_diagnostic_snapshots(expected, drift)
+    assert comparison.matches is False
+    assert comparison.drift_kind == "changed"
+    assert "diagnostic/order" in comparison.message
 
 
 def test_reference_fixture_pair_fails_for_partial_existing_group(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add stable diagnostic snapshot key policy, record, and comparator helpers
- normalize diagnostic payloads through canonical payloads, sorted keys, volatile-key removal, and path scrubbing
- add path stripping, ordering, and drift comparison tests; mark Surface Spec 278 complete

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_reference_images.py -q -k "diagnostic_snapshot"
- git diff --check