### PR TITLE
Implement negative diagnostic fixture matrix

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -494,7 +494,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 276: Surface Reference Requirement Matrix (v1.0)](../specifications/surface-276-surface-reference-requirement-matrix-v1_0.md)
 - [x] [Surface Spec 277: Dirty Versus Promoted Reference Artifact Gate (v1.0)](../specifications/surface-277-dirty-versus-promoted-reference-artifact-gate-v1_0.md)
 - [x] [Surface Spec 278: Diagnostic Snapshot Normalization (v1.0)](../specifications/surface-278-diagnostic-snapshot-normalization-v1_0.md)
-- [ ] [Surface Spec 279: Negative Diagnostic Fixture Matrix Core (v1.0)](../specifications/surface-279-negative-diagnostic-fixture-matrix-core-v1_0.md)
+- [x] [Surface Spec 279: Negative Diagnostic Fixture Matrix Core (v1.0)](../specifications/surface-279-negative-diagnostic-fixture-matrix-core-v1_0.md)
 - [ ] [Surface Spec 280: .impress Unsafe Payload Negative Fixtures (v1.0)](../specifications/surface-280-impress-unsafe-payload-negative-fixtures-v1_0.md)
 - [ ] [Surface Spec 281: Mesh Boundary Negative Fixtures (v1.0)](../specifications/surface-281-mesh-boundary-negative-fixtures-v1_0.md)
 - [ ] [Surface Spec 282: CSG Negative Diagnostic Fixtures (v1.0)](../specifications/surface-282-csg-negative-diagnostic-fixtures-v1_0.md)

--- a/tests/reference_images.py
+++ b/tests/reference_images.py
@@ -162,6 +162,54 @@ class DiagnosticSnapshotComparison:
 
 
 @dataclass(frozen=True)
+class ExpectedDiagnosticKeyRecord:
+    key_path: tuple[str, ...]
+    expected_value: object | None = None
+
+    def __post_init__(self) -> None:
+        _validate_unique_nonempty_strings("key_path", self.key_path)
+
+
+@dataclass(frozen=True)
+class NegativeDiagnosticFixtureRecord:
+    fixture_id: str
+    domain: str
+    expected_keys: tuple[ExpectedDiagnosticKeyRecord, ...]
+    expected_snapshot: DiagnosticSnapshotRecord | None = None
+
+    def __post_init__(self) -> None:
+        if not self.fixture_id.strip():
+            raise ValueError("NegativeDiagnosticFixtureRecord.fixture_id must be non-empty.")
+        if not self.domain.strip():
+            raise ValueError("NegativeDiagnosticFixtureRecord.domain must be non-empty.")
+        if not self.expected_keys:
+            raise ValueError("NegativeDiagnosticFixtureRecord.expected_keys must be non-empty.")
+
+
+@dataclass(frozen=True)
+class NegativeDiagnosticDomainCoverageRecord:
+    domain: str
+    fixture_count: int
+    covered: bool
+
+
+@dataclass(frozen=True)
+class NegativeDiagnosticFixtureMatrixDiagnostic:
+    code: Literal["missing-domain", "missing-diagnostic-key", "snapshot-drift"]
+    fixture_id: str
+    domain: str
+    message: str
+
+
+@dataclass(frozen=True)
+class NegativeDiagnosticFixtureMatrixReport:
+    passed: bool
+    fixtures: tuple[NegativeDiagnosticFixtureRecord, ...]
+    domain_coverage: tuple[NegativeDiagnosticDomainCoverageRecord, ...]
+    diagnostics: tuple[NegativeDiagnosticFixtureMatrixDiagnostic, ...]
+
+
+@dataclass(frozen=True)
 class CvFixtureContract:
     fixture_id: str
     lane: str
@@ -828,6 +876,96 @@ def compare_diagnostic_snapshots(
         actual=actual,
         message=f"Diagnostic snapshot drift for {actual.fixture_id}.",
     )
+
+
+def _snapshot_value_at(payload: dict[str, object], key_path: tuple[str, ...]) -> object:
+    current: object = payload
+    for key in key_path:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(".".join(key_path))
+        current = current[key]
+    return current
+
+
+def evaluate_negative_diagnostic_fixture_matrix(
+    fixtures: Sequence[NegativeDiagnosticFixtureRecord],
+    *,
+    required_domains: Sequence[str],
+) -> NegativeDiagnosticFixtureMatrixReport:
+    """Evaluate domain coverage and expected-key coverage for negative diagnostics."""
+
+    fixture_records = tuple(fixtures)
+    domains = tuple(str(domain).strip() for domain in required_domains)
+    _validate_unique_nonempty_strings("required_domains", domains)
+    diagnostics: list[NegativeDiagnosticFixtureMatrixDiagnostic] = []
+    by_domain = {domain: tuple(record for record in fixture_records if record.domain == domain) for domain in domains}
+    coverage: list[NegativeDiagnosticDomainCoverageRecord] = []
+    for domain in domains:
+        domain_fixtures = by_domain[domain]
+        coverage.append(
+            NegativeDiagnosticDomainCoverageRecord(
+                domain=domain,
+                fixture_count=len(domain_fixtures),
+                covered=bool(domain_fixtures),
+            )
+        )
+        if not domain_fixtures:
+            diagnostics.append(
+                NegativeDiagnosticFixtureMatrixDiagnostic(
+                    code="missing-domain",
+                    fixture_id="",
+                    domain=domain,
+                    message=f"Negative diagnostic fixture matrix has no fixture for domain '{domain}'.",
+                )
+            )
+    for fixture in fixture_records:
+        if fixture.expected_snapshot is None:
+            continue
+        for expected_key in fixture.expected_keys:
+            try:
+                observed = _snapshot_value_at(fixture.expected_snapshot.payload, expected_key.key_path)
+            except KeyError:
+                diagnostics.append(
+                    NegativeDiagnosticFixtureMatrixDiagnostic(
+                        code="missing-diagnostic-key",
+                        fixture_id=fixture.fixture_id,
+                        domain=fixture.domain,
+                        message=(
+                            f"Negative diagnostic fixture '{fixture.fixture_id}' is missing "
+                            f"expected key '{'.'.join(expected_key.key_path)}'."
+                        ),
+                    )
+                )
+                continue
+            if expected_key.expected_value is not None and observed != expected_key.expected_value:
+                diagnostics.append(
+                    NegativeDiagnosticFixtureMatrixDiagnostic(
+                        code="missing-diagnostic-key",
+                        fixture_id=fixture.fixture_id,
+                        domain=fixture.domain,
+                        message=(
+                            f"Negative diagnostic fixture '{fixture.fixture_id}' expected "
+                            f"'{'.'.join(expected_key.key_path)}' to equal {expected_key.expected_value!r}."
+                        ),
+                    )
+                )
+    return NegativeDiagnosticFixtureMatrixReport(
+        passed=not diagnostics,
+        fixtures=fixture_records,
+        domain_coverage=tuple(coverage),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def compare_negative_diagnostic_fixture_snapshot(
+    fixture: NegativeDiagnosticFixtureRecord,
+    actual_snapshot: DiagnosticSnapshotRecord,
+) -> DiagnosticSnapshotComparison:
+    """Compare a domain-owned negative diagnostic fixture against its expected snapshot."""
+
+    if fixture.expected_snapshot is None:
+        raise ValueError("Negative diagnostic fixture has no expected snapshot to compare.")
+    return compare_diagnostic_snapshots(fixture.expected_snapshot, actual_snapshot)
 
 
 def reference_fixture_pair_failures(

--- a/tests/test_reference_images.py
+++ b/tests/test_reference_images.py
@@ -44,6 +44,8 @@ from tests.reference_images import (
     CvFixtureContract,
     DiagnosticPanelContract,
     DiagnosticSnapshotKeyPolicy,
+    ExpectedDiagnosticKeyRecord,
+    NegativeDiagnosticFixtureRecord,
     assess_cv_result,
     canonical_object_view_camera_contracts,
     classify_reference_fixture_pair_promotion_gate,
@@ -67,6 +69,8 @@ from tests.reference_images import (
     initial_text_cv_scope_support,
     HandednessSpaceAnchorContract,
     compare_diagnostic_snapshots,
+    compare_negative_diagnostic_fixture_snapshot,
+    evaluate_negative_diagnostic_fixture_matrix,
     normalize_diagnostic_snapshot,
     planar_loop_bounds,
     reference_artifact_state,
@@ -465,6 +469,84 @@ def test_diagnostic_snapshot_comparator_uses_stable_payload_ordering() -> None:
     assert comparison.matches is False
     assert comparison.drift_kind == "changed"
     assert "diagnostic/order" in comparison.message
+
+
+def test_negative_diagnostic_fixture_matrix_reports_domain_and_key_coverage() -> None:
+    impress_snapshot = normalize_diagnostic_snapshot(
+        {"code": "unsafe-payload", "message": "refused"},
+        fixture_id="impress/unsafe",
+    )
+    csg_snapshot = normalize_diagnostic_snapshot(
+        {"code": "unsupported-family-pair", "family_pair": ("implicit", "mesh")},
+        fixture_id="csg/unsupported",
+    )
+    fixtures = (
+        NegativeDiagnosticFixtureRecord(
+            fixture_id="impress/unsafe",
+            domain=".impress",
+            expected_keys=(ExpectedDiagnosticKeyRecord(("code",), "unsafe-payload"),),
+            expected_snapshot=impress_snapshot,
+        ),
+        NegativeDiagnosticFixtureRecord(
+            fixture_id="csg/unsupported",
+            domain="csg",
+            expected_keys=(
+                ExpectedDiagnosticKeyRecord(("code",), "unsupported-family-pair"),
+                ExpectedDiagnosticKeyRecord(("family_pair",)),
+            ),
+            expected_snapshot=csg_snapshot,
+        ),
+    )
+
+    report = evaluate_negative_diagnostic_fixture_matrix(fixtures, required_domains=(".impress", "csg"))
+
+    assert report.passed is True
+    assert {coverage.domain: coverage.fixture_count for coverage in report.domain_coverage} == {
+        ".impress": 1,
+        "csg": 1,
+    }
+    assert report.diagnostics == ()
+
+
+def test_negative_diagnostic_fixture_matrix_reports_missing_domain_and_key() -> None:
+    snapshot = normalize_diagnostic_snapshot(
+        {"code": "unsafe-payload"},
+        fixture_id="impress/unsafe",
+    )
+    fixtures = (
+        NegativeDiagnosticFixtureRecord(
+            fixture_id="impress/unsafe",
+            domain=".impress",
+            expected_keys=(ExpectedDiagnosticKeyRecord(("message",)),),
+            expected_snapshot=snapshot,
+        ),
+    )
+
+    report = evaluate_negative_diagnostic_fixture_matrix(fixtures, required_domains=(".impress", "csg"))
+
+    assert report.passed is False
+    assert {diagnostic.code for diagnostic in report.diagnostics} == {"missing-domain", "missing-diagnostic-key"}
+    assert any(diagnostic.domain == "csg" for diagnostic in report.diagnostics)
+    assert any(diagnostic.fixture_id == "impress/unsafe" for diagnostic in report.diagnostics)
+
+
+def test_negative_diagnostic_fixture_snapshot_comparison_uses_normalized_snapshots() -> None:
+    expected = normalize_diagnostic_snapshot(
+        {"code": "unsafe-payload", "path": "/tmp/a/payload.impress"},
+        fixture_id="impress/unsafe",
+    )
+    actual = normalize_diagnostic_snapshot(
+        {"path": "/private/tmp/b/payload.impress", "code": "unsafe-payload"},
+        fixture_id="impress/unsafe",
+    )
+    fixture = NegativeDiagnosticFixtureRecord(
+        fixture_id="impress/unsafe",
+        domain=".impress",
+        expected_keys=(ExpectedDiagnosticKeyRecord(("code",), "unsafe-payload"),),
+        expected_snapshot=expected,
+    )
+
+    assert compare_negative_diagnostic_fixture_snapshot(fixture, actual).matches is True
 
 
 def test_reference_fixture_pair_fails_for_partial_existing_group(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add negative diagnostic fixture, expected-key, domain coverage, diagnostic, and matrix report records
- add matrix coverage checker and snapshot comparison integration
- cover accepted matrix, missing domain/key, and normalized snapshot comparison; mark Surface Spec 279 complete

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_reference_images.py -q -k "negative_diagnostic_fixture"
- git diff --check