### PR TITLE
Add mesh boundary negative fixtures

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -496,7 +496,7 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 278: Diagnostic Snapshot Normalization (v1.0)](../specifications/surface-278-diagnostic-snapshot-normalization-v1_0.md)
 - [x] [Surface Spec 279: Negative Diagnostic Fixture Matrix Core (v1.0)](../specifications/surface-279-negative-diagnostic-fixture-matrix-core-v1_0.md)
 - [x] [Surface Spec 280: .impress Unsafe Payload Negative Fixtures (v1.0)](../specifications/surface-280-impress-unsafe-payload-negative-fixtures-v1_0.md)
-- [ ] [Surface Spec 281: Mesh Boundary Negative Fixtures (v1.0)](../specifications/surface-281-mesh-boundary-negative-fixtures-v1_0.md)
+- [x] [Surface Spec 281: Mesh Boundary Negative Fixtures (v1.0)](../specifications/surface-281-mesh-boundary-negative-fixtures-v1_0.md)
 - [ ] [Surface Spec 282: CSG Negative Diagnostic Fixtures (v1.0)](../specifications/surface-282-csg-negative-diagnostic-fixtures-v1_0.md)
 - [ ] [Surface Spec 283: Loft Ambiguity Negative Diagnostic Fixtures (v1.0)](../specifications/surface-283-loft-ambiguity-negative-diagnostic-fixtures-v1_0.md)
 - [ ] [Surface Spec 284: Seam Continuity Negative Diagnostic Fixtures (v1.0)](../specifications/surface-284-seam-continuity-negative-diagnostic-fixtures-v1_0.md)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -45,6 +45,38 @@ from impression.modeling._surface_primitives import (
     make_surface_sphere,
     make_surface_torus,
 )
+from tests.reference_images import (
+    ExpectedDiagnosticKeyRecord,
+    NegativeDiagnosticFixtureRecord,
+    evaluate_negative_diagnostic_fixture_matrix,
+    normalize_diagnostic_snapshot,
+)
+
+
+def _mesh_boundary_negative_fixture(
+    fixture_id: str,
+    operation,
+    *,
+    expected_keys: tuple[ExpectedDiagnosticKeyRecord, ...],
+) -> NegativeDiagnosticFixtureRecord:
+    try:
+        diagnostic = operation()
+    except Exception as exc:  # noqa: BLE001 - negative fixture runner records refusal shape.
+        snapshot = normalize_diagnostic_snapshot(
+            {
+                "code": type(exc).__name__,
+                "message": str(exc),
+            },
+            fixture_id=fixture_id,
+        )
+    else:
+        snapshot = normalize_diagnostic_snapshot(diagnostic, fixture_id=fixture_id)
+    return NegativeDiagnosticFixtureRecord(
+        fixture_id=fixture_id,
+        domain="mesh-boundary",
+        expected_keys=expected_keys,
+        expected_snapshot=snapshot,
+    )
 from impression.modeling._surface_ops import make_surface_linear_extrude, make_surface_rotate_extrude
 from impression.modeling import (
     PATCH_FAMILY_CAPABILITY_MATRIX,
@@ -2459,6 +2491,48 @@ def test_tessellation_helper_contract_accepts_only_surface_boundary_inputs() -> 
     assert isinstance(diagnostic, TessellationBoundaryViolationDiagnostic)
     assert diagnostic.received_type == "dict"
     assert "SurfaceBody" in diagnostic.expected_inputs
+
+
+def test_mesh_boundary_negative_fixtures_feed_diagnostic_matrix() -> None:
+    fixtures = (
+        _mesh_boundary_negative_fixture(
+            "mesh-boundary/dict-primitive-input",
+            lambda: validate_tessellation_helper_boundary_input({"kind": "box", "size": (1.0, 1.0, 1.0)}),
+            expected_keys=(
+                ExpectedDiagnosticKeyRecord(("helper_name",), "surface-to-mesh-adapter"),
+                ExpectedDiagnosticKeyRecord(("received_type",), "dict"),
+                ExpectedDiagnosticKeyRecord(("message",)),
+            ),
+        ),
+        _mesh_boundary_negative_fixture(
+            "mesh-boundary/list-points-input",
+            lambda: validate_tessellation_helper_boundary_input([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]),
+            expected_keys=(
+                ExpectedDiagnosticKeyRecord(("helper_name",), "surface-to-mesh-adapter"),
+                ExpectedDiagnosticKeyRecord(("received_type",), "list"),
+                ExpectedDiagnosticKeyRecord(("message",)),
+            ),
+        ),
+        _mesh_boundary_negative_fixture(
+            "mesh-boundary/adapter-record-refuses-primitive-args",
+            lambda: make_surface_to_mesh_adapter_record({"kind": "sphere", "radius": 1.0}),  # type: ignore[arg-type]
+            expected_keys=(
+                ExpectedDiagnosticKeyRecord(("code",), "ValueError"),
+                ExpectedDiagnosticKeyRecord(("message",)),
+            ),
+        ),
+    )
+
+    report = evaluate_negative_diagnostic_fixture_matrix(fixtures, required_domains=("mesh-boundary",))
+
+    assert report.passed is True
+    assert report.domain_coverage[0].fixture_count == 3
+    assert any(
+        fixture.fixture_id == "mesh-boundary/adapter-record-refuses-primitive-args"
+        and "tessellation boundary" in fixture.expected_snapshot.payload["message"]  # type: ignore[index, union-attr]
+        for fixture in fixtures
+    )
+    assert all(fixture.expected_snapshot is not None for fixture in fixtures)
 
 
 def test_surface_primitive_family_appropriateness_matrix_stays_exact_and_native() -> None:


### PR DESCRIPTION
## Summary
- add mesh-boundary negative fixture runner coverage for primitive-shaped and list-shaped inputs
- snapshot tessellation-boundary diagnostics and adapter-record refusal exceptions through the negative diagnostic matrix
- mark Surface Spec 281 complete

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_surface.py -q -k "mesh_boundary_negative_fixtures or tessellation_helper_contract"
- git diff --check