### PR TITLE
Rewrite preview reference tests for explicit tessellation

### DIFF
--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -501,5 +501,5 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 283: Loft Ambiguity Negative Diagnostic Fixtures (v1.0)](../specifications/surface-283-loft-ambiguity-negative-diagnostic-fixtures-v1_0.md)
 - [x] [Surface Spec 284: Seam Continuity Negative Diagnostic Fixtures (v1.0)](../specifications/surface-284-seam-continuity-negative-diagnostic-fixtures-v1_0.md)
 - [x] [Surface Spec 285: Legacy Primitive Mesh Assumption Inventory (v1.0)](../specifications/surface-285-legacy-primitive-mesh-assumption-inventory-v1_0.md)
-- [ ] [Surface Spec 286: Preview And Reference Tests Explicit Tessellation Rewrite (v1.0)](../specifications/surface-286-preview-and-reference-tests-explicit-tessellation-rewrite-v1_0.md)
+- [x] [Surface Spec 286: Preview And Reference Tests Explicit Tessellation Rewrite (v1.0)](../specifications/surface-286-preview-and-reference-tests-explicit-tessellation-rewrite-v1_0.md)
 - [ ] [Surface Spec 287: Mesh Compatibility API Documentation And Example Rewrite (v1.0)](../specifications/surface-287-mesh-compatibility-api-documentation-and-example-rewrite-v1_0.md)

--- a/tests/test_preview_isolation.py
+++ b/tests/test_preview_isolation.py
@@ -87,11 +87,12 @@ def test_pyvista_show_after_modeling_import():
 def test_internal_mesh_show_after_modeling_import():
     code = dedent(
         """
-        from impression.modeling import make_box
+        from impression.modeling import make_box, tessellate_surface_body
         from impression.mesh import mesh_to_pyvista
         import pyvista as pv
 
-        mesh = mesh_to_pyvista(make_box())
+        body = make_box()
+        mesh = mesh_to_pyvista(tessellate_surface_body(body).mesh)
         plotter = pv.Plotter(off_screen=True)
         plotter.add_mesh(mesh)
         plotter.show(auto_close=True, interactive=False)

--- a/tests/test_reference_images.py
+++ b/tests/test_reference_images.py
@@ -12,6 +12,7 @@ from impression.modeling import (
     Loft,
     as_section,
     handoff_hinge_surface,
+    inventory_legacy_primitive_mesh_assumptions,
     make_bistable_hinge,
     make_box,
     make_living_hinge,
@@ -97,12 +98,21 @@ from tests.reference_images import (
     write_surface_consumer_collection_stl,
 )
 
+PREVIEW_AND_REFERENCE_FILES = (
+    Path(__file__).resolve().with_name("test_preview_isolation.py"),
+    Path(__file__).resolve(),
+)
+
 SYMBOL_FONT_PATH = (
     Path(__file__).resolve().parents[1]
     / "assets"
     / "fonts"
     / "NotoSansSymbols2-Regular.ttf"
 )
+
+
+def _tessellate_reference_mesh(body):
+    return tessellate_surface_body(body).mesh
 
 
 def _require_text_cv_font() -> Path:
@@ -1034,8 +1044,8 @@ def test_handedness_anchor_contract_detects_space_drift() -> None:
 def test_handedness_classifier_detects_same_and_mirrored_witness(tmp_path: Path) -> None:
     mesh = combine_meshes(
         [
-            make_box(size=(1.2, 0.4, 1.0), center=(0.0, 0.0, 0.0)),
-            make_box(size=(0.3, 0.4, 0.3), center=(0.75, 0.0, 0.55)),
+            _tessellate_reference_mesh(make_box(size=(1.2, 0.4, 1.0), center=(0.0, 0.0, 0.0))),
+            _tessellate_reference_mesh(make_box(size=(0.3, 0.4, 0.3), center=(0.75, 0.0, 0.55))),
         ]
     )
     bundle = render_canonical_object_view_bundle(mesh, tmp_path / "expected", stem="arrow")
@@ -1051,6 +1061,16 @@ def test_handedness_classifier_detects_same_and_mirrored_witness(tmp_path: Path)
     assert same.witness_adequate
     assert same.result_class == "same_handedness"
     assert mirrored.result_class == "mirrored"
+
+
+def test_preview_and_reference_files_have_no_stale_public_primitive_mesh_assumptions() -> None:
+    report = inventory_legacy_primitive_mesh_assumptions(
+        {str(path.relative_to(Path(__file__).resolve().parents[1])): path.read_text(encoding="utf-8")
+         for path in PREVIEW_AND_REFERENCE_FILES}
+    )
+
+    assert report.stale_findings == ()
+    assert report.passed is True
 
 
 def test_handedness_classifier_returns_unknown_for_symmetric_witness(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- rewrite preview isolation mesh handoff to tessellate public primitive output explicitly
- rewrite handedness reference witness mesh setup through explicit surface tessellation
- add a stale primitive mesh-assumption guard over preview/reference files
- mark Surface Spec 286 complete in progression

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_reference_images.py -q -k "handedness_classifier_detects_same_and_mirrored_witness or preview_and_reference_files_have_no_stale"
- PYTHONPATH=src ./.venv/bin/pytest tests/test_preview_isolation.py -q -k "internal_mesh_show_after_modeling_import"
- git diff --check