### PR TITLE
Clarify mesh compatibility docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ source ~/.impression/env
 
 ## Your First Preview
 
-Every model is a Python module that exposes a `build()` function returning internal meshes.
-Use the primitives and helpers in `impression.modeling` (not PyVista objects).
+Every model is a Python module that exposes a `build()` function. Public
+primitives return `SurfaceBody` objects by default; preview and export
+tessellate them explicitly at the consumer boundary. Use the primitives and
+helpers in `impression.modeling` (not PyVista objects).
 
 ```python
-from impression.modeling import make_box, make_cylinder, boolean_union
+from impression.modeling import make_box
 
 
 def build():
-    body = make_box(size=(2, 2, 1))
-    post = make_cylinder(radius=0.4, height=2.0)
-    return boolean_union([body, post])
+    return make_box(size=(2, 2, 1))
 ```
 
 Preview it:

--- a/docs/examples/csg/difference_example.py
+++ b/docs/examples/csg/difference_example.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_difference, make_box, make_cylinder
+from impression.modeling import boolean_difference, make_box_mesh, make_cylinder_mesh
 
 
 def build():
-    base = make_box(size=(2, 2, 2), color="#5A7BFF")
-    cutter = make_cylinder(radius=0.4, height=2.5, color="#FF7A18")
+    base = make_box_mesh(size=(2, 2, 2), color="#5A7BFF")
+    cutter = make_cylinder_mesh(radius=0.4, height=2.5, color="#FF7A18")
     return boolean_difference(base, [cutter])
 
 

--- a/docs/examples/csg/intersection_example.py
+++ b/docs/examples/csg/intersection_example.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_intersection, make_box, make_sphere
+from impression.modeling import boolean_intersection, make_box_mesh, make_sphere_mesh
 
 
 def build():
-    box = make_box(size=(2, 2, 2), color=(0.35, 0.55, 0.95))
-    sphere = make_sphere(radius=1.2, color=(1.0, 0.55, 0.2))
+    box = make_box_mesh(size=(2, 2, 2), color=(0.35, 0.55, 0.95))
+    sphere = make_sphere_mesh(radius=1.2, color=(1.0, 0.55, 0.2))
     return boolean_intersection([box, sphere])
 
 

--- a/docs/examples/csg/teeth_union_example.py
+++ b/docs/examples/csg/teeth_union_example.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import make_cylinder, union_meshes
+from impression.modeling import make_cylinder_mesh, union_meshes
 
 
 def build():
@@ -28,7 +28,7 @@ def build():
         angle = math.radians(start + i * step)
         x = radius * math.cos(angle)
         y = radius * math.sin(angle)
-        cyl = make_cylinder(radius=tooth_radius, height=tooth_height, center=(x, y, tooth_height / 2.0))
+        cyl = make_cylinder_mesh(radius=tooth_radius, height=tooth_height, center=(x, y, tooth_height / 2.0))
         meshes[f"tooth-{i}"] = cyl
 
     return union_meshes(meshes)

--- a/docs/examples/csg/tooth_example.py
+++ b/docs/examples/csg/tooth_example.py
@@ -10,15 +10,15 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_union, rotate, make_box, make_cylinder
+from impression.modeling import boolean_union, rotate, make_box_mesh, make_cylinder_mesh
 
 
 def build():
     body_height = 6.0
-    body = make_box(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0), color=(0.5,0.5,0.5,1.0))
+    body = make_box_mesh(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0), color=(0.5,0.5,0.5,1.0))
 
     cap_height = 2.0
-    cap = make_cylinder(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
+    cap = make_cylinder_mesh(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
     rotate(cap, axis=(1.0, 0.0, 0.0), angle_deg=90)
     # Fuse into a single solid; tolerance kept small to avoid masking geometry issues.
     # mesh = boolean_union([body, cap], tolerance=1e-4)

--- a/docs/examples/csg/tooth_parts_example.py
+++ b/docs/examples/csg/tooth_parts_example.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from impression.io import write_stl
-from impression.modeling import make_box, make_cylinder
+from impression.modeling import make_box_mesh, make_cylinder_mesh
 from impression.modeling.group import MeshGroup
 
 
 def build():
     body_height = 6.0
-    body = make_box(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0))
+    body = make_box_mesh(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0))
 
     cap_height = 2.0
-    cap = make_cylinder(radius=2.5, height=cap_height, center=(0.0, 0.0, body_height + cap_height / 2.0))
+    cap = make_cylinder_mesh(radius=2.5, height=cap_height, center=(0.0, 0.0, body_height + cap_height / 2.0))
 
     # Return both solids un-fused so the preview shows overlap and the export keeps both volumes.
     return MeshGroup([body, cap])

--- a/docs/examples/csg/tooth_union_example.py
+++ b/docs/examples/csg/tooth_union_example.py
@@ -10,15 +10,15 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_union, rotate, make_box, make_cylinder
+from impression.modeling import boolean_union, rotate, make_box_mesh, make_cylinder_mesh
 
 
 def build():
     body_height = 6.0
-    body = make_box(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0), color=(0.5,0.5,0.5,1.0))
+    body = make_box_mesh(size=(5.0, 2.0, body_height), center=(0.0, 0.0, body_height / 2.0), color=(0.5,0.5,0.5,1.0))
 
     cap_height = 2.0
-    cap = make_cylinder(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
+    cap = make_cylinder_mesh(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
     rotate(cap, axis=(1.0, 0.0, 0.0), angle_deg=90)
     # Fuse into a single solid; tolerance kept small to avoid masking geometry issues.
     mesh = boolean_union([body, cap], tolerance=1e-4)

--- a/docs/examples/csg/union_example.py
+++ b/docs/examples/csg/union_example.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_union, make_box, make_cylinder
+from impression.modeling import boolean_union, make_box_mesh, make_cylinder_mesh
 
 
 def build():
-    box = make_box(size=(2, 2, 1), color=(0.35, 0.55, 0.95))
-    cyl = make_cylinder(radius=0.6, height=1.5, color=(1.0, 0.6, 0.2))
+    box = make_box_mesh(size=(2, 2, 1), color=(0.35, 0.55, 0.95))
+    cyl = make_cylinder_mesh(radius=0.6, height=1.5, color=(1.0, 0.6, 0.2))
     return boolean_union([box, cyl])
 
 

--- a/docs/examples/csg/union_meshes_example.py
+++ b/docs/examples/csg/union_meshes_example.py
@@ -10,12 +10,12 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import make_box, make_cylinder, union_meshes
+from impression.modeling import make_box_mesh, make_cylinder_mesh, union_meshes
 
 
 def build():
-    box = make_box(size=(2, 2, 1), color=(0.35, 0.55, 0.95))
-    cyl = make_cylinder(radius=0.8, height=1.5, color=(1.0, 0.6, 0.2))
+    box = make_box_mesh(size=(2, 2, 1), color=(0.35, 0.55, 0.95))
+    cyl = make_cylinder_mesh(radius=0.8, height=1.5, color=(1.0, 0.6, 0.2))
     # union_meshes accepts any iterable or mapping
     return union_meshes({"box": box, "cyl": cyl})
 

--- a/docs/modeling/csg.md
+++ b/docs/modeling/csg.md
@@ -1,15 +1,26 @@
 # Modeling — CSG Helpers
 
-Imported from `impression.modeling`:
+Mesh compatibility helpers are imported from `impression.modeling`:
 
 ```python
-from impression.modeling import boolean_union, boolean_difference, boolean_intersection, union_meshes
+from impression.modeling import (
+    boolean_union,
+    boolean_difference,
+    boolean_intersection,
+    make_box_mesh,
+    make_cylinder_mesh,
+    union_meshes,
+)
 ```
 
 Booleans propagate per-object colors onto result faces. Union/intersection faces keep the originating mesh color; difference assigns new cut faces to the cutter’s color.
 If no input colors are provided, the result uses the default preview color.
 
-All helpers operate on internal triangle meshes and use `manifold3d` for robust, watertight-aware booleans.
+The mesh-lane helpers operate on internal triangle meshes and use `manifold3d`
+for robust, watertight-aware booleans. Feed them mesh-specific inputs such as
+`make_*_mesh(...)` or a mesh produced by an explicit tessellation boundary. Do
+not treat public `make_*` primitives as mesh constructors; those return
+`SurfaceBody` by default.
 Install requirement: `pip install manifold3d`.
 
 ## Surface-First Status
@@ -89,7 +100,8 @@ Within that surfaced lane, result posture is now explicit across three caller-fa
 
 The public boolean APIs are now split into two explicit lanes:
 
-- default mesh lane: returns executable mesh geometry today
+- default mesh lane: returns executable mesh geometry today and expects
+  mesh-specific inputs such as `make_*_mesh(...)`
 - surfaced lane: `backend="surface"` returns `SurfaceBooleanResult`
 
 The surfaced lane is the migration contract for downstream callers that want to stop depending on mesh-primary boolean truth. It is intentionally honest:
@@ -101,7 +113,10 @@ The surfaced lane is the migration contract for downstream callers that want to 
 - unsupported execution stays surfaced and does not fall back to mesh
 - legacy mesh deprecation posture remains in place for the executable mesh lane
 
-If you need renderable boolean output today, keep using the default mesh lane. If you are migrating consumers or tests onto the surface-first contract, use `backend="surface"` and inspect the returned `SurfaceBooleanResult`.
+If you need renderable boolean output today, keep using the default mesh lane
+with explicit mesh compatibility inputs. If you are migrating consumers or
+tests onto the surface-first contract, use `backend="surface"` and inspect the
+returned `SurfaceBooleanResult`.
 
 ## Reference Readiness
 
@@ -145,11 +160,11 @@ the same orientation, the same shape but rotated, or a different shape.
 - Preview: `impression preview docs/examples/csg/union_example.py`
 
 ```python
-from impression.modeling import boolean_union, make_box, make_cylinder
+from impression.modeling import boolean_union, make_box_mesh, make_cylinder_mesh
 
 def build():
-    box = make_box(size=(2, 2, 1))
-    cyl = make_cylinder(radius=0.6, height=1.5)
+    box = make_box_mesh(size=(2, 2, 1))
+    cyl = make_cylinder_mesh(radius=0.6, height=1.5)
     return boolean_union([box, cyl])
 ```
 
@@ -158,11 +173,11 @@ def build():
 You can also union a collection directly with `union_meshes`, which accepts either an iterable or a mapping (e.g., dict) of meshes:
 
 ```python
-from impression.modeling import make_box, make_cylinder, union_meshes
+from impression.modeling import make_box_mesh, make_cylinder_mesh, union_meshes
 
 def build():
-    a = make_box(size=(2, 2, 1), color="#5A7BFF")
-    b = make_cylinder(radius=0.8, height=1.5, color="#FF7A18")
+    a = make_box_mesh(size=(2, 2, 1), color="#5A7BFF")
+    b = make_cylinder_mesh(radius=0.8, height=1.5, color="#FF7A18")
     return union_meshes({"box": a, "cyl": b})
 ```
 
@@ -178,11 +193,11 @@ as canonical surfaced modeling truth.
 - Preview: `impression preview docs/examples/csg/difference_example.py`
 
 ```python
-from impression.modeling import boolean_difference, make_box, make_cylinder
+from impression.modeling import boolean_difference, make_box_mesh, make_cylinder_mesh
 
 def build():
-    base = make_box(size=(2, 2, 2))
-    cutter = make_cylinder(radius=0.4, height=2.5)
+    base = make_box_mesh(size=(2, 2, 2))
+    cutter = make_cylinder_mesh(radius=0.4, height=2.5)
     return boolean_difference(base, [cutter])
 ```
 
@@ -194,11 +209,11 @@ def build():
 - Preview: `impression preview docs/examples/csg/intersection_example.py`
 
 ```python
-from impression.modeling import boolean_intersection, make_box, make_sphere
+from impression.modeling import boolean_intersection, make_box_mesh, make_sphere_mesh
 
 def build():
-    box = make_box(size=(2, 2, 2))
-    sphere = make_sphere(radius=1.2)
+    box = make_box_mesh(size=(2, 2, 2))
+    sphere = make_sphere_mesh(radius=1.2)
     return boolean_intersection([box, sphere])
 ```
 

--- a/project/release-0.1.0a/planning/progression.md
+++ b/project/release-0.1.0a/planning/progression.md
@@ -502,4 +502,4 @@ Only final leaf specifications appear here.
 - [x] [Surface Spec 284: Seam Continuity Negative Diagnostic Fixtures (v1.0)](../specifications/surface-284-seam-continuity-negative-diagnostic-fixtures-v1_0.md)
 - [x] [Surface Spec 285: Legacy Primitive Mesh Assumption Inventory (v1.0)](../specifications/surface-285-legacy-primitive-mesh-assumption-inventory-v1_0.md)
 - [x] [Surface Spec 286: Preview And Reference Tests Explicit Tessellation Rewrite (v1.0)](../specifications/surface-286-preview-and-reference-tests-explicit-tessellation-rewrite-v1_0.md)
-- [ ] [Surface Spec 287: Mesh Compatibility API Documentation And Example Rewrite (v1.0)](../specifications/surface-287-mesh-compatibility-api-documentation-and-example-rewrite-v1_0.md)
+- [x] [Surface Spec 287: Mesh Compatibility API Documentation And Example Rewrite (v1.0)](../specifications/surface-287-mesh-compatibility-api-documentation-and-example-rewrite-v1_0.md)

--- a/tests/test_surface_csg_docs.py
+++ b/tests/test_surface_csg_docs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from impression.modeling import inventory_legacy_primitive_mesh_assumptions
+
 
 def test_csg_docs_explain_surface_migration_posture(project_root: Path) -> None:
     doc = (project_root / "docs" / "modeling" / "csg.md").read_text()
@@ -36,3 +38,30 @@ def test_tutorials_keep_mesh_boolean_lane_explicit_while_surface_lane_migrates(p
     serious_modeling = (project_root / "docs" / "tutorials" / "serious-modeling.md").read_text()
     assert "surfaced CSG lane" in getting_started
     assert "executable mesh boolean lane" in serious_modeling
+
+
+def test_mesh_compatibility_docs_and_examples_use_explicit_mesh_inputs(project_root: Path) -> None:
+    paths = (
+        project_root / "README.md",
+        project_root / "docs" / "modeling" / "csg.md",
+        project_root / "docs" / "examples" / "csg" / "union_example.py",
+        project_root / "docs" / "examples" / "csg" / "difference_example.py",
+        project_root / "docs" / "examples" / "csg" / "intersection_example.py",
+        project_root / "docs" / "examples" / "csg" / "union_meshes_example.py",
+        project_root / "docs" / "examples" / "csg" / "teeth_union_example.py",
+        project_root / "docs" / "examples" / "csg" / "tooth_union_example.py",
+        project_root / "docs" / "examples" / "csg" / "tooth_example.py",
+        project_root / "docs" / "examples" / "csg" / "tooth_parts_example.py",
+    )
+    report = inventory_legacy_primitive_mesh_assumptions(
+        {str(path.relative_to(project_root)): path.read_text(encoding="utf-8") for path in paths}
+    )
+    csg_doc = (project_root / "docs" / "modeling" / "csg.md").read_text(encoding="utf-8")
+    union_meshes_example = (project_root / "docs" / "examples" / "csg" / "union_meshes_example.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert report.stale_findings == ()
+    assert "not treat public `make_*` primitives as mesh constructors" in csg_doc
+    assert "make_box_mesh" in union_meshes_example
+    assert "make_cylinder_mesh" in union_meshes_example


### PR DESCRIPTION
## Summary
- teach README first preview as a SurfaceBody default
- update CSG docs to require explicit mesh compatibility inputs for mesh-lane boolean helpers
- rewrite CSG docs examples to use make_*_mesh helpers where mesh output is intended
- add docs guard for stale public primitive mesh assumptions
- mark Surface Spec 287 complete in progression

## Verification
- PYTHONPATH=src ./.venv/bin/pytest tests/test_surface_csg_docs.py -q -k "mesh_compatibility_docs_and_examples or csg_docs_explain"
- PYTHONPATH=src ./.venv/bin/python docs/examples/csg smoke script via importlib
- git diff --check