### PR TITLE
Implement preview render command queue

### DIFF
--- a/project/release-0.1.0a/planning/reference-review-workbench-progression.md
+++ b/project/release-0.1.0a/planning/reference-review-workbench-progression.md
@@ -123,6 +123,26 @@ display-control button bar.
 - [x] [Reference Review Spec 74: Preview Display Control Row Composition](../specifications/reference-review-74-preview-display-control-row-composition-v1_0.md)
 - [x] [Reference Review Spec 74 Test: Preview Display Control Row Composition](../test-specifications/reference-review-74-preview-display-control-row-composition-v1_0.md)
 
+## Preview Concurrency Remediation
+
+These final leaves implement the ad hoc message-queue remediation captured in
+[Reference Review Spec 75: Preview Render Command Queue](../specifications/reference-review-75-preview-render-command-queue-v1_0.md).
+
+- [x] [Reference Review Spec 75a1: Preview Render Command Record Contract](../specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+- [x] [Reference Review Spec 75a1 Test: Preview Render Command Record Contract](../test-specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+- [x] [Reference Review Spec 75a2: Preview Render Coalescing Queue](../specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md)
+- [x] [Reference Review Spec 75a2 Test: Preview Render Coalescing Queue](../test-specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md)
+- [x] [Reference Review Spec 75b1: Preview Future Identity And Stale Exception Guard](../specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md)
+- [x] [Reference Review Spec 75b1 Test: Preview Future Identity And Stale Exception Guard](../test-specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md)
+- [x] [Reference Review Spec 75b2: Preview Completion To Command Routing](../specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md)
+- [x] [Reference Review Spec 75b2 Test: Preview Completion To Command Routing](../test-specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md)
+- [x] [Reference Review Spec 75c1: Preview Widget Queue Drain Scheduler](../specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md)
+- [x] [Reference Review Spec 75c1 Test: Preview Widget Queue Drain Scheduler](../test-specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md)
+- [x] [Reference Review Spec 75c2: Preview Command Application Efficiency](../specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md)
+- [x] [Reference Review Spec 75c2 Test: Preview Command Application Efficiency](../test-specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md)
+- [x] [Reference Review Spec 75d: Preview Render Queue Regression Tests](../specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md)
+- [x] [Reference Review Spec 75d Test: Preview Render Queue Regression Tests](../test-specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md)
+
 ## UI Evidence And Review Quality
 
 - [x] [Reference Review Spec 38: Component Gallery](../specifications/reference-review-38-component-gallery-v1_0.md)
@@ -154,4 +174,9 @@ payload boundary work is completed.
 2026-07-08: Specs 63-74 and their paired test specifications were added for
 the preview display-control icon assets, reusable icon controls, option-group
 controls, display option state, renderer option application, and composed
-button bar. They are intentionally unchecked until implemented and verified.
+button bar, then implemented and verified.
+
+2026-07-08: Specs 75a1-75d and their paired test specifications were
+implemented with a coalesced preview render command queue, stale future
+exception guards, queued shell-to-widget handoff, single-drain display command
+application, and focused regression coverage.

--- a/project/release-0.1.0a/specifications/reference-review-75-preview-render-command-queue-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75-preview-render-command-queue-v1_0.md
@@ -1,0 +1,393 @@
+# Reference Review Spec 75: Preview Render Command Queue (v1.0)
+
+## Overview
+
+Add a typed, bounded, Qt-aware preview render command queue so fixture loads,
+payload completions, display-control toggles, and renderer lifecycle changes
+are decoupled from direct renderer mutation.
+
+This is an ad hoc remediation spec derived from the 2026-07-08 concurrency
+review of the live Reference Review preview path.
+
+## Backlink
+
+- [Architecture: Reference Review Async Concurrency](../architecture/reference-review-async-concurrency.md)
+- [Architecture: Reference Review Preview Qt Wrapper Architecture](../architecture/reference-review-preview-qt-wrapper-architecture.md)
+- [Architecture: Reference Review Preview Payload Boundary Architecture](../architecture/reference-review-preview-payload-boundary-architecture.md)
+
+## Source Manifest
+
+- Ad hoc source: preview concurrency/threading review on 2026-07-08.
+- Related implemented leaves:
+  - [Reference Review Spec 05: UI Thread Handoff And Sanitized Task Errors](reference-review-05-ui-thread-handoff-and-sanitized-task-errors-v1_0.md)
+  - [Reference Review Spec 51: Preview Payload Process Controller](reference-review-51-preview-payload-process-controller-v1_0.md)
+  - [Reference Review Spec 55: Preview Widget Renderer Lifecycle](reference-review-55-preview-widget-renderer-lifecycle-v1_0.md)
+  - [Reference Review Spec 56: Preview Widget Payload Application](reference-review-56-preview-widget-payload-application-v1_0.md)
+  - [Reference Review Spec 70: Preview Display Command Routing](reference-review-70-preview-display-command-routing-v1_0.md)
+- Manifest score: 75.5 before split
+
+## Scope
+
+This specification covers:
+
+- a typed preview render command record for payload, display-options, clear,
+  reset-camera, and failure/diagnostic state transitions
+- a bounded/coalescing preview render command queue owned by the UI preview
+  surface controller
+- a Qt queued-signal handoff for worker completions and UI-originated preview
+  commands
+- replacement of direct renderer mutation from future polling, fixture
+  selection, payload handoff, and display-control button handlers
+- stale-result rejection for both successful and failed payload completions
+  before any preview widget state is cleared or rendered
+
+This specification does not replace the preview payload process worker or the
+shared `impression.preview_qt.QtPreviewSurface`; it routes access to them.
+
+## Responsibilities
+
+- Functions/methods:
+  - enqueue preview command
+  - coalesce display-options and payload-apply commands
+  - drain at most one latest render command per Qt event-loop tick
+  - reject stale command identities before widget mutation
+  - convert payload worker completions and failures into render commands
+  - execute clear/reset/render commands only on the Qt UI thread
+- Data structures/models:
+  - `PreviewRenderCommand`
+  - `PreviewRenderCommandKind`
+  - `PreviewRenderCommandQueue`
+  - `PreviewRenderQueueState`
+  - `PreviewRenderCommandResult`
+- Dependencies/services:
+  - Qt `QObject` signal/slot queued delivery
+  - existing `PreviewPayloadProcessController`
+  - existing `PreviewDisplayOptions`
+  - existing `PreviewRendererLifecycleWidget`
+  - existing shared `QtPreviewSurface`
+- Returns/outputs/signals:
+  - queued command acceptance/rejection diagnostic
+  - render command completion state
+  - preview ready/failure visible state update
+- UI surfaces/components:
+  - Reference Review preview pane
+  - preview display-control button row
+- UI fields/elements:
+  - preview viewport
+  - preview unavailable/loading status text
+  - preview display-control enabled state
+- Reusable code plan:
+  - Existing code reused as-is:
+    - `ReviewWorkbenchMessage`
+    - `WorkerResultEnvelope`
+    - `PreviewPayloadProcessController`
+    - `PreviewDisplayOptions`
+    - `QtPreviewSurface`
+  - Additions to existing reusable library/module:
+    - add preview render command queue records to the Reference Review UI
+      preview boundary
+  - New reusable library/module to create:
+    - `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - all preview renderer mutation occurs on the Qt UI thread
+  - worker results and UI actions enqueue typed commands rather than calling
+    renderer methods directly
+  - queue is bounded and coalesces repeated commands so interaction cannot
+    accumulate unbounded render work
+  - stale commands cannot clear or overwrite the current preview
+- Destructive/write behavior:
+  - none; payload cleanup remains owned by `PreviewPayloadProcessController`
+- Security/privacy-sensitive behavior:
+  - diagnostics stay sanitized before visible UI handoff
+- Performance-sensitive behavior:
+  - display toggles produce at most one renderer scene application per event
+    loop drain
+  - payload deserialization must not be repeated when only display options
+    change
+  - queue draining must not render more often than necessary for the latest
+    state
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+- `src/impression/devtools/reference_review/ui/shell.py`
+- `src/impression/devtools/reference_review/ui/preview_widget.py`
+
+Routes:
+
+- fixture selection:
+  - launch payload worker
+  - enqueue loading/clear state
+  - enqueue payload application only after current successful completion
+- worker completion:
+  - convert future result or exception into a typed command
+  - reject stale identities before visible mutation
+- display controls:
+  - route button command to `PreviewDisplayOptions`
+  - enqueue a display-options command
+  - queue coalesces repeated display-options commands
+- renderer:
+  - preview widget/controller drains queue and mutates `QtPreviewSurface` or
+    `SoftwarePreviewSurface` only on the Qt UI thread
+
+Reuse/extraction decision:
+
+- Keep process-pool payload building as-is.
+- Keep shared `impression.preview_qt` renderer surface as-is.
+- Add a small Reference Review UI command queue rather than introducing
+  Celery, RQ, asyncio queues, or a third-party message broker.
+- Use Qt queued signals for cross-thread UI handoff when worker callbacks are
+  introduced.
+
+UI field/control inventory:
+
+- preview viewport
+- preview loading/unavailable text
+- preview display-control row enabled/disabled state
+- reset view command
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- Queue capacity: one command per coalescing lane.
+- Coalescing lanes:
+  - `payload`: latest payload application for current fixture
+  - `display`: latest display-options state
+  - `lifecycle`: clear/loading/failure/reset commands
+- Drain policy:
+  - a `QTimer.singleShot(0, drain)` or equivalent queued Qt signal schedules
+    drain after enqueue
+  - one drain applies the latest coherent state, not every intermediate state
+- Staleness identity:
+  - owner
+  - request id
+  - fixture id
+  - generation
+- Failure handling:
+  - stale failures are discarded
+  - current failures enqueue a failure-state command
+  - future exceptions without a matching current identity must not clear the
+    current preview
+
+Data ownership:
+
+- payload process controller owns worker launch, active identity, payload
+  cleanup, and stale payload decisions
+- preview render command queue owns pending render commands
+- preview widget owns decoded current datasets and renderer lifecycle
+- renderer surface owns VTK/QtInteractor lifetime only
+
+Open questions and resolved assumptions:
+
+- Use stdlib `queue.Queue` only if cross-thread producers need a Python
+  synchronized queue; otherwise a UI-thread-owned coalescing deque/dict is
+  enough.
+- Do not introduce external queue libraries for this leaf.
+- Existing polling may remain temporarily if it only enqueues commands and
+  stops mutating widgets directly.
+
+Implementation prerequisites:
+
+- existing preview payload process controller
+- existing preview display options state and command routing
+- existing shared Qt preview surface
+
+## Concurrency Contract
+
+Ownership:
+
+- `PreviewPayloadProcessController` owns request identity and payload cleanup.
+- `PreviewRenderCommandQueue` owns pending preview commands.
+- `PreviewRendererLifecycleWidget` owns decoded datasets and render surface
+  lifecycle.
+
+Isolation:
+
+- Commands must carry explicit kind and identity.
+- A command without the current identity may update only neutral loading/empty
+  state when explicitly requested by current selection logic.
+
+Ordering:
+
+- If request B is selected after request A, request A success or failure cannot
+  clear, render, or enable controls for request B.
+- Display commands after a payload command apply to the current decoded
+  datasets without reloading payload JSON.
+
+Staleness:
+
+- Staleness is checked before status text, display controls, datasets, or
+  renderer state are mutated.
+
+Thread affinity:
+
+- Qt widgets, `QtPreviewSurface`, `QtInteractor`, and `SoftwarePreviewSurface`
+  are touched only on the Qt UI thread.
+- Worker completions cross into the UI thread through Qt queued delivery or
+  are polled by the UI thread and then enqueued.
+
+Resource lifetime:
+
+- Queue/controller lifetime is tied to the preview widget/window.
+- Pending commands are cleared on close before renderer disposal.
+
+Shared state:
+
+- Commands are frozen dataclasses.
+- Dataset arrays are immutable-by-convention once stored on the widget.
+
+Cancellation/timeout:
+
+- Cancellation remains best-effort for running process-pool work.
+- Completed stale work is discarded and cleaned up through the existing
+  payload controller.
+
+Backpressure:
+
+- Queue capacity is bounded by coalescing lanes.
+- Repeated display toggles replace the pending display command.
+- Repeated fixture selections replace pending payload/lifecycle commands for
+  older identities.
+
+Failure path:
+
+- Current failure commands show sanitized preview-unavailable text and disable
+  display controls.
+- Stale failure commands are recorded only as diagnostics if needed; they do
+  not mutate visible preview state.
+
+Validation:
+
+- Tests must exercise rapid fixture selection, rapid display toggles, stale
+  success, stale failure, and future exception paths through the integrated
+  shell/widget route.
+
+## Behavior
+
+The implementation must:
+
+- Introduce a typed preview render command queue with deterministic coalescing.
+- Stop direct renderer mutation from:
+  - `_poll_preview_payloads`
+  - `_apply_preview_payload_ready`
+  - `_apply_preview_payload_failed`
+  - `_route_preview_display_command`
+  - fixture selection/loading paths
+- Preserve one long-lived render surface per preview widget.
+- Preserve current payload cleanup behavior.
+- Apply display-option changes without re-reading payload JSON and without
+  resetting the camera.
+- Apply at most one coherent renderer scene update per queue drain.
+- Keep offscreen tests using fake/software render surfaces.
+
+## Verification
+
+Test strategy:
+
+- focused unit tests for command queue coalescing and stale rejection
+- shell integration tests for stale success/failure/exception behavior
+- display-control integration tests proving multiple toggles coalesce into one
+  renderer update
+- renderer lifecycle tests proving the surface is not recreated by queued
+  commands
+
+Additional verification requirements:
+
+- run:
+  - `.venv/bin/python -m pytest tests/test_reference_review_async_core.py tests/test_reference_review_ui_shell.py tests/test_reference_review_preview_payload_controller.py -q`
+  - `.venv/bin/python -m pytest tests/test_preview_controller.py -q`
+- run `git diff --check`
+- manually launch:
+  - `.venv/bin/impression-reference-review --fixture-file tests/reference_review_fixtures/dirty-impress-fixtures.json`
+- manual smoke:
+  - rapidly select fixtures
+  - rapidly toggle authored/inspection color, object edges, triangle wireframe,
+    bounds grid, and axis triad
+  - verify no beachball, stale failure, stale success, or old payload clears
+    the current preview
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 6 x 2 = 12
+- Data structures/models: 4 x 1 = 4
+- Dependencies/services: 5 x 1 = 5
+- Returns/outputs/signals: 3 x 1 = 3
+- Existing reusable code reused as-is: 5 x 0.5 = 2.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 1 x 3 = 3
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 3 x 2 = 6
+- UI surfaces/components: 2 x 2 = 4
+- UI fields/elements: 4 x 1 = 4
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 8 x 3 = 24
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total before split: 75.5
+
+Split decision:
+
+- Split required by score. For implementation, this ad hoc spec should be
+  treated as a short remediation program with these final implementation
+  slices:
+  - 75a: Preview render command records and coalescing queue
+  - 75b: Qt queued handoff and shell completion routing
+  - 75c: Preview widget command drain and renderer mutation boundary
+  - 75d: Integrated stale/rapid-interaction regression tests
+
+## Refinement Status
+
+Ad hoc remediation program spec. Split into child final leaves before
+implementation unless the implementation pass is explicitly scoped to one
+listed child slice.
+
+## Child Specifications
+
+- [Reference Review Spec 75a: Preview Render Command Records And Coalescing Queue](reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md)
+- [Reference Review Spec 75a1: Preview Render Command Record Contract](reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+- [Reference Review Spec 75a2: Preview Render Coalescing Queue](reference-review-75a2-preview-render-coalescing-queue-v1_0.md)
+- [Reference Review Spec 75b: Qt Queued Completion Handoff And Shell Routing](reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md)
+- [Reference Review Spec 75b1: Preview Future Identity And Stale Exception Guard](reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md)
+- [Reference Review Spec 75b2: Preview Completion To Command Routing](reference-review-75b2-preview-completion-to-command-routing-v1_0.md)
+- [Reference Review Spec 75c: Preview Widget Command Drain And Renderer Mutation Boundary](reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md)
+- [Reference Review Spec 75c1: Preview Widget Queue Drain Scheduler](reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md)
+- [Reference Review Spec 75c2: Preview Command Application Efficiency](reference-review-75c2-preview-command-application-efficiency-v1_0.md)
+- [Reference Review Spec 75d: Preview Render Queue Regression Tests](reference-review-75d-preview-render-queue-regression-tests-v1_0.md)
+
+## Five-Pass Review Log
+
+- Pass 1: Scope/readiness review. Confirmed Spec 75 is a remediation program,
+  not a final implementation leaf.
+- Pass 2: Score integrity review. Found Spec 75a undercounted the new reusable
+  module and Specs 75b/75c were too broad for final leaves.
+- Pass 3: Split review. Split command records from queue behavior, shell future
+  exception guarding from completion routing, and widget drain scheduling from
+  renderer application efficiency.
+- Pass 4: Test-spec review. Added paired test specifications for every final
+  leaf and kept broader parent test specs as rollups.
+- Pass 5: Progression/readiness review. Updated progression to include only
+  final leaves and paired test specs; parent specs remain durable context but
+  are not implementation items.
+
+## Acceptance
+
+This specification is complete when:
+
+- child final leaves exist or this spec is explicitly split during
+  implementation intake
+- the preview path is message-driven from worker completion and UI actions to
+  renderer mutation
+- stale completions and exceptions cannot clear or overwrite the current
+  preview
+- rapid fixture selection and rapid display toggles do not generate unbounded
+  renderer work

--- a/project/release-0.1.0a/specifications/reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md
@@ -1,0 +1,169 @@
+# Reference Review Spec 75a: Preview Render Command Records And Coalescing Queue (v1.0)
+
+## Overview
+
+Add the typed command records and bounded coalescing queue used by the
+Reference Review preview path.
+
+## Backlink
+
+- [Reference Review Spec 75: Preview Render Command Queue](reference-review-75-preview-render-command-queue-v1_0.md)
+
+## Source Manifest
+
+- This leaf is derived from ad hoc remediation spec 75.
+- Manifest score: 26.5 before split
+
+## Scope
+
+This specification covers:
+
+- `PreviewRenderCommandKind`
+- `PreviewRenderCommand`
+- `PreviewRenderQueueState`
+- `PreviewRenderCommandResult`
+- `PreviewRenderCommandQueue`
+- deterministic replacement/coalescing rules for payload, display, lifecycle,
+  reset, and failure commands
+
+## Responsibilities
+
+- Functions/methods:
+  - enqueue command
+  - coalesce command by lane
+  - drain pending commands
+  - clear pending commands
+- Data structures/models:
+  - render command kind
+  - render command
+  - queue state
+  - command result
+- Dependencies/services:
+  - existing payload identity records
+  - existing `PreviewDisplayOptions`
+- Returns/outputs/signals:
+  - accepted/replaced/rejected command result
+- UI surfaces/components:
+  - preview pane command source
+- UI fields/elements:
+  - none directly
+- Reusable code plan:
+  - New reusable library/module to create:
+    - `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - queue records are immutable and safe to pass between producer paths
+  - queue stores bounded latest commands only
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - no raw paths beyond already-sanitized diagnostics
+- Performance-sensitive behavior:
+  - repeated display commands collapse to one latest command
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+
+Routes:
+
+- imported by preview shell and preview widget/controller only
+
+Reuse/extraction decision:
+
+- create a small project-local typed queue rather than adding an external
+  message-queue dependency
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- lanes: `payload`, `display`, `lifecycle`, `camera`
+- latest command wins within each lane
+- stale identity rejection is supported by command fields but applied by later
+  leaves
+
+Data ownership:
+
+- queue owns pending commands only
+
+Open questions and resolved assumptions:
+
+- no external queue library is required for this leaf
+
+Implementation prerequisites:
+
+- existing `PreviewDisplayOptions`
+- existing payload identity fields
+
+## Behavior
+
+The implementation must:
+
+- create frozen command records
+- reject unknown command kinds
+- coalesce repeated commands by lane
+- drain commands in deterministic order:
+  - lifecycle/failure
+  - payload
+  - display
+  - camera
+- expose queue state for tests
+
+## Verification
+
+Test strategy:
+
+- unit tests for record validation, lane mapping, coalescing, drain order, and
+  clearing pending commands
+
+Additional verification requirements:
+
+- run focused Reference Review async/UI tests and `git diff --check`
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 4 x 2 = 8
+- Data structures/models: 4 x 1 = 4
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 1 x 3 = 3
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 0 x 2 = 0
+- UI fields/elements: 0 x 1 = 0
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 2 x 3 = 6
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 26.5
+
+Split decision:
+
+- Split required. Split into Spec 75a1 for command records and Spec 75a2 for
+  queue coalescing behavior.
+
+## Refinement Status
+
+Split parent. Do not implement this document directly.
+
+## Child Specifications
+
+- [Reference Review Spec 75a1: Preview Render Command Record Contract](reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+- [Reference Review Spec 75a2: Preview Render Coalescing Queue](reference-review-75a2-preview-render-coalescing-queue-v1_0.md)
+
+## Acceptance
+
+This specification is complete when:
+
+- Specs 75a1 and 75a2 are implemented and verified

--- a/project/release-0.1.0a/specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md
@@ -1,0 +1,158 @@
+# Reference Review Spec 75a1: Preview Render Command Record Contract (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one immutable command-record contract with validation and focused unit tests.
+
+## Overview
+
+Define immutable preview render command records that can carry payload,
+display, lifecycle, failure, and camera commands without mutating Qt widgets.
+
+## Backlink
+
+- [Reference Review Spec 75: Preview Render Command Queue](reference-review-75-preview-render-command-queue-v1_0.md)
+- [Reference Review Spec 75a: Preview Render Command Records And Coalescing Queue](reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75a.
+- Manifest score: 14.5
+
+## Scope
+
+This specification covers:
+
+- `PreviewRenderCommandKind`
+- `PreviewRenderCommand`
+- `PreviewRenderCommandResult`
+- command identity fields
+- command validation
+
+## Responsibilities
+
+- Functions/methods:
+  - command construction validation
+- Data structures/models:
+  - render command kind
+  - render command
+  - command result
+- Dependencies/services:
+  - existing payload identity shape
+- Returns/outputs/signals:
+  - command result record
+- UI surfaces/components:
+  - none
+- UI fields/elements:
+  - none
+- Reusable code plan:
+  - New reusable library/module to create:
+    - `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - commands are frozen and safe to pass between producer paths
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - no unsanitized raw diagnostic text is introduced by command records
+- Performance-sensitive behavior:
+  - none
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+
+Routes:
+
+- imported by shell and preview widget/controller after this leaf
+
+Reuse/extraction decision:
+
+- create a local typed command module; do not add external queue dependencies
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- command kinds are explicit enum values
+- identity fields are optional only for neutral lifecycle commands
+
+Data ownership:
+
+- records own immutable command data only
+
+Open questions and resolved assumptions:
+
+- no external queue library is required
+
+Implementation prerequisites:
+
+- existing payload identity fields
+
+## Behavior
+
+The implementation must:
+
+- reject unknown command kinds
+- preserve identity fields for stale-result checks
+- support command results suitable for queue diagnostics
+
+## Verification
+
+Test strategy:
+
+- unit tests for enum validation, immutable records, identity fields, and
+  command result values
+
+Additional verification requirements:
+
+- run queue-related tests and `git diff --check`
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 1 x 2 = 2
+- Data structures/models: 3 x 1 = 3
+- Dependencies/services: 1 x 1 = 1
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 1 x 3 = 3
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 0 x 2 = 0
+- UI surfaces/components: 0 x 2 = 0
+- UI fields/elements: 0 x 1 = 0
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 14.5
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf defines only the immutable
+  command contract.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when command records exist and are covered by
+unit tests.

--- a/project/release-0.1.0a/specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md
@@ -1,0 +1,167 @@
+# Reference Review Spec 75a2: Preview Render Coalescing Queue (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one bounded coalescing queue using the command records from Spec 75a1.
+
+## Overview
+
+Add the bounded/coalescing queue that stores only the latest preview render
+command per lane.
+
+## Backlink
+
+- [Reference Review Spec 75a1: Preview Render Command Record Contract](reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75a.
+- Manifest score: 20.5
+
+## Scope
+
+This specification covers:
+
+- `PreviewRenderCommandQueue`
+- `PreviewRenderQueueState`
+- lane mapping
+- command enqueue/coalescing
+- deterministic drain order
+- clearing pending commands
+
+## Responsibilities
+
+- Functions/methods:
+  - enqueue command
+  - coalesce command by lane
+  - drain pending commands
+  - clear pending commands
+- Data structures/models:
+  - queue state
+- Dependencies/services:
+  - Spec 75a1 command records
+- Returns/outputs/signals:
+  - accepted/replaced/rejected command result
+- UI surfaces/components:
+  - none
+- UI fields/elements:
+  - none
+- Reusable code plan:
+  - Existing code reused as-is:
+    - Spec 75a1 command records
+  - Additions to existing reusable library/module:
+    - add queue behavior to `preview_render_queue.py`
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - queue stores bounded latest commands only
+  - queue does not execute renderer work
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - none
+- Performance-sensitive behavior:
+  - repeated display commands collapse to one latest command
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_render_queue.py`
+
+Routes:
+
+- shell and preview widget/controller will use this queue in later leaves
+
+Reuse/extraction decision:
+
+- implement a small typed coalescing queue rather than using a general
+  third-party message queue
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- lanes: `payload`, `display`, `lifecycle`, `camera`
+- latest command wins within each lane
+- drain order: lifecycle, payload, display, camera
+
+Data ownership:
+
+- queue owns pending commands only
+
+Open questions and resolved assumptions:
+
+- stale identity rejection is supported by command fields but enforced in
+  shell/widget leaves
+
+Implementation prerequisites:
+
+- Spec 75a1
+
+## Behavior
+
+The implementation must:
+
+- coalesce repeated commands by lane
+- return a result indicating accepted, replaced, or rejected state
+- expose queue state for tests
+
+## Verification
+
+Test strategy:
+
+- unit tests for lane mapping, coalescing, drain order, and clearing pending
+  commands
+
+Additional verification requirements:
+
+- run queue-related tests and `git diff --check`
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 4 x 2 = 8
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 1 x 1 = 1
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 0 x 2 = 0
+- UI fields/elements: 0 x 1 = 0
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 2 x 3 = 6
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 20.5
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf implements one bounded
+  coalescing queue and does not mutate UI or renderer state.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when the queue behavior is implemented and
+covered by unit tests.

--- a/project/release-0.1.0a/specifications/reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md
@@ -1,0 +1,177 @@
+# Reference Review Spec 75b: Qt Queued Completion Handoff And Shell Routing (v1.0)
+
+## Overview
+
+Route preview payload completions and failures into the preview command queue
+without directly mutating preview widgets from future polling or worker
+callbacks.
+
+## Backlink
+
+- [Reference Review Spec 75: Preview Render Command Queue](reference-review-75-preview-render-command-queue-v1_0.md)
+
+## Source Manifest
+
+- This leaf is derived from ad hoc remediation spec 75.
+- Manifest score: 40 before split
+
+## Scope
+
+This specification covers:
+
+- converting successful payload completions into payload render commands
+- converting current failures into failure render commands
+- discarding stale successes and stale failures before visible preview mutation
+- ensuring future exceptions are identity-aware and cannot clear the current
+  preview
+- using Qt queued delivery or UI-thread polling only as an enqueue mechanism
+
+## Responsibilities
+
+- Functions/methods:
+  - future completion handling
+  - payload-ready command enqueue
+  - payload-failed command enqueue
+  - stale exception rejection
+  - preview display-control enable/disable routing
+- Data structures/models:
+  - future-to-request identity map
+  - completion command
+- Dependencies/services:
+  - `PreviewPayloadProcessController`
+  - `PreviewRenderCommandQueue`
+  - Qt signal/slot queued delivery
+- Returns/outputs/signals:
+  - queued payload/failure command
+  - rejected stale completion diagnostic
+- UI surfaces/components:
+  - Reference Review shell
+- UI fields/elements:
+  - preview unavailable/loading text
+  - display-control enabled state
+- Reusable code plan:
+  - Existing code reused as-is:
+    - payload process controller
+    - render command queue
+  - Additions to existing reusable library/module:
+    - shell routing helpers
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - no worker completion directly mutates Qt widgets
+  - stale completions and exceptions are rejected before enqueue
+- Destructive/write behavior:
+  - payload cleanup remains owned by payload controller
+- Security/privacy-sensitive behavior:
+  - visible diagnostics remain sanitized
+- Performance-sensitive behavior:
+  - polling or callbacks enqueue a command and return quickly
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+- `src/impression/devtools/reference_review/async_core/qt_handoff.py`
+
+Routes:
+
+- `PreviewPayloadProcessController.handle_completion` returns events that shell
+  converts to render commands
+- future exception path also routes through identity-aware command handling
+
+Reuse/extraction decision:
+
+- keep `ProcessPoolExecutor` payload workers
+- use Qt queued signals when crossing threads; polling may remain only if it
+  enqueues commands and does not mutate widgets
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- future identity is stored when launch returns an accepted future
+- exceptions from untracked or stale futures are ignored for visible preview
+  state
+
+Data ownership:
+
+- shell owns future tracking
+- payload controller owns active identity
+- queue owns pending render commands
+
+Open questions and resolved assumptions:
+
+- no external queue dependency is required
+
+Implementation prerequisites:
+
+- Spec 75a
+
+## Behavior
+
+The implementation must:
+
+- stop direct calls to preview widget `set_preview_payload` and `clear_preview`
+  from future polling
+- enqueue payload/failure commands instead
+- prevent stale exceptions from clearing current preview state
+- keep preview display controls disabled until a current payload command is
+  applied successfully
+
+## Verification
+
+Test strategy:
+
+- shell tests for stale success, stale failure, stale exception, and current
+  failure behavior
+
+Additional verification requirements:
+
+- run Reference Review shell and payload-controller tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 5 x 2 = 10
+- Data structures/models: 2 x 1 = 2
+- Dependencies/services: 3 x 1 = 3
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 2 x 1 = 2
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 4 x 3 = 12
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 40
+
+Split decision:
+
+- Split required. Split into Spec 75b1 for future identity/stale exception
+  guarding and Spec 75b2 for current completion-to-command routing.
+
+## Refinement Status
+
+Split parent. Do not implement this document directly.
+
+## Child Specifications
+
+- [Reference Review Spec 75b1: Preview Future Identity And Stale Exception Guard](reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md)
+- [Reference Review Spec 75b2: Preview Completion To Command Routing](reference-review-75b2-preview-completion-to-command-routing-v1_0.md)
+
+## Acceptance
+
+This specification is complete when:
+
+- Specs 75b1 and 75b2 are implemented and verified

--- a/project/release-0.1.0a/specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md
@@ -1,0 +1,162 @@
+# Reference Review Spec 75b1: Preview Future Identity And Stale Exception Guard (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one shell-owned future identity guard that prevents stale exceptions from mutating preview state.
+
+## Overview
+
+Track preview futures by request identity so stale future exceptions cannot
+clear or overwrite the current preview.
+
+## Backlink
+
+- [Reference Review Spec 75b: Qt Queued Completion Handoff And Shell Routing](reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75b.
+- Manifest score: 22.5
+
+## Scope
+
+This specification covers:
+
+- future-to-request identity tracking
+- stale future exception rejection
+- current future exception conversion into a queued failure command
+
+## Responsibilities
+
+- Functions/methods:
+  - track accepted future identity
+  - classify future exception freshness
+  - enqueue current failure command
+- Data structures/models:
+  - future identity map
+- Dependencies/services:
+  - `PreviewPayloadProcessController`
+  - Spec 75a command queue
+- Returns/outputs/signals:
+  - stale/current exception decision
+- UI surfaces/components:
+  - Reference Review shell
+- UI fields/elements:
+  - preview unavailable text
+- Reusable code plan:
+  - Existing code reused as-is:
+    - payload process controller active identity
+  - Additions to existing reusable library/module:
+    - shell future tracking helpers
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - stale exceptions cannot mutate preview state
+  - future handling only enqueues commands
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - visible exception text remains sanitized
+- Performance-sensitive behavior:
+  - exception handling returns quickly after enqueue/discard
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+
+Routes:
+
+- payload launch stores accepted future identity
+- polling/callback exception handling consults identity before enqueue
+
+Reuse/extraction decision:
+
+- keep `ProcessPoolExecutor`; do not add external queue dependencies
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- untracked future exceptions are ignored for visible preview state
+- stale future exceptions are ignored for visible preview state
+
+Data ownership:
+
+- shell owns future identity map
+
+Open questions and resolved assumptions:
+
+- diagnostics may be retained later, but visible mutation is forbidden for
+  stale exceptions
+
+Implementation prerequisites:
+
+- Spec 75a1
+- Spec 75a2
+
+## Behavior
+
+The implementation must:
+
+- prevent stale future exceptions from calling `clear_preview`
+- enqueue a current failure command for current future exceptions
+
+## Verification
+
+Test strategy:
+
+- shell tests for stale exception and current exception paths
+
+Additional verification requirements:
+
+- run Reference Review shell tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 3 x 2 = 6
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 2 x 3 = 6
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 22.5
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf only tracks future identity and
+  prevents stale exceptions from mutating visible preview state.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when stale future exceptions cannot clear the
+current preview.

--- a/project/release-0.1.0a/specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md
@@ -1,0 +1,165 @@
+# Reference Review Spec 75b2: Preview Completion To Command Routing (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one routing change from current payload completion events into render queue commands.
+
+## Overview
+
+Convert current preview payload successes and failures into render queue
+commands without directly mutating preview widgets.
+
+## Backlink
+
+- [Reference Review Spec 75b: Qt Queued Completion Handoff And Shell Routing](reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75b.
+- Manifest score: 24
+
+## Scope
+
+This specification covers:
+
+- current successful payload completion to payload command
+- current failed payload completion to failure command
+- stale successful/failed completion discard before enqueue
+- display-control readiness remains disabled until payload command applies
+
+## Responsibilities
+
+- Functions/methods:
+  - payload-ready command enqueue
+  - payload-failed command enqueue
+  - stale completion discard
+- Data structures/models:
+  - completion-to-command mapping
+- Dependencies/services:
+  - `PreviewPayloadProcessController`
+  - Spec 75a command queue
+- Returns/outputs/signals:
+  - queued payload/failure command result
+- UI surfaces/components:
+  - Reference Review shell
+- UI fields/elements:
+  - display-control enabled state
+- Reusable code plan:
+  - Existing code reused as-is:
+    - payload process controller handoff decisions
+    - render command queue
+  - Additions to existing reusable library/module:
+    - shell command enqueue helpers
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - worker completions enqueue commands only
+- Destructive/write behavior:
+  - payload cleanup remains owned by payload controller
+- Security/privacy-sensitive behavior:
+  - visible diagnostics remain sanitized by existing payload controller
+- Performance-sensitive behavior:
+  - completion handling does not apply renderer work directly
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+
+Routes:
+
+- `PreviewPayloadProcessController.handle_completion` returns event
+- shell converts current event to queued command
+
+Reuse/extraction decision:
+
+- use existing payload controller staleness decisions
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- successful command does not enable controls until applied by widget drain
+- failed command disables controls through widget drain
+
+Data ownership:
+
+- shell owns completion-to-command routing only
+
+Open questions and resolved assumptions:
+
+- renderer mutation belongs to Spec 75c leaves
+
+Implementation prerequisites:
+
+- Spec 75a1
+- Spec 75a2
+- Spec 75b1
+
+## Behavior
+
+The implementation must:
+
+- stop direct `set_preview_payload` and `clear_preview` calls from completion
+  handlers
+- enqueue payload/failure commands instead
+
+## Verification
+
+Test strategy:
+
+- shell tests for current success, current failure, stale success, and stale
+  failure routing
+
+Additional verification requirements:
+
+- run Reference Review shell and payload-controller tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 3 x 2 = 6
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 24
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf only routes current/stale
+  completion events to command queue outcomes.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when payload completions enqueue commands and
+do not mutate renderer widgets directly.

--- a/project/release-0.1.0a/specifications/reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md
@@ -1,0 +1,180 @@
+# Reference Review Spec 75c: Preview Widget Command Drain And Renderer Mutation Boundary (v1.0)
+
+## Overview
+
+Make the preview widget/controller the only component that drains render
+commands and mutates the renderer surface.
+
+## Backlink
+
+- [Reference Review Spec 75: Preview Render Command Queue](reference-review-75-preview-render-command-queue-v1_0.md)
+
+## Source Manifest
+
+- This leaf is derived from ad hoc remediation spec 75.
+- Manifest score: 43 before split
+
+## Scope
+
+This specification covers:
+
+- preview widget command-drain method
+- Qt event-loop scheduling for queue drains
+- payload command application
+- display-options command application without payload JSON reload
+- lifecycle/failure command application
+- camera reset command application
+
+## Responsibilities
+
+- Functions/methods:
+  - schedule queue drain
+  - drain command queue
+  - apply payload command
+  - apply display command
+  - apply failure/lifecycle command
+  - apply camera command
+- Data structures/models:
+  - preview queue state consumed by widget
+- Dependencies/services:
+  - `PreviewRenderCommandQueue`
+  - `PreviewRendererLifecycleWidget`
+  - `QtPreviewSurface`
+  - `SoftwarePreviewSurface`
+- Returns/outputs/signals:
+  - command application result
+- UI surfaces/components:
+  - preview pane
+- UI fields/elements:
+  - preview viewport
+  - preview status text
+  - reset view command
+- Reusable code plan:
+  - Existing code reused as-is:
+    - shared Qt preview surface
+    - software preview fallback
+  - Additions to existing reusable library/module:
+    - preview widget command-drain methods
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - renderer mutation is UI-thread-only
+  - queue drain is scheduled, not nested recursively
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - sanitized diagnostics only
+- Performance-sensitive behavior:
+  - display commands must reuse decoded current datasets
+  - repeated toggles must result in one coherent render application per drain
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_widget.py`
+- `src/impression/preview_qt.py` only if a small non-reset display update hook
+  is required
+
+Routes:
+
+- shell enqueues commands
+- widget schedules and drains
+- renderer surface receives final coherent state
+
+Reuse/extraction decision:
+
+- do not add rendering logic to shell
+- do not add a second renderer path
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- drain is scheduled with Qt event-loop delivery
+- display command does not reset camera
+- payload command aligns camera only for new current payload
+
+Data ownership:
+
+- widget owns decoded current datasets
+- renderer owns render surface lifetime
+
+Open questions and resolved assumptions:
+
+- software fallback may continue to project in `paintEvent`; native Qt path
+  should remain shared-preview based
+
+Implementation prerequisites:
+
+- Spec 75a
+- Spec 75b
+
+## Behavior
+
+The implementation must:
+
+- make renderer mutation reachable only through queue drain
+- keep renderer long-lived
+- apply display options without re-reading payload files
+- avoid duplicate render/apply passes for one display toggle
+- preserve current ready/failure visible state semantics
+
+## Verification
+
+Test strategy:
+
+- widget tests with fake renderer proving one scene update after coalesced
+  toggles
+- widget tests proving payload JSON is not reread for display-only commands
+- lifecycle tests proving renderer is not recreated
+
+Additional verification requirements:
+
+- run Reference Review UI shell tests and preview controller tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 6 x 2 = 12
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 4 x 1 = 4
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 3 x 2 = 6
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 3 x 1 = 3
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 3 x 3 = 9
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 43
+
+Split decision:
+
+- Split required. Split into Spec 75c1 for queue drain scheduling and Spec
+  75c2 for efficient queued command application.
+
+## Refinement Status
+
+Split parent. Do not implement this document directly.
+
+## Child Specifications
+
+- [Reference Review Spec 75c1: Preview Widget Queue Drain Scheduler](reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md)
+- [Reference Review Spec 75c2: Preview Command Application Efficiency](reference-review-75c2-preview-command-application-efficiency-v1_0.md)
+
+## Acceptance
+
+This specification is complete when:
+
+- Specs 75c1 and 75c2 are implemented and verified

--- a/project/release-0.1.0a/specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md
@@ -1,0 +1,165 @@
+# Reference Review Spec 75c1: Preview Widget Queue Drain Scheduler (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one widget-owned event-loop drain scheduler for queued preview commands.
+
+## Overview
+
+Add the preview widget/controller drain scheduler that ensures queued preview
+commands are applied on the Qt UI thread and not recursively.
+
+## Backlink
+
+- [Reference Review Spec 75c: Preview Widget Command Drain And Renderer Mutation Boundary](reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75c.
+- Manifest score: 22.5
+
+## Scope
+
+This specification covers:
+
+- schedule queue drain
+- drain command queue
+- prevent nested drain scheduling
+- clear pending commands on close
+
+## Responsibilities
+
+- Functions/methods:
+  - schedule queue drain
+  - drain command queue
+  - guard nested drain
+  - clear pending commands
+- Data structures/models:
+  - queue drain state
+- Dependencies/services:
+  - Spec 75a coalescing queue
+  - `PreviewRendererLifecycleWidget`
+- Returns/outputs/signals:
+  - command application result
+- UI surfaces/components:
+  - preview pane
+- UI fields/elements:
+  - preview viewport
+- Reusable code plan:
+  - Existing code reused as-is:
+    - render command queue
+  - Additions to existing reusable library/module:
+    - preview widget drain methods
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - drain is Qt UI-thread-only
+  - drain scheduling is non-reentrant
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - none
+- Performance-sensitive behavior:
+  - one scheduled drain handles current coalesced state
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_widget.py`
+
+Routes:
+
+- shell enqueues commands
+- widget schedules a drain
+
+Reuse/extraction decision:
+
+- do not add renderer mutation to shell
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- drain is scheduled with Qt event-loop delivery
+- pending commands are cleared before renderer disposal
+
+Data ownership:
+
+- preview widget owns drain state
+
+Open questions and resolved assumptions:
+
+- native VTK rendering remains inside the existing renderer surface
+
+Implementation prerequisites:
+
+- Spec 75a1
+- Spec 75a2
+
+## Behavior
+
+The implementation must:
+
+- schedule exactly one pending drain while work is queued
+- avoid nested drain calls from command application
+- clear pending commands on close
+
+## Verification
+
+Test strategy:
+
+- widget tests for one scheduled drain, non-reentrant behavior, and close
+  cleanup
+
+Additional verification requirements:
+
+- run Reference Review UI shell tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 4 x 2 = 8
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 22.5
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf only schedules and drains
+  commands; actual renderer application details are in Spec 75c2.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when preview command drains are scheduled and
+owned by the preview widget.

--- a/project/release-0.1.0a/specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md
@@ -1,0 +1,173 @@
+# Reference Review Spec 75c2: Preview Command Application Efficiency (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one renderer-application efficiency change that applies queued payload/display commands without duplicate renderer work.
+
+## Overview
+
+Apply queued payload and display commands efficiently: payload commands load
+datasets once, display commands reuse decoded datasets, and one display state
+produces one renderer application.
+
+## Backlink
+
+- [Reference Review Spec 75c: Preview Widget Command Drain And Renderer Mutation Boundary](reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md)
+
+## Source Manifest
+
+- This leaf is split from ad hoc remediation spec 75c.
+- Manifest score: 23
+
+## Scope
+
+This specification covers:
+
+- payload command application
+- display-options command application without payload JSON reload
+- failure/lifecycle command application
+- camera reset command application
+- avoiding duplicate render/apply passes for one display update
+
+## Responsibilities
+
+- Functions/methods:
+  - apply payload command
+  - apply display command
+  - apply lifecycle/failure command
+- Data structures/models:
+  - none
+- Dependencies/services:
+  - `PreviewRendererLifecycleWidget`
+  - `QtPreviewSurface`
+  - `SoftwarePreviewSurface`
+- Returns/outputs/signals:
+  - command application result
+- UI surfaces/components:
+  - preview pane
+- UI fields/elements:
+  - preview viewport
+  - preview status text
+- Reusable code plan:
+  - Existing code reused as-is:
+    - shared Qt preview surface
+    - software preview fallback
+  - Additions to existing reusable library/module:
+    - preview widget command application helpers
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - renderer mutation happens only during widget-owned drain
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - sanitized diagnostics only
+- Performance-sensitive behavior:
+  - display commands reuse decoded datasets
+  - one display command yields one renderer scene update
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_widget.py`
+- `src/impression/preview_qt.py` only if a small non-reset display update hook
+  is required
+
+Routes:
+
+- widget drain calls command application helpers
+- renderer surface receives final coherent state
+
+Reuse/extraction decision:
+
+- keep one shared renderer path and do not add rendering logic to shell
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- display command does not reset camera
+- payload command aligns camera only for new current payload
+
+Data ownership:
+
+- widget owns decoded current datasets
+- renderer owns render surface lifetime
+
+Open questions and resolved assumptions:
+
+- software fallback may continue to project in `paintEvent`
+
+Implementation prerequisites:
+
+- Spec 75c1
+
+## Behavior
+
+The implementation must:
+
+- apply display options without re-reading payload files
+- avoid duplicate render/apply passes for one display toggle
+- preserve current ready/failure visible state semantics
+
+## Verification
+
+Test strategy:
+
+- widget tests with fake renderer proving one scene update after coalesced
+  toggles
+- widget tests proving payload JSON is not reread for display-only commands
+- lifecycle tests proving renderer is not recreated
+
+Additional verification requirements:
+
+- run Reference Review UI shell tests and preview controller tests
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 3 x 2 = 6
+- Data structures/models: 0 x 1 = 0
+- Dependencies/services: 3 x 1 = 3
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 2 x 2 = 4
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 2 x 1 = 2
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 23
+
+Split decision:
+
+- No split needed. Cohesion reason: this leaf only optimizes queued command
+  application inside the preview widget drain.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when queued payload/display commands mutate the
+renderer efficiently without duplicate render work or payload JSON reload.

--- a/project/release-0.1.0a/specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md
@@ -1,0 +1,168 @@
+# Reference Review Spec 75d: Preview Render Queue Regression Tests (v1.0)
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one regression-verification leaf for the preview render queue remediation.
+
+## Overview
+
+Add regression tests and manual smoke evidence for the preview render command
+queue remediation.
+
+## Backlink
+
+- [Reference Review Spec 75: Preview Render Command Queue](reference-review-75-preview-render-command-queue-v1_0.md)
+- [Reference Review Test Spec 75: Preview Render Command Queue](../test-specifications/reference-review-75-preview-render-command-queue-v1_0.md)
+
+## Source Manifest
+
+- This leaf is derived from ad hoc remediation spec 75.
+- Manifest score: 21.5
+
+## Scope
+
+This specification covers:
+
+- automated tests for Specs 75a-75c
+- manual smoke checklist updates for live `.impress` fixture review
+
+## Responsibilities
+
+- Functions/methods:
+  - test queue coalescing
+  - test stale completion rejection
+  - test display-toggle coalescing
+  - test renderer lifecycle preservation
+- Data structures/models:
+  - fake renderer
+  - fake payload completion
+- Dependencies/services:
+  - pytest
+  - PySide6 offscreen tests
+- Returns/outputs/signals:
+  - test diagnostics
+- UI surfaces/components:
+  - preview pane
+- UI fields/elements:
+  - preview viewport
+  - display-control row
+- Reusable code plan:
+  - Existing code reused as-is:
+    - existing Reference Review shell test helpers
+  - Additions to existing reusable library/module:
+    - none
+  - New reusable library/module to create:
+    - none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - tests exercise stale/rapid adjacent paths
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - sanitized failure text remains asserted
+- Performance-sensitive behavior:
+  - tests assert bounded renderer update count
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- `tests/test_reference_review_ui_shell.py`
+- `tests/test_reference_review_async_core.py`
+- optional new `tests/test_reference_review_preview_render_queue.py`
+
+Routes:
+
+- tests should use fake renderer surfaces where native VTK would be unstable
+  offscreen
+
+Reuse/extraction decision:
+
+- prefer small fake renderers over launching native VTK in automated tests
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- automated tests run offscreen
+- manual smoke uses dirty `.impress` fixture file
+
+Data ownership:
+
+- tests own temporary payload files and fake futures
+
+Open questions and resolved assumptions:
+
+- manual live interaction evidence remains required because offscreen tests
+  cannot prove native VTK responsiveness
+
+Implementation prerequisites:
+
+- Specs 75a-75c
+
+## Behavior
+
+The implementation must:
+
+- add automated coverage for the queue and UI integration
+- document manual smoke observations when implementation completes
+
+## Verification
+
+Test strategy:
+
+- run the paired test spec checklist
+
+Additional verification requirements:
+
+- run required validation commands from the paired test spec
+
+## Manifest Assessment
+
+Score:
+
+- Functions/methods: 3 x 2 = 6
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 21.5
+
+Split decision:
+
+- No split needed. Cohesion reason: this is the regression leaf for the
+  preview render command queue remediation and contains no production
+  implementation route.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when:
+
+- automated regression tests cover the queue remediation
+- manual smoke evidence is recorded after implementation

--- a/project/release-0.1.0a/test-specifications/reference-review-75-preview-render-command-queue-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75-preview-render-command-queue-v1_0.md
@@ -1,0 +1,91 @@
+# Reference Review Test Spec 75: Preview Render Command Queue (v1.0)
+
+## Overview
+
+Verify the ad hoc preview render command queue remediation for Reference
+Review. The tests must prove that preview worker completions and UI actions are
+decoupled from direct renderer mutation, stale completions are harmless, and
+rapid interaction is bounded.
+
+## Paired Specification
+
+- [Reference Review Spec 75: Preview Render Command Queue](../specifications/reference-review-75-preview-render-command-queue-v1_0.md)
+
+## Test Scope
+
+This test specification covers:
+
+- command record validation
+- queue coalescing
+- stale success/failure rejection
+- current failure presentation
+- display-option coalescing
+- renderer lifecycle preservation
+- shell integration for rapid selection and rapid display-control changes
+
+## Automated Tests
+
+Add focused tests for:
+
+- `PreviewRenderCommand` requires a known kind and carries identity fields.
+- `PreviewRenderCommandQueue` keeps only the latest display command.
+- `PreviewRenderCommandQueue` replaces stale payload commands with the newest
+  current payload command.
+- draining the queue applies at most one renderer scene update for repeated
+  display toggles.
+- display-option commands update an existing decoded dataset without re-reading
+  the payload JSON.
+- a stale successful payload completion does not call `set_preview_payload`.
+- a stale failed payload completion does not call `clear_preview`.
+- an exception from an old future does not clear the current preview.
+- current payload failure disables display controls and shows sanitized
+  unavailable text.
+- closing the window clears pending commands before renderer disposal.
+
+## Integration Tests
+
+Extend existing Reference Review UI shell tests to cover:
+
+- rapid selection of two fixtures where the first completion arrives last
+- rapid toggling of preview display controls while a payload is loading
+- rapid toggling of preview display controls after a payload is ready
+- renderer surface is created once and reused across queued payload/display
+  commands
+- fake renderer receives one coherent final command after coalesced toggles
+
+## Manual Smoke
+
+Run:
+
+```bash
+.venv/bin/impression-reference-review --fixture-file tests/reference_review_fixtures/dirty-impress-fixtures.json
+```
+
+Then verify:
+
+- rapidly select several fixtures
+- rapidly toggle authored/inspection color
+- rapidly toggle object edges and triangle wireframe
+- rapidly toggle bounds grid and axis triad
+- preview remains responsive
+- no old completion clears or overwrites the selected fixture
+- renderer does not beachball during interaction
+
+## Required Validation Commands
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tests/test_reference_review_async_core.py tests/test_reference_review_ui_shell.py tests/test_reference_review_preview_payload_controller.py -q
+.venv/bin/python -m pytest tests/test_preview_controller.py -q
+git diff --check
+```
+
+## Acceptance
+
+This test specification is complete when:
+
+- all automated tests above are implemented or explicitly mapped to equivalent
+  existing coverage
+- the required validation commands pass
+- the manual smoke launch is documented with observed behavior

--- a/project/release-0.1.0a/test-specifications/reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md
@@ -1,0 +1,19 @@
+# Reference Review Test Spec 75a: Preview Render Command Records And Coalescing Queue (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75a](../specifications/reference-review-75a-preview-render-command-records-and-coalescing-queue-v1_0.md)
+
+## Automated Tests
+
+- command kind validation
+- immutable command record fields
+- lane mapping for payload, display, lifecycle, camera, and failure commands
+- latest command wins within each lane
+- deterministic drain order
+- clear pending commands empties queue state
+
+## Acceptance
+
+- queue unit tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md
@@ -1,0 +1,18 @@
+# Reference Review Test Spec 75a1: Preview Render Command Record Contract (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75a1](../specifications/reference-review-75a1-preview-render-command-record-contract-v1_0.md)
+
+## Automated Tests
+
+- command kind enum rejects unknown values
+- command records are immutable
+- identity fields are preserved
+- neutral lifecycle commands may omit identity
+- command result values are deterministic
+
+## Acceptance
+
+- command-record unit tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md
@@ -1,0 +1,18 @@
+# Reference Review Test Spec 75a2: Preview Render Coalescing Queue (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75a2](../specifications/reference-review-75a2-preview-render-coalescing-queue-v1_0.md)
+
+## Automated Tests
+
+- lane mapping for payload, display, lifecycle, and camera commands
+- latest command wins within each lane
+- enqueue result reports accepted or replaced
+- drain order is lifecycle, payload, display, camera
+- clearing pending commands empties queue state
+
+## Acceptance
+
+- coalescing queue unit tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md
@@ -1,0 +1,19 @@
+# Reference Review Test Spec 75b: Qt Queued Completion Handoff And Shell Routing (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75b](../specifications/reference-review-75b-qt-queued-completion-handoff-and-shell-routing-v1_0.md)
+
+## Automated Tests
+
+- current successful completion enqueues payload command
+- current failure enqueues failure command and disables display controls
+- stale successful completion does not enqueue payload command
+- stale failed completion does not clear current preview
+- stale future exception does not clear current preview
+- completion routing does not directly call renderer mutation methods
+
+## Acceptance
+
+- shell completion tests pass
+- payload-controller tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md
@@ -1,0 +1,16 @@
+# Reference Review Test Spec 75b1: Preview Future Identity And Stale Exception Guard (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75b1](../specifications/reference-review-75b1-preview-future-identity-and-stale-exception-guard-v1_0.md)
+
+## Automated Tests
+
+- accepted preview future is tracked with request identity
+- stale future exception does not call `clear_preview`
+- untracked future exception does not mutate visible preview state
+- current future exception enqueues a failure command
+
+## Acceptance
+
+- shell future-exception tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md
@@ -1,0 +1,18 @@
+# Reference Review Test Spec 75b2: Preview Completion To Command Routing (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75b2](../specifications/reference-review-75b2-preview-completion-to-command-routing-v1_0.md)
+
+## Automated Tests
+
+- current successful completion enqueues payload command
+- current failure enqueues failure command
+- stale successful completion does not enqueue payload command
+- stale failed completion does not enqueue failure command
+- completion handlers do not directly call renderer mutation methods
+
+## Acceptance
+
+- shell completion-routing tests pass
+- payload-controller tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md
@@ -1,0 +1,19 @@
+# Reference Review Test Spec 75c: Preview Widget Command Drain And Renderer Mutation Boundary (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75c](../specifications/reference-review-75c-preview-widget-command-drain-and-renderer-mutation-boundary-v1_0.md)
+
+## Automated Tests
+
+- queued payload command applies datasets through fake renderer
+- queued display command reuses current decoded datasets
+- repeated display toggles produce one final renderer update
+- display command does not reset camera
+- payload command aligns camera for new payload
+- renderer surface is not recreated by queued commands
+
+## Acceptance
+
+- widget command-drain tests pass
+- preview controller tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md
@@ -1,0 +1,16 @@
+# Reference Review Test Spec 75c1: Preview Widget Queue Drain Scheduler (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75c1](../specifications/reference-review-75c1-preview-widget-queue-drain-scheduler-v1_0.md)
+
+## Automated Tests
+
+- enqueue schedules one drain
+- repeated enqueue while scheduled does not schedule nested drains
+- drain clears pending scheduled state
+- close clears pending commands before renderer disposal
+
+## Acceptance
+
+- widget drain-scheduler tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md
@@ -1,0 +1,19 @@
+# Reference Review Test Spec 75c2: Preview Command Application Efficiency (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75c2](../specifications/reference-review-75c2-preview-command-application-efficiency-v1_0.md)
+
+## Automated Tests
+
+- queued payload command applies datasets through fake renderer
+- queued display command reuses current decoded datasets
+- repeated display toggles produce one final renderer update
+- display command does not reset camera
+- payload command aligns camera for new payload
+- renderer surface is not recreated by queued commands
+
+## Acceptance
+
+- widget command-application tests pass
+- preview controller tests pass

--- a/project/release-0.1.0a/test-specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md
@@ -1,0 +1,27 @@
+# Reference Review Test Spec 75d: Preview Render Queue Regression Tests (v1.0)
+
+## Paired Specification
+
+- [Reference Review Spec 75d](../specifications/reference-review-75d-preview-render-queue-regression-tests-v1_0.md)
+
+## Automated Tests
+
+- integrated rapid fixture-selection stale success path
+- integrated rapid fixture-selection stale failure path
+- integrated rapid display-toggle coalescing path
+- close-event pending-command cleanup path
+
+## Manual Smoke
+
+Run:
+
+```bash
+.venv/bin/impression-reference-review --fixture-file tests/reference_review_fixtures/dirty-impress-fixtures.json
+```
+
+Verify rapid fixture selection and rapid display toggles remain responsive.
+
+## Acceptance
+
+- automated integration tests pass
+- manual smoke result is recorded in implementation notes

--- a/src/impression/devtools/reference_review/async_core/dispatcher.py
+++ b/src/impression/devtools/reference_review/async_core/dispatcher.py
@@ -54,8 +54,8 @@ class TaskDispatcher:
         self._lock = Lock()
         self._pending: dict[tuple[str, ReviewTaskKind], int] = {}
 
-    def close(self) -> None:
-        self._executor.shutdown(wait=True)
+    def close(self, *, wait: bool = True, cancel_futures: bool = False) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=cancel_futures)
 
     def dispatch(
         self,
@@ -77,6 +77,14 @@ class TaskDispatcher:
                 return DispatchResult(False, request, diagnostic="queue_full")
             if policy.coalesce and pending >= policy.max_pending:
                 self._tracker.cancel(request)
+                self._audit.emit(
+                    build_audit_event(
+                        "dispatch_coalesced",
+                        request,
+                        details={"reason": "queue_full"},
+                    )
+                )
+                return DispatchResult(False, request, diagnostic="coalesced")
             self._pending[pending_key] = pending + 1
 
         self._tracker.register(request)
@@ -112,4 +120,3 @@ class TaskDispatcher:
                 else:
                     self._pending.pop(pending_key, None)
         return envelope
-

--- a/src/impression/devtools/reference_review/preview_payload_builder.py
+++ b/src/impression/devtools/reference_review/preview_payload_builder.py
@@ -10,6 +10,7 @@ import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Lock
 from types import ModuleType
 from typing import Any, Callable, Iterator
 
@@ -29,6 +30,7 @@ from .preview_payload import (
 )
 
 PREVIEW_PAYLOAD_FORMAT = "impression.reference-review.preview-payload.v1"
+_PREVIEW_SOURCE_IMPORT_LOCK = Lock()
 
 
 @dataclass(frozen=True)
@@ -120,17 +122,18 @@ def load_preview_source(
 
     entrypoint = request.entrypoint
     kwargs = {parameter.name: parameter.value for parameter in request.parameters}
-    with _temporary_import_roots(_source_import_roots(request, import_roots)):
-        if "." in entrypoint and not request.source_path.is_file():
-            module_name, function_name = entrypoint.rsplit(".", 1)
-            module = importlib.import_module(module_name)
-            builder = getattr(module, function_name, None)
-        else:
-            module = _load_module_from_path(request.source_path, request)
-            builder = _resolve_entrypoint(module, entrypoint)
-    if builder is None or not callable(builder):
-        raise ValueError(f"entrypoint {entrypoint!r} is not callable")
-    return builder(**kwargs)
+    with _PREVIEW_SOURCE_IMPORT_LOCK:
+        with _temporary_import_roots(_source_import_roots(request, import_roots)):
+            if "." in entrypoint and not request.source_path.is_file():
+                module_name, function_name = entrypoint.rsplit(".", 1)
+                module = importlib.import_module(module_name)
+                builder = getattr(module, function_name, None)
+            else:
+                module = _load_module_from_path(request.source_path, request)
+                builder = _resolve_entrypoint(module, entrypoint)
+            if builder is None or not callable(builder):
+                raise ValueError(f"entrypoint {entrypoint!r} is not callable")
+            return builder(**kwargs)
 
 
 def tessellate_preview_source(

--- a/src/impression/devtools/reference_review/preview_payload_controller.py
+++ b/src/impression/devtools/reference_review/preview_payload_controller.py
@@ -137,6 +137,7 @@ class PreviewPayloadProcessController:
         *,
         owner: str = "preview-payload",
         dispatcher: TaskDispatcher | None = None,
+        owns_dispatcher: bool | None = None,
         request_ids: RequestIdAllocator | None = None,
         payload_dir: Path | None = None,
         cwd: Path | None = None,
@@ -144,7 +145,7 @@ class PreviewPayloadProcessController:
     ) -> None:
         self._owner = owner
         self._dispatcher = dispatcher
-        self._owns_dispatcher = dispatcher is None
+        self._owns_dispatcher = dispatcher is None if owns_dispatcher is None else owns_dispatcher
         self._process_executor = None if dispatcher is not None else ProcessPoolExecutor(max_workers=1)
         self._launch_executor = None if dispatcher is not None else ThreadPoolExecutor(max_workers=1)
         self._process_futures: list[Future[WorkerResultEnvelope]] = []
@@ -357,7 +358,7 @@ class PreviewPayloadProcessController:
                     payload_dir=self._payload_dir,
                     cwd=self._cwd,
                     home=self._home,
-                ).result,
+                ),
             )
         else:
             result = self._launch_process(message, record, generation=generation)

--- a/src/impression/devtools/reference_review/preview_payload_controller.py
+++ b/src/impression/devtools/reference_review/preview_payload_controller.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import io
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Lock
 from typing import Callable
 
 from .async_core import (
@@ -145,7 +146,9 @@ class PreviewPayloadProcessController:
         self._dispatcher = dispatcher
         self._owns_dispatcher = dispatcher is None
         self._process_executor = None if dispatcher is not None else ProcessPoolExecutor(max_workers=1)
+        self._launch_executor = None if dispatcher is not None else ThreadPoolExecutor(max_workers=1)
         self._process_futures: list[Future[WorkerResultEnvelope]] = []
+        self._process_lock = Lock()
         self._request_ids = request_ids or RequestIdAllocator()
         self._payload_dir = payload_dir
         self._cwd = cwd
@@ -174,9 +177,14 @@ class PreviewPayloadProcessController:
         for future in self._process_futures:
             future.cancel()
         self._process_futures = []
+        if self._launch_executor is not None:
+            self._launch_executor.shutdown(wait=False, cancel_futures=True)
+            self._launch_executor = None
         if self._process_executor is not None:
-            self._process_executor.shutdown(wait=False, cancel_futures=True)
-            self._process_executor = None
+            with self._process_lock:
+                process_executor = self._process_executor
+                self._process_executor = None
+            process_executor.shutdown(wait=False, cancel_futures=True)
         if self._dispatcher is not None and self._owns_dispatcher:
             self._dispatcher.close()
 
@@ -372,7 +380,7 @@ class PreviewPayloadProcessController:
         *,
         generation: int,
     ) -> DispatchResult:
-        if self._process_executor is None:
+        if self._process_executor is None or self._launch_executor is None:
             return DispatchResult(False, message, diagnostic="preview_executor_closed")
         retained: list[Future[WorkerResultEnvelope]] = []
         for future in self._process_futures:
@@ -381,18 +389,52 @@ class PreviewPayloadProcessController:
             future.cancel()
             if not future.cancelled():
                 retained.append(future)
-        future = self._process_executor.submit(
-            _run_payload_worker_envelope,
+        future = self._launch_executor.submit(
+            self._submit_process_payload,
             message,
             record,
             generation=generation,
-            payload_dir=self._payload_dir,
-            cwd=self._cwd,
-            home=self._home,
         )
         retained.append(future)
         self._process_futures = retained
         return DispatchResult(True, message, future=future)
+
+    def _submit_process_payload(
+        self,
+        message: ReviewWorkbenchMessage,
+        record: ReviewSourceModelRecord,
+        *,
+        generation: int,
+    ) -> WorkerResultEnvelope:
+        with self._process_lock:
+            process_executor = self._process_executor
+            if process_executor is None:
+                return WorkerResultEnvelope(
+                    request=message,
+                    ok=False,
+                    error="preview_executor_closed",
+                )
+            future = process_executor.submit(
+                _run_payload_worker_envelope,
+                message,
+                record,
+                generation=generation,
+                payload_dir=self._payload_dir,
+                cwd=self._cwd,
+                home=self._home,
+            )
+        try:
+            return future.result()
+        except Exception as exc:
+            return WorkerResultEnvelope(
+                request=message,
+                ok=False,
+                error=sanitize_error_text(
+                    str(exc) or exc.__class__.__name__,
+                    cwd=self._cwd,
+                    home=self._home,
+                ),
+            )
 
 
 def _run_payload_worker_envelope(

--- a/src/impression/devtools/reference_review/preview_payload_controller.py
+++ b/src/impression/devtools/reference_review/preview_payload_controller.py
@@ -187,7 +187,7 @@ class PreviewPayloadProcessController:
                 self._process_executor = None
             process_executor.shutdown(wait=False, cancel_futures=True)
         if self._dispatcher is not None and self._owns_dispatcher:
-            self._dispatcher.close()
+            self._dispatcher.close(wait=False, cancel_futures=True)
 
     def adopt_payload(self, payload: PreviewPayload) -> None:
         if payload.payload_path is None:

--- a/src/impression/devtools/reference_review/ui/__init__.py
+++ b/src/impression/devtools/reference_review/ui/__init__.py
@@ -39,6 +39,13 @@ from .preview_controls import (
     route_preview_display_command,
     select_exclusive_icon_option,
 )
+from .preview_render_queue import (
+    PreviewRenderCommand,
+    PreviewRenderCommandKind,
+    PreviewRenderCommandQueue,
+    PreviewRenderCommandResult,
+    PreviewRenderQueueState,
+)
 from .markdown_context import BlockedLinkDiagnostic, MarkdownContextRenderer, RenderedMarkdownContext
 from .preview_bridge import (
     PreviewAdapterDecision,
@@ -136,6 +143,11 @@ __all__ = [
     "PreviewDisplayCommandRecord",
     "PreviewDisplayControlBar",
     "PreviewDisplayOptions",
+    "PreviewRenderCommand",
+    "PreviewRenderCommandKind",
+    "PreviewRenderCommandQueue",
+    "PreviewRenderCommandResult",
+    "PreviewRenderQueueState",
     "RenderedMarkdownContext",
     "RefusalDisplayState",
     "ScreenshotArtifact",

--- a/src/impression/devtools/reference_review/ui/preview_render_queue.py
+++ b/src/impression/devtools/reference_review/ui/preview_render_queue.py
@@ -227,6 +227,13 @@ class PreviewRenderCommandQueue:
                 commands.append(command)
         return tuple(commands)
 
+    def pop_next(self) -> PreviewRenderCommand | None:
+        for lane in self._LANE_ORDER:
+            command = self._pending.pop(lane, None)
+            if command is not None:
+                return command
+        return None
+
     def clear(self) -> PreviewRenderQueueState:
         self._pending.clear()
         return self.state

--- a/src/impression/devtools/reference_review/ui/preview_render_queue.py
+++ b/src/impression/devtools/reference_review/ui/preview_render_queue.py
@@ -1,0 +1,232 @@
+"""Coalesced render-command records for the Reference Review preview pane."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ..preview_payload import PreviewPayload
+from .preview_controls import PreviewDisplayOptions
+
+
+PreviewRenderIdentity = tuple[str, int, str, int]
+
+
+class PreviewRenderCommandKind(str, Enum):
+    """Renderer command categories accepted by the preview widget."""
+
+    LOADING = "loading"
+    CLEAR = "clear"
+    FAILURE = "failure"
+    PAYLOAD = "payload"
+    DISPLAY = "display"
+    RESET_CAMERA = "reset_camera"
+
+    @property
+    def lane(self) -> str:
+        if self in {
+            PreviewRenderCommandKind.LOADING,
+            PreviewRenderCommandKind.CLEAR,
+            PreviewRenderCommandKind.FAILURE,
+        }:
+            return "lifecycle"
+        if self is PreviewRenderCommandKind.PAYLOAD:
+            return "payload"
+        if self is PreviewRenderCommandKind.DISPLAY:
+            return "display"
+        return "camera"
+
+
+@dataclass(frozen=True)
+class PreviewRenderCommand:
+    """Immutable request to mutate the preview renderer on the Qt thread."""
+
+    kind: PreviewRenderCommandKind
+    owner: str | None = None
+    request_id: int | None = None
+    fixture_id: str | None = None
+    generation: int | None = None
+    payload: PreviewPayload | None = None
+    display_options: PreviewDisplayOptions | None = None
+    message: str = ""
+    diagnostic: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata or {})))
+
+    @classmethod
+    def loading(
+        cls,
+        message: str = "Loading preview...",
+        *,
+        identity: PreviewRenderIdentity | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls._from_identity(
+            PreviewRenderCommandKind.LOADING,
+            identity,
+            message=message,
+        )
+
+    @classmethod
+    def clear(
+        cls,
+        message: str = "No fixture selected.",
+        *,
+        identity: PreviewRenderIdentity | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls._from_identity(
+            PreviewRenderCommandKind.CLEAR,
+            identity,
+            message=message,
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        message: str,
+        *,
+        diagnostic: str | None = None,
+        identity: PreviewRenderIdentity | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls._from_identity(
+            PreviewRenderCommandKind.FAILURE,
+            identity,
+            message=message,
+            diagnostic=diagnostic,
+        )
+
+    @classmethod
+    def payload_ready(
+        cls,
+        payload: PreviewPayload,
+        *,
+        display_options: PreviewDisplayOptions | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls(
+            kind=PreviewRenderCommandKind.PAYLOAD,
+            owner=payload.request.owner,
+            request_id=payload.request.request_id,
+            fixture_id=payload.request.fixture_id,
+            generation=payload.request.generation,
+            payload=payload,
+            display_options=display_options,
+        )
+
+    @classmethod
+    def display(
+        cls,
+        options: PreviewDisplayOptions,
+        *,
+        identity: PreviewRenderIdentity | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls._from_identity(
+            PreviewRenderCommandKind.DISPLAY,
+            identity,
+            display_options=options,
+        )
+
+    @classmethod
+    def reset_camera(
+        cls,
+        *,
+        identity: PreviewRenderIdentity | None = None,
+    ) -> "PreviewRenderCommand":
+        return cls._from_identity(PreviewRenderCommandKind.RESET_CAMERA, identity)
+
+    @classmethod
+    def _from_identity(
+        cls,
+        kind: PreviewRenderCommandKind,
+        identity: PreviewRenderIdentity | None,
+        **kwargs: Any,
+    ) -> "PreviewRenderCommand":
+        if identity is None:
+            return cls(kind=kind, **kwargs)
+        owner, request_id, fixture_id, generation = identity
+        return cls(
+            kind=kind,
+            owner=owner,
+            request_id=request_id,
+            fixture_id=fixture_id,
+            generation=generation,
+            **kwargs,
+        )
+
+    @property
+    def identity(self) -> PreviewRenderIdentity | None:
+        if (
+            self.owner is None
+            or self.request_id is None
+            or self.fixture_id is None
+            or self.generation is None
+        ):
+            return None
+        return (self.owner, self.request_id, self.fixture_id, self.generation)
+
+    @property
+    def lane(self) -> str:
+        return self.kind.lane
+
+
+@dataclass(frozen=True)
+class PreviewRenderCommandResult:
+    """Outcome of enqueuing or applying a preview render command."""
+
+    command: PreviewRenderCommand
+    accepted: bool
+    status: str
+    replaced: bool = False
+    ready: bool = False
+    diagnostic: str | None = None
+
+
+@dataclass(frozen=True)
+class PreviewRenderQueueState:
+    """Inspectable state for the coalescing render queue."""
+
+    pending_count: int
+    pending_lanes: tuple[str, ...]
+
+
+class PreviewRenderCommandQueue:
+    """Tiny latest-wins queue drained only by the preview widget."""
+
+    _LANE_ORDER = ("lifecycle", "payload", "display", "camera")
+
+    def __init__(self) -> None:
+        self._pending: dict[str, PreviewRenderCommand] = {}
+
+    @property
+    def state(self) -> PreviewRenderQueueState:
+        return PreviewRenderQueueState(
+            pending_count=len(self._pending),
+            pending_lanes=tuple(
+                lane for lane in self._LANE_ORDER if lane in self._pending
+            ),
+        )
+
+    def enqueue(self, command: PreviewRenderCommand) -> PreviewRenderCommandResult:
+        lane = command.lane
+        replaced = lane in self._pending
+        self._pending[lane] = command
+        return PreviewRenderCommandResult(
+            command=command,
+            accepted=True,
+            status="queued",
+            replaced=replaced,
+        )
+
+    def drain(self) -> tuple[PreviewRenderCommand, ...]:
+        commands: list[PreviewRenderCommand] = []
+        for lane in self._LANE_ORDER:
+            command = self._pending.pop(lane, None)
+            if command is not None:
+                commands.append(command)
+        return tuple(commands)
+
+    def clear(self) -> PreviewRenderQueueState:
+        self._pending.clear()
+        return self.state

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -345,7 +345,8 @@ class PreviewRendererLifecycleWidget(QWidget):
 
     def _drain_preview_render_queue(self) -> None:
         self._render_drain_scheduled = False
-        for command in self._render_queue.drain():
+        command = self._render_queue.pop_next()
+        if command is not None:
             result = self._apply_render_command(command)
             self.renderCommandApplied.emit(result)
         if self._render_queue.state.pending_count and not self._render_drain_scheduled:

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -763,12 +763,21 @@ def _preview_scene_apply_options(
     *,
     align_camera: bool,
 ) -> PreviewSceneApplyOptions:
+    lighting = options.lighting_mode != LIGHTING_MODE_FLAT
+    smooth_shading = options.lighting_mode == LIGHTING_MODE_CAMERA
     return PreviewSceneApplyOptions(
         show_edges=options.show_triangle_wireframe,
         face_edges=options.show_object_edges,
         show_bounds=options.show_bounds_grid,
         show_axes=options.show_axis_triad,
         align_camera=align_camera,
+        show_object_fill=options.show_object_fill,
+        show_polylines=options.show_polylines,
+        smooth_shading=smooth_shading,
+        lighting=lighting,
+        specular=0.2 if options.lighting_mode == LIGHTING_MODE_CAMERA else 0.0,
+        background="#07111f",
+        background_top="#10223a" if options.show_gradient_background else None,
     )
 
 
@@ -777,7 +786,11 @@ def _datasets_for_display_options(
     options: PreviewDisplayOptions,
 ) -> tuple[Mesh | Polyline, ...]:
     if options.color_mode == COLOR_MODE_AUTHORED:
-        return datasets
+        return tuple(
+            dataset
+            for dataset in datasets
+            if not isinstance(dataset, Polyline) or options.show_polylines
+        )
     prepared: list[Mesh | Polyline] = []
     for dataset in datasets:
         if isinstance(dataset, Mesh):
@@ -791,6 +804,8 @@ def _datasets_for_display_options(
                 )
             )
         else:
+            if not options.show_polylines:
+                continue
             prepared.append(
                 Polyline(
                     np.asarray(dataset.points, dtype=float),

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -22,6 +22,7 @@ from impression.preview_qt import (
     QtPreviewSurface,
     QtPreviewSurfaceConfig,
     apply_qt_preview_scene,
+    configure_qt_preview_surface_format,
     qt_preview_supported_environment,
 )
 from ..async_core.qt_handoff import sanitize_error_text
@@ -1343,6 +1344,7 @@ def _ensure_widget_app() -> QApplication:
     app = QApplication.instance()
     if app is not None:
         return app
+    configure_qt_preview_surface_format()
     _PREVIEW_WIDGET_APP = QApplication([])
     return _PREVIEW_WIDGET_APP
 

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Callable
 
 import numpy as np
-from PySide6.QtCore import QPoint, QPointF, Qt
+from PySide6.QtCore import QPoint, QPointF, Qt, QTimer, Signal
 from PySide6.QtGui import QColor, QLinearGradient, QPainter, QPen, QPolygonF
 from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 
@@ -33,6 +33,12 @@ from .preview_controls import (
     LIGHTING_MODE_FACE_NORMALS,
     LIGHTING_MODE_FLAT,
     PreviewDisplayOptions,
+)
+from .preview_render_queue import (
+    PreviewRenderCommand,
+    PreviewRenderCommandKind,
+    PreviewRenderCommandQueue,
+    PreviewRenderCommandResult,
 )
 
 _PREVIEW_WIDGET_APP: QApplication | None = None
@@ -274,6 +280,8 @@ def route_preview_toolbar_command(
 class PreviewRendererLifecycleWidget(QWidget):
     """Widget host that owns one long-lived embedded preview renderer."""
 
+    renderCommandApplied = Signal(object)
+
     def __init__(self, parent: QWidget | None = None) -> None:
         _ensure_widget_app()
         super().__init__(parent)
@@ -290,6 +298,8 @@ class PreviewRendererLifecycleWidget(QWidget):
         self._payload_state = PreviewWidgetPayloadState()
         self._current_datasets: list[Mesh | Polyline] = []
         self._display_options = PreviewDisplayOptions()
+        self._render_queue = PreviewRenderCommandQueue()
+        self._render_drain_scheduled = False
 
     @property
     def renderer_state(self) -> PreviewRendererLifecycleState:
@@ -323,6 +333,112 @@ class PreviewRendererLifecycleWidget(QWidget):
         self._display_options = options
         self._apply_display_options_to_plotter()
 
+    def enqueue_render_command(
+        self,
+        command: PreviewRenderCommand,
+    ) -> PreviewRenderCommandResult:
+        result = self._render_queue.enqueue(command)
+        if not self._render_drain_scheduled:
+            self._render_drain_scheduled = True
+            QTimer.singleShot(0, self._drain_preview_render_queue)
+        return result
+
+    def _drain_preview_render_queue(self) -> None:
+        self._render_drain_scheduled = False
+        for command in self._render_queue.drain():
+            result = self._apply_render_command(command)
+            self.renderCommandApplied.emit(result)
+        if self._render_queue.state.pending_count and not self._render_drain_scheduled:
+            self._render_drain_scheduled = True
+            QTimer.singleShot(0, self._drain_preview_render_queue)
+
+    def _apply_render_command(
+        self,
+        command: PreviewRenderCommand,
+    ) -> PreviewRenderCommandResult:
+        try:
+            if command.kind is PreviewRenderCommandKind.PAYLOAD:
+                if command.payload is None:
+                    return PreviewRenderCommandResult(
+                        command=command,
+                        accepted=False,
+                        status="missing-payload",
+                        diagnostic="preview-render-command-missing-payload",
+                    )
+                if command.display_options is not None:
+                    self._display_options = command.display_options
+                state = self.set_preview_payload(command.payload)
+                return PreviewRenderCommandResult(
+                    command=command,
+                    accepted=state.ready,
+                    status="applied" if state.ready else "failed",
+                    ready=state.ready,
+                    diagnostic=state.diagnostic,
+                )
+            if command.kind is PreviewRenderCommandKind.DISPLAY:
+                if command.display_options is None:
+                    return PreviewRenderCommandResult(
+                        command=command,
+                        accepted=False,
+                        status="missing-display-options",
+                        diagnostic="preview-render-command-missing-display-options",
+                    )
+                self.set_display_options(command.display_options)
+                return PreviewRenderCommandResult(
+                    command=command,
+                    accepted=True,
+                    status="applied",
+                    ready=self._payload_state.ready,
+                )
+            if command.kind is PreviewRenderCommandKind.RESET_CAMERA:
+                self.reset_view()
+                return PreviewRenderCommandResult(
+                    command=command,
+                    accepted=True,
+                    status="applied",
+                    ready=self._payload_state.ready,
+                )
+            if command.kind is PreviewRenderCommandKind.LOADING:
+                message = command.message or "Loading preview..."
+                self._status.setText(message)
+                self._status.show()
+                return PreviewRenderCommandResult(command=command, accepted=True, status="applied")
+            if command.kind is PreviewRenderCommandKind.CLEAR:
+                state = self.clear_preview(command.message or "No fixture selected.")
+                return PreviewRenderCommandResult(
+                    command=command,
+                    accepted=True,
+                    status="applied",
+                    ready=state.ready,
+                    diagnostic=state.diagnostic,
+                )
+            if command.kind is PreviewRenderCommandKind.FAILURE:
+                message = command.message or "Preview unavailable."
+                diagnostic = command.diagnostic or message
+                state = self.clear_preview(message)
+                return PreviewRenderCommandResult(
+                    command=command,
+                    accepted=False,
+                    status="failed",
+                    ready=state.ready,
+                    diagnostic=diagnostic,
+                )
+        except Exception as exc:
+            diagnostic = sanitize_error_text(str(exc) or exc.__class__.__name__)
+            self.clear_preview(f"Preview unavailable: {diagnostic}")
+            return PreviewRenderCommandResult(
+                command=command,
+                accepted=False,
+                status="exception",
+                diagnostic=diagnostic,
+            )
+        return PreviewRenderCommandResult(
+            command=command,
+            accepted=False,
+            status="unsupported",
+            diagnostic="unsupported-preview-render-command",
+        )
+
     def clear_renderer_scene(self, message: str) -> None:
         if self._plotter is not None:
             self._plotter.clear()
@@ -334,6 +450,19 @@ class PreviewRendererLifecycleWidget(QWidget):
         self._payload_state = PreviewWidgetPayloadState(diagnostic=message)
         self.clear_renderer_scene(message)
         return self._payload_state
+
+    def reset_view(self) -> None:
+        if self._plotter is None:
+            return
+        reset_camera = getattr(self._plotter, "reset_camera", None)
+        if callable(reset_camera):
+            reset_camera()
+        reset_clipping = getattr(self._plotter, "reset_camera_clipping_range", None)
+        if callable(reset_clipping):
+            reset_clipping()
+        render = getattr(self._plotter, "render", None)
+        if callable(render):
+            render()
 
     def set_preview_payload(
         self,
@@ -367,6 +496,8 @@ class PreviewRendererLifecycleWidget(QWidget):
             return self._fail_payload(payload, str(exc) or exc.__class__.__name__)
 
     def dispose_renderer(self) -> None:
+        self._render_queue.clear()
+        self._render_drain_scheduled = False
         if self._plotter is not None:
             self._plotter.close()
             self._plotter = None
@@ -565,18 +696,22 @@ class PyVistaQtPreviewSurface(QWidget):
 
     def set_display_options(self, options: PreviewDisplayOptions) -> None:
         self._display_options = options
-        self._surface.set_apply_options(_preview_scene_apply_options(options, align_camera=False))
         if self._datasets:
-            self._surface.set_datasets(
+            self._surface.replace_scene(
                 _datasets_for_display_options(self._datasets, options),
+                apply_options=_preview_scene_apply_options(options, align_camera=False),
                 align_camera=False,
+            )
+        else:
+            self._surface.set_apply_options(
+                _preview_scene_apply_options(options, align_camera=False)
             )
 
     def set_datasets(self, datasets: tuple[Mesh | Polyline, ...]) -> None:
         self._datasets = tuple(datasets)
-        self._surface.set_apply_options(_preview_scene_apply_options(self._display_options, align_camera=True))
-        self._surface.set_datasets(
+        self._surface.replace_scene(
             _datasets_for_display_options(self._datasets, self._display_options),
+            apply_options=_preview_scene_apply_options(self._display_options, align_camera=True),
             align_camera=True,
         )
 

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -775,6 +775,7 @@ def _preview_scene_apply_options(
         show_polylines=options.show_polylines,
         smooth_shading=smooth_shading,
         lighting=lighting,
+        lighting_profile=options.lighting_mode,
         specular=0.2 if options.lighting_mode == LIGHTING_MODE_CAMERA else 0.0,
         background="#07111f",
         background_top="#10223a" if options.show_gradient_background else None,

--- a/src/impression/devtools/reference_review/ui/shell.py
+++ b/src/impression/devtools/reference_review/ui/shell.py
@@ -43,6 +43,7 @@ from ..preview_payload_controller import (
 )
 from ..async_core import WorkerResultEnvelope
 from ..async_core import ReviewTaskKind, TaskDispatcher, WorkerPolicy
+from impression.preview_qt import configure_qt_preview_surface_format
 
 _ACTIVE_LAUNCH: "WorkbenchLaunchResult | None" = None
 _USAGE = """usage: impression-reference-review [--fixture-file PATH] [--fixture-root PATH] [--fixture-db PATH] [--check] [--offscreen]
@@ -75,6 +76,7 @@ def _ensure_qt_app(argv: Sequence[str], *, offscreen: bool, widgets: bool = Fals
         app = QApplication.instance()
         if app is not None:
             return app
+        configure_qt_preview_surface_format()
         return QApplication(list(argv))
     from PySide6.QtGui import QGuiApplication
 

--- a/src/impression/devtools/reference_review/ui/shell.py
+++ b/src/impression/devtools/reference_review/ui/shell.py
@@ -326,6 +326,7 @@ class ReferenceReviewWindow(QWidget):
             Future[WorkerResultEnvelope],
             PreviewRenderIdentity | None,
         ] = {}
+        self._pending_preview_record: ReviewSourceModelRecord | None = None
         self._preview_poll_timer = QTimer(self)
         self._preview_poll_timer.setInterval(30)
         self._preview_poll_timer.timeout.connect(self._poll_preview_payloads)
@@ -549,6 +550,11 @@ class ReferenceReviewWindow(QWidget):
             return
         result = self._preview_controller.launch(record)
         if not result.accepted or result.future is None:
+            if result.diagnostic in {"queue_full", "coalesced"} and self._preview_futures:
+                self._pending_preview_record = record
+                if not self._preview_poll_timer.isActive():
+                    self._preview_poll_timer.start()
+                return
             identity = self._preview_identity_for_dispatch_request(getattr(result, "request", None))
             self.preview_surface.enqueue_render_command(
                 PreviewRenderCommand.failure(
@@ -598,6 +604,40 @@ class ReferenceReviewWindow(QWidget):
         self._preview_futures = pending
         if not self._preview_futures:
             self._preview_poll_timer.stop()
+            self._launch_pending_preview_record()
+
+    def _launch_pending_preview_record(self) -> None:
+        record = self._pending_preview_record
+        self._pending_preview_record = None
+        if record is None:
+            return
+        if self._selected_index < 0 or self._selected_index >= len(self.queue.records):
+            return
+        if self.queue.records[self._selected_index].fixture_id != record.fixture_id:
+            return
+        self.preview_surface.enqueue_render_command(PreviewRenderCommand.loading())
+        result = self._preview_controller.launch(record)
+        if not result.accepted or result.future is None:
+            if result.diagnostic in {"queue_full", "coalesced"} and self._preview_futures:
+                self._pending_preview_record = record
+                if not self._preview_poll_timer.isActive():
+                    self._preview_poll_timer.start()
+                return
+            identity = self._preview_identity_for_dispatch_request(getattr(result, "request", None))
+            self.preview_surface.enqueue_render_command(
+                PreviewRenderCommand.failure(
+                    f"Preview unavailable: {result.diagnostic or 'queue_full'}",
+                    diagnostic=result.diagnostic,
+                    identity=identity,
+                )
+            )
+            return
+        self._preview_futures.append(result.future)
+        self._preview_future_identities[result.future] = (
+            self._preview_identity_for_dispatch_request(getattr(result, "request", None))
+        )
+        if not self._preview_poll_timer.isActive():
+            self._preview_poll_timer.start()
 
     def _apply_preview_payload_ready(self, event: PreviewPayloadReadyEvent) -> None:
         self.preview_surface.enqueue_render_command(
@@ -687,6 +727,7 @@ class ReferenceReviewWindow(QWidget):
             future.cancel()
         self._preview_futures = []
         self._preview_future_identities = {}
+        self._pending_preview_record = None
         self._preview_controller.close()
         self.preview_surface.shutdown()
         super().closeEvent(event)

--- a/src/impression/devtools/reference_review/ui/shell.py
+++ b/src/impression/devtools/reference_review/ui/shell.py
@@ -16,6 +16,12 @@ from .preview_controls import (
     PreviewDisplayOptions,
     route_preview_display_command,
 )
+from .preview_render_queue import (
+    PreviewRenderCommand,
+    PreviewRenderCommandKind,
+    PreviewRenderCommandResult,
+    PreviewRenderIdentity,
+)
 from .preview_widget import PreviewRendererLifecycleWidget
 from .queue_context import FixtureQueueViewModel
 from ..source_registry import (
@@ -306,6 +312,10 @@ class ReferenceReviewWindow(QWidget):
         self._preview_display_options = PreviewDisplayOptions()
         self._preview_controller = PreviewPayloadProcessController(cwd=Path.cwd())
         self._preview_futures: list[Future[WorkerResultEnvelope]] = []
+        self._preview_future_identities: dict[
+            Future[WorkerResultEnvelope],
+            PreviewRenderIdentity | None,
+        ] = {}
         self._preview_poll_timer = QTimer(self)
         self._preview_poll_timer.setInterval(30)
         self._preview_poll_timer.timeout.connect(self._poll_preview_payloads)
@@ -363,6 +373,9 @@ class ReferenceReviewWindow(QWidget):
         self.preview_layout = QVBoxLayout(self.preview_frame)
         self.preview_layout.setContentsMargins(0, 0, 0, 0)
         self.preview_surface = InteractiveStlPreviewLabel(self.preview_frame)
+        self.preview_surface.renderCommandApplied.connect(
+            self._handle_preview_render_command_result
+        )
         self.preview_layout.addWidget(self.preview_surface)
         main_layout.addWidget(self.preview_frame, 1, 0)
 
@@ -519,15 +532,26 @@ class ReferenceReviewWindow(QWidget):
         self._preview_load_generation += 1
         self.artifact_thumb.setText(str(item.get("artifact_display_path", "")))
         self.preview_surface.prepare_artifact(live_artifact)
+        self.preview_surface.enqueue_render_command(PreviewRenderCommand.loading())
         self.preview_display_controls.set_ready(False)
         if live_artifact is None:
-            self.preview_surface.set_artifact(None)
+            self.preview_surface.enqueue_render_command(PreviewRenderCommand.clear())
             return
         result = self._preview_controller.launch(record)
         if not result.accepted or result.future is None:
-            self.preview_surface.clear_preview(f"Preview unavailable: {result.diagnostic or 'queue_full'}")
+            identity = self._preview_identity_for_dispatch_request(getattr(result, "request", None))
+            self.preview_surface.enqueue_render_command(
+                PreviewRenderCommand.failure(
+                    f"Preview unavailable: {result.diagnostic or 'queue_full'}",
+                    diagnostic=result.diagnostic,
+                    identity=identity,
+                )
+            )
             return
         self._preview_futures.append(result.future)
+        self._preview_future_identities[result.future] = (
+            self._preview_identity_for_dispatch_request(getattr(result, "request", None))
+        )
         if not self._preview_poll_timer.isActive():
             self._preview_poll_timer.start()
 
@@ -545,8 +569,17 @@ class ReferenceReviewWindow(QWidget):
             try:
                 envelope = future.result()
             except Exception as exc:
-                self.preview_surface.clear_preview(f"Preview unavailable: {exc.__class__.__name__}")
+                identity = self._preview_future_identities.pop(future, None)
+                if self._preview_identity_is_current(identity):
+                    self.preview_surface.enqueue_render_command(
+                        PreviewRenderCommand.failure(
+                            f"Preview unavailable: {exc.__class__.__name__}",
+                            diagnostic=str(exc) or exc.__class__.__name__,
+                            identity=identity,
+                        )
+                    )
                 continue
+            self._preview_future_identities.pop(future, None)
             self._preview_controller.handle_completion(
                 envelope,
                 self._apply_preview_payload_ready,
@@ -557,14 +590,59 @@ class ReferenceReviewWindow(QWidget):
             self._preview_poll_timer.stop()
 
     def _apply_preview_payload_ready(self, event: PreviewPayloadReadyEvent) -> None:
-        state = self.preview_surface.set_preview_payload(event.payload)
-        if state.ready:
-            self.preview_display_controls.set_ready(True)
-            self._preview_controller.cleanup_payload(event.payload, reason="completed")
+        self.preview_surface.enqueue_render_command(
+            PreviewRenderCommand.payload_ready(
+                event.payload,
+                display_options=self._preview_display_options,
+            )
+        )
 
     def _apply_preview_payload_failed(self, event: PreviewPayloadFailedEvent) -> None:
-        self.preview_surface.clear_preview(f"Preview unavailable: {event.diagnostic.message}")
+        self.preview_surface.enqueue_render_command(
+            PreviewRenderCommand.failure(
+                f"Preview unavailable: {event.diagnostic.message}",
+                diagnostic=event.diagnostic.message,
+                identity=self._preview_controller.active_identity,
+            )
+        )
         self.preview_display_controls.set_ready(False)
+
+    def _handle_preview_render_command_result(
+        self,
+        result: PreviewRenderCommandResult,
+    ) -> None:
+        if result.command.kind is PreviewRenderCommandKind.PAYLOAD:
+            self.preview_display_controls.set_ready(result.ready)
+            if result.ready and result.command.payload is not None:
+                self._preview_controller.cleanup_payload(result.command.payload, reason="completed")
+            return
+        if result.command.kind in {
+            PreviewRenderCommandKind.CLEAR,
+            PreviewRenderCommandKind.FAILURE,
+            PreviewRenderCommandKind.LOADING,
+        }:
+            self.preview_display_controls.set_ready(False)
+
+    def _preview_identity_for_dispatch_request(
+        self,
+        request: object,
+    ) -> PreviewRenderIdentity | None:
+        owner = getattr(request, "owner", None)
+        request_id = getattr(request, "request_id", None)
+        fixture_id = getattr(request, "fixture_id", None)
+        payload = getattr(request, "payload", None)
+        generation = payload.get("generation") if isinstance(payload, dict) else None
+        if (
+            not isinstance(owner, str)
+            or not isinstance(request_id, int)
+            or not isinstance(fixture_id, str)
+            or not isinstance(generation, int)
+        ):
+            return None
+        return (owner, request_id, fixture_id, generation)
+
+    def _preview_identity_is_current(self, identity: PreviewRenderIdentity | None) -> bool:
+        return identity is not None and identity == self._preview_controller.active_identity
 
     def _route_preview_display_command(self, command: str) -> None:
         result = route_preview_display_command(
@@ -576,7 +654,12 @@ class ReferenceReviewWindow(QWidget):
             return
         self._preview_display_options = result.options
         self.preview_display_controls.set_options(result.options)
-        self.preview_surface.set_display_options(result.options)
+        self.preview_surface.enqueue_render_command(
+            PreviewRenderCommand.display(
+                result.options,
+                identity=self._preview_controller.active_identity,
+            )
+        )
 
     def _sync_properties(self) -> None:
         has_fixture = self._selected_index >= 0
@@ -593,6 +676,7 @@ class ReferenceReviewWindow(QWidget):
         for future in self._preview_futures:
             future.cancel()
         self._preview_futures = []
+        self._preview_future_identities = {}
         self._preview_controller.close()
         self.preview_surface.shutdown()
         super().closeEvent(event)

--- a/src/impression/devtools/reference_review/ui/shell.py
+++ b/src/impression/devtools/reference_review/ui/shell.py
@@ -42,6 +42,7 @@ from ..preview_payload_controller import (
     PreviewPayloadReadyEvent,
 )
 from ..async_core import WorkerResultEnvelope
+from ..async_core import ReviewTaskKind, TaskDispatcher, WorkerPolicy
 
 _ACTIVE_LAUNCH: "WorkbenchLaunchResult | None" = None
 _USAGE = """usage: impression-reference-review [--fixture-file PATH] [--fixture-root PATH] [--fixture-db PATH] [--check] [--offscreen]
@@ -310,7 +311,16 @@ class ReferenceReviewWindow(QWidget):
         self._fixture_items = _fixture_items_for_qml(queue, artifact_previews)
         self._preview_load_generation = 0
         self._preview_display_options = PreviewDisplayOptions()
-        self._preview_controller = PreviewPayloadProcessController(cwd=Path.cwd())
+        self._preview_controller = PreviewPayloadProcessController(
+            cwd=Path.cwd(),
+            dispatcher=TaskDispatcher(
+                max_workers=1,
+                policies={
+                    ReviewTaskKind.PREVIEW_BUILD: WorkerPolicy(max_pending=1, coalesce=True),
+                },
+            ),
+            owns_dispatcher=True,
+        )
         self._preview_futures: list[Future[WorkerResultEnvelope]] = []
         self._preview_future_identities: dict[
             Future[WorkerResultEnvelope],

--- a/src/impression/preview.py
+++ b/src/impression/preview.py
@@ -131,6 +131,7 @@ class PreviewSceneApplyOptions:
     show_polylines: bool = True
     smooth_shading: bool = True
     lighting: bool = True
+    lighting_profile: str = "camera"
     specular: float = 0.2
     background: str | None = None
     background_top: str | None = None
@@ -231,6 +232,7 @@ class PreviewSceneController:
         show_polylines: bool = True,
         smooth_shading: bool = True,
         lighting: bool = True,
+        lighting_profile: str = "camera",
         specular: float = 0.2,
         background: str | None = None,
         background_top: str | None = None,
@@ -240,6 +242,7 @@ class PreviewSceneController:
         datasets = list(datasets)
         style = self.style
         plotter.clear()
+        self._clear_scene_decoration_state(plotter)
         if background is not None:
             if background_top is None:
                 plotter.set_background(background)
@@ -256,25 +259,35 @@ class PreviewSceneController:
                 if not show_polylines:
                     continue
                 pv_mesh = self.polyline_to_pyvista(mesh)
-                plotter.add_mesh(
+                actor = plotter.add_mesh(
                     pv_mesh,
                     name=f"mesh-{index}",
                     color=mesh.color or style.default_polyline_color,
                     line_width=2.0,
                     render_lines_as_tubes=False,
                 )
+                self._configure_actor_lighting(
+                    actor,
+                    lighting=False,
+                    lighting_profile="flat",
+                )
                 continue
 
             pv_mesh = mesh_to_pyvista(mesh)
             if not show_object_fill:
                 if show_edges:
-                    plotter.add_mesh(
+                    actor = plotter.add_mesh(
                         pv_mesh,
                         name=f"mesh-{index}-wireframe",
                         color=style.feature_edge_color,
                         style="wireframe",
                         line_width=1.0,
                         lighting=False,
+                    )
+                    self._configure_actor_lighting(
+                        actor,
+                        lighting=False,
+                        lighting_profile="flat",
                     )
                 if face_edges:
                     self.add_feature_edges(plotter, pv_mesh, index)
@@ -285,7 +298,7 @@ class PreviewSceneController:
                 scalars = np.asarray(cell_colors)
                 rgba_mode = scalars.shape[1] >= 4
                 rgb_mode = scalars.shape[1] == 3
-                plotter.add_mesh(
+                actor = plotter.add_mesh(
                     pv_mesh,
                     name=f"mesh-{index}",
                     show_edges=show_edges,
@@ -295,6 +308,11 @@ class PreviewSceneController:
                     smooth_shading=smooth_shading,
                     lighting=lighting,
                     specular=specular,
+                )
+                self._configure_actor_lighting(
+                    actor,
+                    lighting=lighting,
+                    lighting_profile=lighting_profile,
                 )
                 if face_edges:
                     self.add_feature_edges(plotter, pv_mesh, index)
@@ -309,7 +327,7 @@ class PreviewSceneController:
                 color = style.color_cycle[index % len(style.color_cycle)]
                 opacity = 1.0
 
-            plotter.add_mesh(
+            actor = plotter.add_mesh(
                 pv_mesh,
                 name=f"mesh-{index}",
                 show_edges=show_edges,
@@ -319,11 +337,56 @@ class PreviewSceneController:
                 lighting=lighting,
                 specular=specular,
             )
+            self._configure_actor_lighting(
+                actor,
+                lighting=lighting,
+                lighting_profile=lighting_profile,
+            )
             if face_edges:
                 self.add_feature_edges(plotter, pv_mesh, index)
 
         if align_camera:
             self.reset_camera(plotter, datasets)
+
+    def _clear_scene_decoration_state(self, plotter) -> None:
+        for method_name in (
+            "hide_axes_all",
+            "hide_axes",
+            "remove_bounds_axes",
+            "remove_bounding_box",
+            "disable_eye_dome_lighting",
+        ):
+            method = getattr(plotter, method_name, None)
+            if callable(method):
+                method()
+
+    def _configure_actor_lighting(
+        self,
+        actor,
+        *,
+        lighting: bool,
+        lighting_profile: str,
+    ) -> None:
+        get_property = getattr(actor, "GetProperty", None)
+        if not callable(get_property):
+            return
+        prop = get_property()
+        if prop is None:
+            return
+        if lighting:
+            lighting_on = getattr(prop, "LightingOn", None)
+            if callable(lighting_on):
+                lighting_on()
+        else:
+            lighting_off = getattr(prop, "LightingOff", None)
+            if callable(lighting_off):
+                lighting_off()
+        if lighting_profile == "camera":
+            interpolation = getattr(prop, "SetInterpolationToPhong", None)
+        else:
+            interpolation = getattr(prop, "SetInterpolationToFlat", None)
+        if callable(interpolation):
+            interpolation()
 
     def add_feature_edges(self, plotter, mesh, index: int) -> None:
         if not hasattr(mesh, "extract_feature_edges"):

--- a/src/impression/preview.py
+++ b/src/impression/preview.py
@@ -127,6 +127,13 @@ class PreviewSceneApplyOptions:
     show_bounds: bool = True
     show_axes: bool = True
     align_camera: bool = False
+    show_object_fill: bool = True
+    show_polylines: bool = True
+    smooth_shading: bool = True
+    lighting: bool = True
+    specular: float = 0.2
+    background: str | None = None
+    background_top: str | None = None
 
 
 @dataclass(frozen=True)
@@ -220,12 +227,24 @@ class PreviewSceneController:
         show_bounds: bool = True,
         show_axes: bool = True,
         align_camera: bool = False,
+        show_object_fill: bool = True,
+        show_polylines: bool = True,
+        smooth_shading: bool = True,
+        lighting: bool = True,
+        specular: float = 0.2,
+        background: str | None = None,
+        background_top: str | None = None,
     ) -> None:
         """Apply datasets to a caller-owned plotter using shared preview semantics."""
 
         datasets = list(datasets)
         style = self.style
         plotter.clear()
+        if background is not None:
+            if background_top is None:
+                plotter.set_background(background)
+            else:
+                plotter.set_background(background, top=background_top)
         if not _pyvista_safe_mode():
             if show_bounds:
                 self.show_bounds_with_units(plotter)
@@ -234,6 +253,8 @@ class PreviewSceneController:
 
         for index, mesh in enumerate(datasets):
             if isinstance(mesh, Polyline):
+                if not show_polylines:
+                    continue
                 pv_mesh = self.polyline_to_pyvista(mesh)
                 plotter.add_mesh(
                     pv_mesh,
@@ -245,6 +266,20 @@ class PreviewSceneController:
                 continue
 
             pv_mesh = mesh_to_pyvista(mesh)
+            if not show_object_fill:
+                if show_edges:
+                    plotter.add_mesh(
+                        pv_mesh,
+                        name=f"mesh-{index}-wireframe",
+                        color=style.feature_edge_color,
+                        style="wireframe",
+                        line_width=1.0,
+                        lighting=False,
+                    )
+                if face_edges:
+                    self.add_feature_edges(plotter, pv_mesh, index)
+                continue
+
             cell_colors = mesh.face_colors
             if cell_colors is not None and len(cell_colors) == mesh.n_faces:
                 scalars = np.asarray(cell_colors)
@@ -257,8 +292,9 @@ class PreviewSceneController:
                     scalars=scalars,
                     rgb=rgb_mode,
                     rgba=rgba_mode,
-                    smooth_shading=True,
-                    specular=0.2,
+                    smooth_shading=smooth_shading,
+                    lighting=lighting,
+                    specular=specular,
                 )
                 if face_edges:
                     self.add_feature_edges(plotter, pv_mesh, index)
@@ -279,8 +315,9 @@ class PreviewSceneController:
                 show_edges=show_edges,
                 color=color,
                 opacity=opacity,
-                smooth_shading=True,
-                specular=0.2,
+                smooth_shading=smooth_shading,
+                lighting=lighting,
+                specular=specular,
             )
             if face_edges:
                 self.add_feature_edges(plotter, pv_mesh, index)

--- a/src/impression/preview.py
+++ b/src/impression/preview.py
@@ -557,6 +557,8 @@ class PreviewLightingPresetController:
         if not self._supported:
             return
         normalized = profile if profile in {"flat", "face_normals", "camera"} else "camera"
+        self._ensure_attached(self._head_light)
+        self._ensure_attached(self._fill_light)
         self._set_light(self._head_light, normalized in {"face_normals", "camera"})
         self._set_light(self._fill_light, normalized == "camera")
 
@@ -574,6 +576,28 @@ class PreviewLightingPresetController:
             self._initialized = True
         except Exception:
             self._supported = False
+
+    def _ensure_attached(self, light) -> None:
+        if light is None:
+            return
+        lights = self._renderer_lights()
+        if lights is not None and any(item is light for item in lights):
+            return
+        add_light = getattr(self._plotter, "add_light", None)
+        if callable(add_light):
+            add_light(light)
+
+    def _renderer_lights(self):
+        renderer = getattr(self._plotter, "renderer", None)
+        lights = getattr(renderer, "lights", None)
+        if lights is None:
+            lights = getattr(self._plotter, "lights", None)
+        if lights is None:
+            return None
+        try:
+            return tuple(lights)
+        except TypeError:
+            return None
 
     def _set_light(self, light, enabled: bool) -> None:
         if light is None:

--- a/src/impression/preview.py
+++ b/src/impression/preview.py
@@ -159,6 +159,7 @@ class PreviewSceneController:
         self.options = options or PreviewControllerOptions()
         self._pyvista_provider = pyvista_provider
         self._home_camera = None
+        self._lighting_presets: dict[int, PreviewLightingPresetController] = {}
 
     @property
     def style(self) -> PreviewStyle:
@@ -243,6 +244,11 @@ class PreviewSceneController:
         style = self.style
         plotter.clear()
         self._clear_scene_decoration_state(plotter)
+        self._apply_lighting_preset(
+            plotter,
+            lighting=lighting,
+            lighting_profile=lighting_profile,
+        )
         if background is not None:
             if background_top is None:
                 plotter.set_background(background)
@@ -388,6 +394,22 @@ class PreviewSceneController:
         if callable(interpolation):
             interpolation()
 
+    def _apply_lighting_preset(
+        self,
+        plotter,
+        *,
+        lighting: bool,
+        lighting_profile: str,
+    ) -> None:
+        preset = self._lighting_presets.get(id(plotter))
+        if preset is None:
+            preset = PreviewLightingPresetController(
+                plotter,
+                pyvista_provider=self._pyvista_provider,
+            )
+            self._lighting_presets[id(plotter)] = preset
+        preset.apply("flat" if not lighting else lighting_profile)
+
     def add_feature_edges(self, plotter, mesh, index: int) -> None:
         if not hasattr(mesh, "extract_feature_edges"):
             return
@@ -505,6 +527,65 @@ class PreviewSceneController:
                 bounds[4] = min(bounds[4], mesh_bounds[4])
                 bounds[5] = max(bounds[5], mesh_bounds[5])
         return bounds
+
+
+class PreviewLightingPresetController:
+    """Long-lived light presets for a caller-owned PyVista plotter."""
+
+    def __init__(
+        self,
+        plotter,
+        *,
+        pyvista_provider: Callable[[], object] | None = None,
+    ) -> None:
+        self._plotter = plotter
+        self._pyvista_provider = pyvista_provider
+        self._initialized = False
+        self._supported = True
+        self._head_light = None
+        self._fill_light = None
+
+    @property
+    def supported(self) -> bool:
+        return self._supported
+
+    def apply(self, profile: str) -> None:
+        if not self._supported:
+            return
+        if not self._initialized:
+            self._initialize()
+        if not self._supported:
+            return
+        normalized = profile if profile in {"flat", "face_normals", "camera"} else "camera"
+        self._set_light(self._head_light, normalized in {"face_normals", "camera"})
+        self._set_light(self._fill_light, normalized == "camera")
+
+    def _initialize(self) -> None:
+        try:
+            pv = self._pyvista_provider() if self._pyvista_provider is not None else __import__("pyvista")
+            self._head_light = pv.Light(light_type="headlight", intensity=0.9)
+            self._fill_light = pv.Light(light_type="camera light", intensity=0.35)
+            add_light = getattr(self._plotter, "add_light", None)
+            if not callable(add_light):
+                self._supported = False
+                return
+            add_light(self._head_light)
+            add_light(self._fill_light)
+            self._initialized = True
+        except Exception:
+            self._supported = False
+
+    def _set_light(self, light, enabled: bool) -> None:
+        if light is None:
+            return
+        method_name = "switch_on" if enabled else "switch_off"
+        method = getattr(light, method_name, None)
+        if callable(method):
+            method()
+            return
+        fallback = getattr(light, "SetSwitch", None)
+        if callable(fallback):
+            fallback(1 if enabled else 0)
 
 
 def _pyvista_safe_mode() -> bool:

--- a/src/impression/preview_qt.py
+++ b/src/impression/preview_qt.py
@@ -135,6 +135,19 @@ class QtPreviewSurface(QWidget):
             self._camera_aligned = False
         self._apply_scene(align_camera=align_camera)
 
+    def replace_scene(
+        self,
+        datasets: Iterable[Mesh | Polyline],
+        *,
+        apply_options: PreviewSceneApplyOptions,
+        align_camera: bool = True,
+    ) -> None:
+        self._apply_options = apply_options
+        self._datasets = tuple(datasets)
+        if align_camera:
+            self._camera_aligned = False
+        self._apply_scene(align_camera=align_camera)
+
     def clear(self) -> None:
         self._datasets = ()
         self._camera_aligned = False

--- a/src/impression/preview_qt.py
+++ b/src/impression/preview_qt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass, field
 from typing import Iterable
 
@@ -26,6 +27,7 @@ class QtPreviewSurfaceConfig:
     apply_options: PreviewSceneApplyOptions = field(default_factory=PreviewSceneApplyOptions)
     allow_offscreen: bool = False
     auto_update: bool | float = False
+    qvtk_base: str | None = None
 
     @classmethod
     def workbench_default(cls) -> "QtPreviewSurfaceConfig":
@@ -47,6 +49,7 @@ class QtPreviewSurfaceConfig:
             ),
             allow_offscreen=False,
             auto_update=False,
+            qvtk_base="QOpenGLWidget",
         )
 
 
@@ -75,6 +78,32 @@ def apply_qt_preview_scene(
     )
 
 
+def configure_qvtk_backend(base: str | None) -> None:
+    """Configure the QVTK widget backend before pyvistaqt imports it."""
+
+    if base is None:
+        return
+    if "pyvistaqt.rwi" in sys.modules:
+        return
+    import vtkmodules.qt
+
+    vtkmodules.qt.QVTKRWIBase = base
+
+
+def configure_qt_preview_surface_format() -> None:
+    """Configure the OpenGL surface format used by embedded preview widgets."""
+
+    from PySide6.QtGui import QSurfaceFormat
+
+    fmt = QSurfaceFormat()
+    fmt.setRenderableType(QSurfaceFormat.RenderableType.OpenGL)
+    fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CompatibilityProfile)
+    fmt.setVersion(2, 1)
+    fmt.setDepthBufferSize(24)
+    fmt.setStencilBufferSize(8)
+    QSurfaceFormat.setDefaultFormat(fmt)
+
+
 class QtPreviewSurface(QWidget):
     """Reusable Qt-embedded PyVista preview surface.
 
@@ -99,6 +128,7 @@ class QtPreviewSurface(QWidget):
         self._datasets: tuple[Mesh | Polyline, ...] = ()
         self._camera_aligned = False
 
+        configure_qvtk_backend(self._config.qvtk_base)
         from pyvistaqt import QtInteractor
 
         layout = QVBoxLayout(self)

--- a/src/impression/preview_qt.py
+++ b/src/impression/preview_qt.py
@@ -79,6 +79,7 @@ def apply_qt_preview_scene(
         show_polylines=options.show_polylines,
         smooth_shading=options.smooth_shading,
         lighting=options.lighting,
+        lighting_profile=options.lighting_profile,
         specular=options.specular,
         background=options.background,
         background_top=options.background_top,

--- a/src/impression/preview_qt.py
+++ b/src/impression/preview_qt.py
@@ -75,6 +75,13 @@ def apply_qt_preview_scene(
         show_bounds=options.show_bounds,
         show_axes=options.show_axes,
         align_camera=options.align_camera,
+        show_object_fill=options.show_object_fill,
+        show_polylines=options.show_polylines,
+        smooth_shading=options.smooth_shading,
+        lighting=options.lighting,
+        specular=options.specular,
+        background=options.background,
+        background_top=options.background_top,
     )
 
 

--- a/src/impression/preview_qt.py
+++ b/src/impression/preview_qt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Iterable
 
 from PySide6.QtWidgets import QVBoxLayout, QWidget
@@ -83,6 +83,17 @@ def apply_qt_preview_scene(
         background=options.background,
         background_top=options.background_top,
     )
+
+
+def preview_scene_options_for_camera_state(
+    options: PreviewSceneApplyOptions,
+    *,
+    align_camera: bool,
+    camera_aligned: bool,
+) -> PreviewSceneApplyOptions:
+    """Return scene options preserving display flags while resolving camera alignment."""
+
+    return replace(options, align_camera=align_camera and not camera_aligned)
 
 
 def configure_qvtk_backend(base: str | None) -> None:
@@ -217,12 +228,10 @@ class QtPreviewSurface(QWidget):
         )
 
     def _apply_scene(self, *, align_camera: bool) -> None:
-        options = PreviewSceneApplyOptions(
-            show_edges=self._apply_options.show_edges,
-            face_edges=self._apply_options.face_edges,
-            show_bounds=self._apply_options.show_bounds,
-            show_axes=self._apply_options.show_axes,
-            align_camera=align_camera and not self._camera_aligned,
+        options = preview_scene_options_for_camera_state(
+            self._apply_options,
+            align_camera=align_camera,
+            camera_aligned=self._camera_aligned,
         )
         self._configure_plotter()
         apply_qt_preview_scene(

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -27,10 +27,16 @@ class FakePlotter:
     def __init__(self) -> None:
         self.background_calls: list[tuple[str, str | None]] = []
         self.eye_dome_calls = 0
+        self.eye_dome_disabled_calls = 0
         self.axes_calls: list[dict[str, object]] = []
+        self.hide_axes_all_calls = 0
+        self.hide_axes_calls = 0
         self.bounds_calls: list[dict[str, object]] = []
+        self.remove_bounds_axes_calls = 0
+        self.remove_bounding_box_calls = 0
         self.clear_calls = 0
         self.mesh_calls: list[dict[str, object]] = []
+        self.actors: list[FakeActor] = []
         self.camera_position = None
 
     def set_background(self, background: str, *, top: str | None = None) -> None:
@@ -39,19 +45,62 @@ class FakePlotter:
     def enable_eye_dome_lighting(self) -> None:
         self.eye_dome_calls += 1
 
+    def disable_eye_dome_lighting(self) -> None:
+        self.eye_dome_disabled_calls += 1
+
     def add_axes(self, **kwargs: object) -> None:
         self.axes_calls.append(dict(kwargs))
+
+    def hide_axes_all(self) -> None:
+        self.hide_axes_all_calls += 1
+
+    def hide_axes(self) -> None:
+        self.hide_axes_calls += 1
 
     def show_bounds(self, **kwargs: object) -> None:
         self.bounds_calls.append(dict(kwargs))
 
+    def remove_bounds_axes(self) -> None:
+        self.remove_bounds_axes_calls += 1
+
+    def remove_bounding_box(self) -> None:
+        self.remove_bounding_box_calls += 1
+
     def clear(self) -> None:
         self.clear_calls += 1
 
-    def add_mesh(self, mesh: object, **kwargs: object) -> None:
+    def add_mesh(self, mesh: object, **kwargs: object) -> "FakeActor":
         call = dict(kwargs)
         call["mesh"] = mesh
         self.mesh_calls.append(call)
+        actor = FakeActor()
+        self.actors.append(actor)
+        return actor
+
+
+class FakeActor:
+    def __init__(self) -> None:
+        self.property = FakeActorProperty()
+
+    def GetProperty(self) -> "FakeActorProperty":
+        return self.property
+
+
+class FakeActorProperty:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def LightingOn(self) -> None:
+        self.calls.append("LightingOn")
+
+    def LightingOff(self) -> None:
+        self.calls.append("LightingOff")
+
+    def SetInterpolationToFlat(self) -> None:
+        self.calls.append("SetInterpolationToFlat")
+
+    def SetInterpolationToPhong(self) -> None:
+        self.calls.append("SetInterpolationToPhong")
 
 
 class FakePyVista:
@@ -230,6 +279,7 @@ def test_preview_scene_controller_applies_mesh_scene_and_feature_edges(monkeypat
         "lighting": True,
         "specular": 0.2,
     }
+    assert plotter.actors[0].property.calls == ["LightingOn", "SetInterpolationToPhong"]
     edge_call = plotter.mesh_calls[1]
     assert isinstance(edge_call.pop("mesh"), FakeFeatureEdges)
     assert edge_call == {
@@ -288,7 +338,67 @@ def test_preview_scene_controller_can_render_edges_without_object_fill(monkeypat
         "line_width": 1.0,
         "lighting": False,
     }
+    assert plotter.actors[0].property.calls == ["LightingOff", "SetInterpolationToFlat"]
     assert isinstance(plotter.mesh_calls[1]["mesh"], FakeFeatureEdges)
+
+
+def test_preview_scene_controller_resets_persistent_axes_and_bounds(monkeypatch) -> None:
+    import impression.preview as preview_module
+
+    plotter = FakePlotter()
+    pv_mesh = FakePvMesh()
+    monkeypatch.setattr(preview_module, "mesh_to_pyvista", lambda mesh: pv_mesh)
+    controller = PreviewSceneController(unit_settings=UnitSettings("millimeters", "mm", 1.0))
+    mesh = Mesh(
+        vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+        faces=np.array([[0, 1, 2]]),
+    )
+
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_bounds=False,
+        show_axes=False,
+        lighting=True,
+        lighting_profile="face_normals",
+        smooth_shading=False,
+        specular=0.0,
+    )
+
+    assert plotter.hide_axes_all_calls == 1
+    assert plotter.hide_axes_calls == 1
+    assert plotter.remove_bounds_axes_calls == 1
+    assert plotter.remove_bounding_box_calls == 1
+    assert plotter.eye_dome_disabled_calls == 1
+    assert plotter.axes_calls == []
+    assert plotter.bounds_calls == []
+    assert plotter.actors[0].property.calls == ["LightingOn", "SetInterpolationToFlat"]
+
+
+def test_preview_scene_controller_camera_lighting_uses_smooth_actor_interpolation(monkeypatch) -> None:
+    import impression.preview as preview_module
+
+    plotter = FakePlotter()
+    pv_mesh = FakePvMesh()
+    monkeypatch.setattr(preview_module, "mesh_to_pyvista", lambda mesh: pv_mesh)
+    controller = PreviewSceneController(unit_settings=UnitSettings("millimeters", "mm", 1.0))
+    mesh = Mesh(
+        vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+        faces=np.array([[0, 1, 2]]),
+    )
+
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_bounds=False,
+        show_axes=False,
+        lighting=True,
+        lighting_profile="camera",
+        smooth_shading=True,
+        specular=0.2,
+    )
+
+    assert plotter.actors[0].property.calls == ["LightingOn", "SetInterpolationToPhong"]
 
 
 def test_preview_scene_controller_resets_camera_from_combined_bounds() -> None:
@@ -472,6 +582,7 @@ def test_qt_preview_scene_handoff_delegates_to_shared_controller() -> None:
                 "show_polylines": True,
                 "smooth_shading": True,
                 "lighting": True,
+                "lighting_profile": "camera",
                 "specular": 0.2,
                 "background": None,
                 "background_top": None,
@@ -491,6 +602,7 @@ def test_qt_preview_preserves_display_options_when_resolving_camera_alignment() 
         show_polylines=False,
         smooth_shading=False,
         lighting=False,
+        lighting_profile="flat",
         specular=0.0,
         background="#07111f",
         background_top="#10223a",
@@ -512,6 +624,7 @@ def test_qt_preview_preserves_display_options_when_resolving_camera_alignment() 
         show_polylines=False,
         smooth_shading=False,
         lighting=False,
+        lighting_profile="flat",
         specular=0.0,
         background="#07111f",
         background_top="#10223a",

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -226,6 +226,7 @@ def test_preview_scene_controller_applies_mesh_scene_and_feature_edges(monkeypat
         "color": "#6ab0ff",
         "opacity": 1.0,
         "smooth_shading": True,
+        "lighting": True,
         "specular": 0.2,
     }
     edge_call = plotter.mesh_calls[1]
@@ -254,6 +255,39 @@ def test_preview_scene_controller_supports_legacy_feature_edge_signature(monkeyp
 
     assert pv_mesh.feature_angles == [60.0]
     assert len(plotter.mesh_calls) == 2
+
+
+def test_preview_scene_controller_can_render_edges_without_object_fill(monkeypatch) -> None:
+    import impression.preview as preview_module
+
+    plotter = FakePlotter()
+    pv_mesh = FakePvMesh()
+    monkeypatch.setattr(preview_module, "mesh_to_pyvista", lambda mesh: pv_mesh)
+    controller = PreviewSceneController(unit_settings=UnitSettings("millimeters", "mm", 1.0))
+    mesh = Mesh(
+        vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+        faces=np.array([[0, 1, 2]]),
+    )
+
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_edges=True,
+        face_edges=True,
+        show_bounds=False,
+        show_axes=False,
+        show_object_fill=False,
+    )
+
+    assert plotter.mesh_calls[0] == {
+        "mesh": pv_mesh,
+        "name": "mesh-0-wireframe",
+        "color": "#cdd7ff",
+        "style": "wireframe",
+        "line_width": 1.0,
+        "lighting": False,
+    }
+    assert isinstance(plotter.mesh_calls[1]["mesh"], FakeFeatureEdges)
 
 
 def test_preview_scene_controller_resets_camera_from_combined_bounds() -> None:
@@ -433,6 +467,13 @@ def test_qt_preview_scene_handoff_delegates_to_shared_controller() -> None:
                 "show_bounds": False,
                 "show_axes": False,
                 "align_camera": True,
+                "show_object_fill": True,
+                "show_polylines": True,
+                "smooth_shading": True,
+                "lighting": True,
+                "specular": 0.2,
+                "background": None,
+                "background_top": None,
             },
         )
     ]

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -37,6 +37,7 @@ class FakePlotter:
         self.clear_calls = 0
         self.mesh_calls: list[dict[str, object]] = []
         self.actors: list[FakeActor] = []
+        self.light_calls: list[FakeLight] = []
         self.camera_position = None
 
     def set_background(self, background: str, *, top: str | None = None) -> None:
@@ -65,6 +66,9 @@ class FakePlotter:
 
     def remove_bounding_box(self) -> None:
         self.remove_bounding_box_calls += 1
+
+    def add_light(self, light: "FakeLight") -> None:
+        self.light_calls.append(light)
 
     def clear(self) -> None:
         self.clear_calls += 1
@@ -101,6 +105,22 @@ class FakeActorProperty:
 
     def SetInterpolationToPhong(self) -> None:
         self.calls.append("SetInterpolationToPhong")
+
+
+class FakeLight:
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = dict(kwargs)
+        self.switch_calls: list[str] = []
+
+    def switch_on(self) -> None:
+        self.switch_calls.append("on")
+
+    def switch_off(self) -> None:
+        self.switch_calls.append("off")
+
+
+class FakeLightingPyVista:
+    Light = FakeLight
 
 
 class FakePyVista:
@@ -399,6 +419,59 @@ def test_preview_scene_controller_camera_lighting_uses_smooth_actor_interpolatio
     )
 
     assert plotter.actors[0].property.calls == ["LightingOn", "SetInterpolationToPhong"]
+
+
+def test_preview_scene_controller_reuses_predefined_light_presets(monkeypatch) -> None:
+    import impression.preview as preview_module
+
+    plotter = FakePlotter()
+    pv_mesh = FakePvMesh()
+    monkeypatch.setattr(preview_module, "mesh_to_pyvista", lambda mesh: pv_mesh)
+    controller = PreviewSceneController(
+        unit_settings=UnitSettings("millimeters", "mm", 1.0),
+        pyvista_provider=lambda: FakeLightingPyVista,
+    )
+    mesh = Mesh(
+        vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+        faces=np.array([[0, 1, 2]]),
+    )
+
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_bounds=False,
+        show_axes=False,
+        lighting=True,
+        lighting_profile="face_normals",
+        smooth_shading=False,
+    )
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_bounds=False,
+        show_axes=False,
+        lighting=True,
+        lighting_profile="camera",
+        smooth_shading=True,
+    )
+    controller.apply_scene(
+        plotter,
+        [mesh],
+        show_bounds=False,
+        show_axes=False,
+        lighting=False,
+        lighting_profile="flat",
+        smooth_shading=False,
+    )
+
+    assert [light.kwargs for light in plotter.light_calls] == [
+        {"light_type": "headlight", "intensity": 0.9},
+        {"light_type": "camera light", "intensity": 0.35},
+    ]
+    head, fill = plotter.light_calls
+    assert head.switch_calls == ["on", "on", "off"]
+    assert fill.switch_calls == ["off", "on", "off"]
+    assert len(plotter.light_calls) == 2
 
 
 def test_preview_scene_controller_resets_camera_from_combined_bounds() -> None:

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -18,6 +18,7 @@ from impression.preview_qt import (
     apply_qt_preview_scene,
     configure_qt_preview_surface_format,
     configure_qvtk_backend,
+    preview_scene_options_for_camera_state,
     qt_preview_supported_environment,
 )
 
@@ -477,6 +478,44 @@ def test_qt_preview_scene_handoff_delegates_to_shared_controller() -> None:
             },
         )
     ]
+
+
+def test_qt_preview_preserves_display_options_when_resolving_camera_alignment() -> None:
+    options = PreviewSceneApplyOptions(
+        show_edges=True,
+        face_edges=False,
+        show_bounds=False,
+        show_axes=True,
+        align_camera=False,
+        show_object_fill=False,
+        show_polylines=False,
+        smooth_shading=False,
+        lighting=False,
+        specular=0.0,
+        background="#07111f",
+        background_top="#10223a",
+    )
+
+    resolved = preview_scene_options_for_camera_state(
+        options,
+        align_camera=True,
+        camera_aligned=False,
+    )
+
+    assert resolved == PreviewSceneApplyOptions(
+        show_edges=True,
+        face_edges=False,
+        show_bounds=False,
+        show_axes=True,
+        align_camera=True,
+        show_object_fill=False,
+        show_polylines=False,
+        smooth_shading=False,
+        lighting=False,
+        specular=0.0,
+        background="#07111f",
+        background_top="#10223a",
+    )
 
 
 def test_reference_review_shell_does_not_apply_preview_scenes() -> None:

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -38,7 +38,9 @@ class FakePlotter:
         self.mesh_calls: list[dict[str, object]] = []
         self.actors: list[FakeActor] = []
         self.light_calls: list[FakeLight] = []
+        self.active_lights: list[FakeLight] = []
         self.camera_position = None
+        self.renderer = FakeRenderer(self)
 
     def set_background(self, background: str, *, top: str | None = None) -> None:
         self.background_calls.append((background, top))
@@ -69,9 +71,12 @@ class FakePlotter:
 
     def add_light(self, light: "FakeLight") -> None:
         self.light_calls.append(light)
+        if light not in self.active_lights:
+            self.active_lights.append(light)
 
     def clear(self) -> None:
         self.clear_calls += 1
+        self.active_lights.clear()
 
     def add_mesh(self, mesh: object, **kwargs: object) -> "FakeActor":
         call = dict(kwargs)
@@ -107,6 +112,15 @@ class FakeActorProperty:
         self.calls.append("SetInterpolationToPhong")
 
 
+class FakeRenderer:
+    def __init__(self, plotter: FakePlotter) -> None:
+        self._plotter = plotter
+
+    @property
+    def lights(self) -> tuple["FakeLight", ...]:
+        return tuple(self._plotter.active_lights)
+
+
 class FakeLight:
     def __init__(self, **kwargs: object) -> None:
         self.kwargs = dict(kwargs)
@@ -120,7 +134,13 @@ class FakeLight:
 
 
 class FakeLightingPyVista:
-    Light = FakeLight
+    created: list[FakeLight] = []
+
+    @classmethod
+    def Light(cls, **kwargs: object) -> FakeLight:
+        light = FakeLight(**kwargs)
+        cls.created.append(light)
+        return light
 
 
 class FakePyVista:
@@ -424,6 +444,7 @@ def test_preview_scene_controller_camera_lighting_uses_smooth_actor_interpolatio
 def test_preview_scene_controller_reuses_predefined_light_presets(monkeypatch) -> None:
     import impression.preview as preview_module
 
+    FakeLightingPyVista.created = []
     plotter = FakePlotter()
     pv_mesh = FakePvMesh()
     monkeypatch.setattr(preview_module, "mesh_to_pyvista", lambda mesh: pv_mesh)
@@ -464,14 +485,16 @@ def test_preview_scene_controller_reuses_predefined_light_presets(monkeypatch) -
         smooth_shading=False,
     )
 
-    assert [light.kwargs for light in plotter.light_calls] == [
+    assert [light.kwargs for light in FakeLightingPyVista.created] == [
         {"light_type": "headlight", "intensity": 0.9},
         {"light_type": "camera light", "intensity": 0.35},
     ]
-    head, fill = plotter.light_calls
+    head, fill = FakeLightingPyVista.created
     assert head.switch_calls == ["on", "on", "off"]
     assert fill.switch_calls == ["off", "on", "off"]
-    assert len(plotter.light_calls) == 2
+    assert len(FakeLightingPyVista.created) == 2
+    assert plotter.light_calls == [head, fill, head, fill, head, fill]
+    assert plotter.active_lights == [head, fill]
 
 
 def test_preview_scene_controller_resets_camera_from_combined_bounds() -> None:

--- a/tests/test_preview_controller.py
+++ b/tests/test_preview_controller.py
@@ -16,6 +16,8 @@ from impression.preview import (
 from impression.preview_qt import (
     QtPreviewSurfaceConfig,
     apply_qt_preview_scene,
+    configure_qt_preview_surface_format,
+    configure_qvtk_backend,
     qt_preview_supported_environment,
 )
 
@@ -358,6 +360,37 @@ def test_qt_preview_surface_config_has_workbench_defaults() -> None:
     assert config.apply_options.show_axes is False
     assert config.apply_options.align_camera is True
     assert config.auto_update is False
+    assert config.qvtk_base == "QOpenGLWidget"
+
+
+def test_qt_preview_configures_qopengl_backend_before_pyvistaqt_import() -> None:
+    import sys
+    import vtkmodules.qt
+
+    original_base = getattr(vtkmodules.qt, "QVTKRWIBase", None)
+    sys.modules.pop("pyvistaqt.rwi", None)
+    try:
+        vtkmodules.qt.QVTKRWIBase = "QWidget"
+        configure_qvtk_backend("QOpenGLWidget")
+
+        assert vtkmodules.qt.QVTKRWIBase == "QOpenGLWidget"
+    finally:
+        if original_base is not None:
+            vtkmodules.qt.QVTKRWIBase = original_base
+
+
+def test_qt_preview_configures_opengl_compatibility_surface_format() -> None:
+    from PySide6.QtGui import QSurfaceFormat
+
+    configure_qt_preview_surface_format()
+
+    fmt = QSurfaceFormat.defaultFormat()
+    assert fmt.renderableType() == QSurfaceFormat.RenderableType.OpenGL
+    assert fmt.profile() == QSurfaceFormat.OpenGLContextProfile.CompatibilityProfile
+    assert fmt.majorVersion() == 2
+    assert fmt.minorVersion() == 1
+    assert fmt.depthBufferSize() == 24
+    assert fmt.stencilBufferSize() == 8
 
 
 def test_qt_preview_supported_environment_rejects_offscreen_by_default(monkeypatch) -> None:

--- a/tests/test_reference_review_async_core.py
+++ b/tests/test_reference_review_async_core.py
@@ -131,6 +131,33 @@ def test_dispatcher_rejects_when_bounded_queue_is_full() -> None:
     assert len(hold) == 1
 
 
+def test_dispatcher_coalesces_without_submitting_extra_work() -> None:
+    release = Event()
+    hold: list[ReviewWorkbenchMessage] = []
+
+    def worker(message: ReviewWorkbenchMessage) -> str:
+        hold.append(message)
+        release.wait(timeout=2)
+        return "done"
+
+    dispatcher = TaskDispatcher(
+        max_workers=1,
+        policies={ReviewTaskKind.PREVIEW_BUILD: WorkerPolicy(max_pending=1, coalesce=True)},
+    )
+
+    first = dispatcher.dispatch(_message(1), worker)
+    second = dispatcher.dispatch(_message(2), worker)
+    release.set()
+    if first.future:
+        first.future.result(timeout=2)
+    dispatcher.close()
+
+    assert first.accepted
+    assert not second.accepted
+    assert second.diagnostic == "coalesced"
+    assert len(hold) == 1
+
+
 def test_latest_request_tracker_rejects_stale_completions_and_cancels_old_tokens() -> None:
     tracker = LatestRequestTracker()
     old = _message(1)

--- a/tests/test_reference_review_preview_payload_builder.py
+++ b/tests/test_reference_review_preview_payload_builder.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 
 from impression.mesh import Mesh
+import impression.devtools.reference_review.preview_payload_builder as preview_payload_builder
 from impression.devtools.reference_review import (
     EntrypointParameterRecord,
     LoadedPreviewDataset,
@@ -63,6 +64,30 @@ def test_preview_source_loader_invokes_fixture_entrypoint_with_parameters(
     assert dataset.request is request
     assert dataset.dataset_count == 1
     assert dataset.datasets[0].vertices.shape[0] > 0
+
+
+def test_preview_source_loader_serializes_process_import_state(tmp_path: Path) -> None:
+    source = tmp_path / "simple.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord("fixture/import-lock", "Import Lock", source)
+    request = _request_from_record(record)
+    acquired = []
+
+    class RecordingLock:
+        def __enter__(self):
+            acquired.append("enter")
+
+        def __exit__(self, exc_type, exc, tb):
+            acquired.append("exit")
+
+    original_lock = preview_payload_builder._PREVIEW_SOURCE_IMPORT_LOCK
+    preview_payload_builder._PREVIEW_SOURCE_IMPORT_LOCK = RecordingLock()  # type: ignore[assignment]
+    try:
+        assert load_preview_source(request) is None
+    finally:
+        preview_payload_builder._PREVIEW_SOURCE_IMPORT_LOCK = original_lock
+
+    assert acquired == ["enter", "exit"]
 
 
 def test_preview_dataset_builder_tessellates_real_dirty_impress_source_fixture(

--- a/tests/test_reference_review_preview_payload_controller.py
+++ b/tests/test_reference_review_preview_payload_controller.py
@@ -18,6 +18,7 @@ from impression.devtools.reference_review import (
 from impression.devtools.reference_review.async_core import (
     DispatchResult,
     ReviewTaskKind,
+    TaskDispatcher,
     ReviewWorkbenchMessage,
     WorkerResultEnvelope,
 )
@@ -104,6 +105,33 @@ def test_preview_payload_process_controller_records_launch_rejection() -> None:
     assert not dispatch.accepted
     assert controller.diagnostics[0].code == "preview-payload-launch-rejected"
     assert controller.diagnostics[0].message == "queue_full"
+
+
+def test_preview_payload_controller_dispatcher_route_builds_payload(tmp_path: Path) -> None:
+    source = tmp_path / "model.py"
+    source.write_text("from impression.modeling import make_box\n\ndef build():\n    return make_box(backend='surface')\n")
+    record = ReviewSourceModelRecord(
+        fixture_id="fixture/dispatcher",
+        feature_name="Dispatcher",
+        source_path=source,
+    )
+    dispatcher = TaskDispatcher(max_workers=1)
+    controller = PreviewPayloadProcessController(
+        dispatcher=dispatcher,
+        owns_dispatcher=True,
+        payload_dir=tmp_path,
+        cwd=tmp_path,
+    )
+
+    dispatch = controller.launch(record)
+    envelope = dispatch.future.result(timeout=2) if dispatch.future else None
+    controller.close()
+
+    assert envelope is not None
+    assert envelope.ok
+    assert isinstance(envelope.result, PreviewPayloadProcessResult)
+    assert envelope.result.payload.payload_path is not None
+    assert envelope.result.payload.payload_path.exists()
 
 
 def test_preview_payload_process_launch_does_not_block_on_process_submit(tmp_path: Path) -> None:

--- a/tests/test_reference_review_preview_payload_controller.py
+++ b/tests/test_reference_review_preview_payload_controller.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from concurrent.futures import Future
 from pathlib import Path
+from threading import Event
+from time import monotonic
 
 from impression.devtools.reference_review import (
     PreviewPayload,
@@ -16,6 +19,7 @@ from impression.devtools.reference_review.async_core import (
     DispatchResult,
     ReviewTaskKind,
     ReviewWorkbenchMessage,
+    WorkerResultEnvelope,
 )
 
 
@@ -100,6 +104,54 @@ def test_preview_payload_process_controller_records_launch_rejection() -> None:
     assert not dispatch.accepted
     assert controller.diagnostics[0].code == "preview-payload-launch-rejected"
     assert controller.diagnostics[0].message == "queue_full"
+
+
+def test_preview_payload_process_launch_does_not_block_on_process_submit(tmp_path: Path) -> None:
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        fixture_id="fixture/nonblocking-launch",
+        feature_name="Nonblocking",
+        source_path=source,
+    )
+    entered_submit = Event()
+    release_submit = Event()
+
+    class BlockingProcessExecutor:
+        def submit(self, _worker, message, *_args, **_kwargs):
+            entered_submit.set()
+            release_submit.wait(timeout=2)
+            future: Future[WorkerResultEnvelope] = Future()
+            future.set_result(
+                WorkerResultEnvelope(
+                    request=message,
+                    ok=False,
+                    error="controlled-test-submit",
+                )
+            )
+            return future
+
+        def shutdown(self, *, wait=True, cancel_futures=False):
+            release_submit.set()
+
+    controller = PreviewPayloadProcessController(payload_dir=tmp_path, cwd=tmp_path)
+    assert controller._process_executor is not None
+    controller._process_executor.shutdown(wait=False, cancel_futures=True)
+    controller._process_executor = BlockingProcessExecutor()  # type: ignore[assignment]
+
+    start = monotonic()
+    dispatch = controller.launch(record)
+    elapsed = monotonic() - start
+
+    assert dispatch.accepted
+    assert elapsed < 0.2
+    assert entered_submit.wait(timeout=1)
+    release_submit.set()
+    assert dispatch.future is not None
+    envelope = dispatch.future.result(timeout=2)
+    controller.close()
+
+    assert envelope.error == "controlled-test-submit"
 
 
 def _payload_for_cleanup(tmp_path: Path, *, request_id: int = 1) -> PreviewPayload:

--- a/tests/test_reference_review_preview_payload_controller.py
+++ b/tests/test_reference_review_preview_payload_controller.py
@@ -134,6 +134,26 @@ def test_preview_payload_controller_dispatcher_route_builds_payload(tmp_path: Pa
     assert envelope.result.payload.payload_path.exists()
 
 
+def test_preview_payload_controller_closes_owned_dispatcher_without_waiting() -> None:
+    calls = []
+
+    class RecordingDispatcher:
+        def dispatch(self, _request, _worker):
+            raise AssertionError("not used")
+
+        def close(self, *, wait=True, cancel_futures=False):
+            calls.append((wait, cancel_futures))
+
+    controller = PreviewPayloadProcessController(
+        dispatcher=RecordingDispatcher(),  # type: ignore[arg-type]
+        owns_dispatcher=True,
+    )
+
+    controller.close()
+
+    assert calls == [(False, True)]
+
+
 def test_preview_payload_process_launch_does_not_block_on_process_submit(tmp_path: Path) -> None:
     source = tmp_path / "model.py"
     source.write_text("def build():\n    return None\n")

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -1380,6 +1380,27 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
     assert window._preview_futures == []
 
 
+def test_window_preview_controller_uses_thread_dispatcher_not_process_pool(tmp_path: Path) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    artifact = tmp_path / "part.impress"
+    artifact.write_text('{"format": "impress"}\n')
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        "demo/part",
+        "demo",
+        source,
+        artifact_paths=(artifact,),
+    )
+
+    result = launch_workbench(fixture_records=(record,), offscreen=True)
+    window = result.engine.rootObjects()[0]
+
+    assert window._preview_controller._dispatcher is not None
+    assert window._preview_controller._owns_dispatcher
+    assert window._preview_controller._process_executor is None
+
+
 def test_window_preview_ignores_stale_future_exception(tmp_path: Path) -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     artifact = tmp_path / "part.impress"

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import QObject, QSize, Qt
 from PySide6.QtGui import QIcon, QImage, QPainter
 from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QTabWidget, QToolButton, QWidget
 
-from impression.mesh import Mesh
+from impression.mesh import Mesh, Polyline
 from impression.devtools.reference_review import ReviewSourceModelRecord
 from impression.devtools.reference_review.ui import (
     BridgeRecord,
@@ -1222,6 +1222,7 @@ def test_pyvistaqt_preview_surface_uses_lightweight_scene_handoff(
         "show_polylines": True,
         "smooth_shading": False,
         "lighting": True,
+        "lighting_profile": "face_normals",
         "specular": 0.0,
         "background": "#07111f",
         "background_top": "#10223a",
@@ -1251,9 +1252,27 @@ def test_pyvistaqt_preview_scene_options_map_display_controls() -> None:
     assert apply_options.show_polylines is False
     assert apply_options.smooth_shading is True
     assert apply_options.lighting is True
+    assert apply_options.lighting_profile == "camera"
     assert apply_options.specular == 0.2
     assert apply_options.background == "#07111f"
     assert apply_options.background_top is None
+
+
+def test_pyvistaqt_preview_dataset_filtering_hides_polylines() -> None:
+    mesh = Mesh(
+        vertices=np.asarray(((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0))),
+        faces=np.asarray(((0, 1, 2),)),
+    )
+    polyline = Polyline(np.asarray(((0.0, 0.0, 0.0), (1.0, 1.0, 0.0))))
+
+    filtered = preview_widget._datasets_for_display_options(
+        (mesh, polyline),
+        PreviewDisplayOptions(show_polylines=False),
+    )
+
+    assert len(filtered) == 1
+    assert filtered[0] is not polyline
+    assert isinstance(filtered[0], Mesh)
 
 
 def test_preview_render_command_records_and_queue_coalesce_by_lane(tmp_path: Path) -> None:

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -1279,6 +1279,36 @@ def test_preview_widget_drains_latest_display_command_once() -> None:
     assert applied == [PreviewDisplayOptions(show_axis_triad=True)]
 
 
+def test_preview_widget_drains_one_render_command_per_turn() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    widget = PreviewRendererLifecycleWidget()
+    applied = []
+
+    class FakePlotter(QWidget):
+        def clear(self) -> None:
+            pass
+
+        def set_display_options(self, options) -> None:
+            applied.append(options)
+
+    widget.ensure_renderer(renderer_factory=lambda parent: FakePlotter(parent))
+    applied.clear()
+
+    widget.enqueue_render_command(PreviewRenderCommand.loading())
+    widget.enqueue_render_command(
+        PreviewRenderCommand.display(PreviewDisplayOptions(show_axis_triad=False))
+    )
+
+    widget._drain_preview_render_queue()
+
+    assert widget._status.text() == "Loading preview..."
+    assert applied == []
+
+    widget._drain_preview_render_queue()
+
+    assert applied == [PreviewDisplayOptions(show_axis_triad=False)]
+
+
 def test_pyvistaqt_display_options_replace_scene_once(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     QApplication.instance() or QApplication([])
@@ -1372,6 +1402,7 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
     window._load_artifact_preview(window._fixture_items[0])
     future.set_result(SimpleNamespace(ok=True))
     window._poll_preview_payloads()
+    window.preview_surface._drain_preview_render_queue()
     window.preview_surface._drain_preview_render_queue()
 
     assert launched == [record]
@@ -1467,6 +1498,91 @@ def test_window_preview_ignores_stale_future_exception(tmp_path: Path) -> None:
 
     assert enqueued == []
     assert window._preview_futures == [current_future]
+
+
+def test_window_preview_retries_latest_coalesced_request(tmp_path: Path) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    artifact = tmp_path / "part.impress"
+    artifact.write_text('{"format": "impress"}\n')
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        "demo/part",
+        "demo",
+        source,
+        artifact_paths=(artifact,),
+    )
+    result = launch_workbench(fixture_records=(record,), offscreen=True)
+    window = result.engine.rootObjects()[0]
+    first_future: Future = Future()
+    second_future: Future = Future()
+    launched = []
+
+    class CoalescingPreviewController:
+        def __init__(self) -> None:
+            self.active_identity = None
+            self._calls = 0
+
+        def launch(self, record):
+            self._calls += 1
+            launched.append(record)
+            request = SimpleNamespace(
+                owner="preview-payload",
+                request_id=self._calls,
+                fixture_id=record.fixture_id,
+                payload={"generation": self._calls},
+            )
+            self.active_identity = (
+                request.owner,
+                request.request_id,
+                request.fixture_id,
+                self._calls,
+            )
+            if self._calls == 1:
+                return SimpleNamespace(
+                    accepted=True,
+                    future=first_future,
+                    request=request,
+                    diagnostic=None,
+                )
+            if self._calls == 2:
+                return SimpleNamespace(
+                    accepted=False,
+                    future=None,
+                    request=request,
+                    diagnostic="coalesced",
+                )
+            return SimpleNamespace(
+                accepted=True,
+                future=second_future,
+                request=request,
+                diagnostic=None,
+            )
+
+        def handle_completion(self, envelope, handoff, diagnostic_handoff=None):
+            return None
+
+        def close(self):
+            pass
+
+    window._preview_controller.close()
+    window._preview_futures = []
+    window._preview_future_identities = {}
+    window._pending_preview_record = None
+    window._preview_controller = CoalescingPreviewController()
+
+    window._load_artifact_preview(window._fixture_items[0])
+    window._load_artifact_preview(window._fixture_items[0])
+
+    assert window._preview_futures == [first_future]
+    assert window._pending_preview_record is record
+
+    first_future.set_result(SimpleNamespace(ok=False, result=None, error="stale"))
+    window._poll_preview_payloads()
+
+    assert launched == [record, record, record]
+    assert window._preview_futures == [second_future]
+    assert window._pending_preview_record is None
 
 
 def test_live_preview_process_target_is_non_ui_module() -> None:

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -14,7 +14,7 @@ import pytest
 import numpy as np
 from PySide6.QtCore import QObject, QSize, Qt
 from PySide6.QtGui import QIcon, QImage, QPainter
-from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QTabWidget, QToolButton
+from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QTabWidget, QToolButton, QWidget
 
 from impression.mesh import Mesh
 from impression.devtools.reference_review import ReviewSourceModelRecord
@@ -30,6 +30,9 @@ from impression.devtools.reference_review.ui import (
     ExclusiveIconOptionRecord,
     PreviewDisplayControlBar,
     PreviewDisplayOptions,
+    PreviewRenderCommand,
+    PreviewRenderCommandKind,
+    PreviewRenderCommandQueue,
     WorkbenchIconToggleButton,
     build_dependency_policy_report,
     launch_workbench,
@@ -44,6 +47,7 @@ from impression.devtools.reference_review.ui import (
 )
 from impression.devtools.reference_review import (
     LoadedPreviewDataset,
+    PreviewPayload,
     PreviewPayloadRequest,
     build_impress_preview_result,
     write_preview_payload_file,
@@ -1217,6 +1221,107 @@ def test_pyvistaqt_preview_surface_uses_lightweight_scene_handoff(
     }
 
 
+def test_preview_render_command_records_and_queue_coalesce_by_lane(tmp_path: Path) -> None:
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord("fixture/queue", "feature", source)
+    request = PreviewPayloadRequest.from_source_record(
+        record,
+        owner="preview-payload",
+        request_id=4,
+        generation=2,
+    )
+    payload = PreviewPayload.success(request, payload_path=tmp_path / "payload.json")
+    first_display = PreviewDisplayOptions(show_bounds_grid=True)
+    second_display = PreviewDisplayOptions(show_bounds_grid=False)
+    queue = PreviewRenderCommandQueue()
+
+    first = queue.enqueue(PreviewRenderCommand.display(first_display))
+    second = queue.enqueue(PreviewRenderCommand.display(second_display))
+    queue.enqueue(PreviewRenderCommand.payload_ready(payload))
+
+    assert not first.replaced
+    assert second.replaced
+    assert queue.state.pending_lanes == ("payload", "display")
+    commands = queue.drain()
+    assert [command.kind for command in commands] == [
+        PreviewRenderCommandKind.PAYLOAD,
+        PreviewRenderCommandKind.DISPLAY,
+    ]
+    assert commands[0].identity == payload.identity
+    assert commands[1].display_options == second_display
+    assert queue.state.pending_count == 0
+
+
+def test_preview_widget_drains_latest_display_command_once() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    widget = PreviewRendererLifecycleWidget()
+    applied = []
+
+    class FakePlotter(QWidget):
+        def clear(self) -> None:
+            pass
+
+        def set_display_options(self, options) -> None:
+            applied.append(options)
+
+    widget.ensure_renderer(renderer_factory=lambda parent: FakePlotter(parent))
+    applied.clear()
+
+    widget.enqueue_render_command(
+        PreviewRenderCommand.display(PreviewDisplayOptions(show_axis_triad=False))
+    )
+    widget.enqueue_render_command(
+        PreviewRenderCommand.display(PreviewDisplayOptions(show_axis_triad=True))
+    )
+    widget._drain_preview_render_queue()
+
+    assert applied == [PreviewDisplayOptions(show_axis_triad=True)]
+
+
+def test_pyvistaqt_display_options_replace_scene_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    QApplication.instance() or QApplication([])
+    mesh = Mesh(
+        vertices=np.asarray(((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0))),
+        faces=np.asarray(((0, 1, 2),)),
+    )
+
+    class FakeQtPreviewSurface(QWidget):
+        def __init__(self, parent=None, *, config=None):
+            super().__init__(parent)
+            self.calls = []
+
+        @property
+        def plotter(self):
+            return object()
+
+        def replace_scene(self, datasets, *, apply_options, align_camera=True):
+            self.calls.append(("replace", tuple(datasets), apply_options, align_camera))
+
+        def set_apply_options(self, options):
+            self.calls.append(("set_apply_options", options))
+
+        def set_datasets(self, datasets, *, align_camera=True):
+            self.calls.append(("set_datasets", tuple(datasets), align_camera))
+
+        def clear(self):
+            pass
+
+    monkeypatch.setattr(preview_widget, "QtPreviewSurface", FakeQtPreviewSurface)
+    surface = preview_widget.PyVistaQtPreviewSurface()
+
+    surface.set_datasets((mesh,))
+    fake_surface = surface._surface
+    assert [call[0] for call in fake_surface.calls] == ["replace"]
+    fake_surface.calls.clear()
+
+    surface.set_display_options(PreviewDisplayOptions(show_triangle_wireframe=True))
+
+    assert [call[0] for call in fake_surface.calls] == ["replace"]
+    assert fake_surface.calls[0][3] is False
+
+
 def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     artifact = tmp_path / "part.impress"
@@ -1232,6 +1337,13 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
     result = launch_workbench(fixture_records=(record,), offscreen=True)
     window = result.engine.rootObjects()[0]
     future: Future = Future()
+    request = PreviewPayloadRequest.from_source_record(
+        record,
+        owner="preview-payload",
+        request_id=1,
+        generation=1,
+    )
+    payload = PreviewPayload.success(request, payload_path=tmp_path / "payload.json")
     launched = []
     applied = []
     cleaned = []
@@ -1242,7 +1354,7 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
             return SimpleNamespace(accepted=True, future=future, diagnostic=None)
 
         def handle_completion(self, envelope, handoff, diagnostic_handoff=None):
-            handoff(SimpleNamespace(payload="payload"))
+            handoff(SimpleNamespace(payload=payload))
 
         def cleanup_payload(self, payload, *, reason: str):
             cleaned.append((payload, reason))
@@ -1254,17 +1366,86 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
     window._preview_futures = []
     window._preview_controller = FakePreviewController()
     window.preview_surface.set_preview_payload = lambda payload: (
-        applied.append(payload) or SimpleNamespace(ready=True)
+        applied.append(payload) or SimpleNamespace(ready=True, diagnostic=None)
     )
 
     window._load_artifact_preview(window._fixture_items[0])
     future.set_result(SimpleNamespace(ok=True))
     window._poll_preview_payloads()
+    window.preview_surface._drain_preview_render_queue()
 
     assert launched == [record]
-    assert applied == ["payload"]
-    assert cleaned == [("payload", "completed")]
+    assert applied == [payload]
+    assert cleaned == [(payload, "completed")]
     assert window._preview_futures == []
+
+
+def test_window_preview_ignores_stale_future_exception(tmp_path: Path) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    artifact = tmp_path / "part.impress"
+    artifact.write_text('{"format": "impress"}\n')
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        "demo/part",
+        "demo",
+        source,
+        artifact_paths=(artifact,),
+    )
+    result = launch_workbench(fixture_records=(record,), offscreen=True)
+    window = result.engine.rootObjects()[0]
+    stale_future: Future = Future()
+    current_future: Future = Future()
+    futures = [stale_future, current_future]
+    enqueued = []
+
+    class FakePreviewController:
+        def __init__(self) -> None:
+            self.active_identity = None
+            self._request_id = 0
+
+        def launch(self, record):
+            self._request_id += 1
+            generation = self._request_id
+            request = SimpleNamespace(
+                owner="preview-payload",
+                request_id=self._request_id,
+                fixture_id=record.fixture_id,
+                payload={"generation": generation},
+            )
+            self.active_identity = (
+                request.owner,
+                request.request_id,
+                request.fixture_id,
+                generation,
+            )
+            return SimpleNamespace(
+                accepted=True,
+                future=futures[self._request_id - 1],
+                request=request,
+                diagnostic=None,
+            )
+
+        def handle_completion(self, envelope, handoff, diagnostic_handoff=None):
+            raise AssertionError("stale exception should not reach completion handling")
+
+        def close(self):
+            pass
+
+    window._preview_controller.close()
+    window._preview_futures = []
+    window._preview_future_identities = {}
+    window._preview_controller = FakePreviewController()
+    window.preview_surface.enqueue_render_command = lambda command: enqueued.append(command)
+
+    window._load_artifact_preview(window._fixture_items[0])
+    window._load_artifact_preview(window._fixture_items[0])
+    enqueued.clear()
+    stale_future.set_exception(RuntimeError("stale failure"))
+    window._poll_preview_payloads()
+
+    assert enqueued == []
+    assert window._preview_futures == [current_future]
 
 
 def test_live_preview_process_target_is_non_ui_module() -> None:

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -1218,7 +1218,42 @@ def test_pyvistaqt_preview_surface_uses_lightweight_scene_handoff(
         "show_bounds": True,
         "show_axes": True,
         "align_camera": True,
+        "show_object_fill": True,
+        "show_polylines": True,
+        "smooth_shading": False,
+        "lighting": True,
+        "specular": 0.0,
+        "background": "#07111f",
+        "background_top": "#10223a",
     }
+
+
+def test_pyvistaqt_preview_scene_options_map_display_controls() -> None:
+    options = PreviewDisplayOptions(
+        lighting_mode="camera",
+        show_object_fill=False,
+        show_triangle_wireframe=True,
+        show_object_edges=False,
+        show_bounds_grid=False,
+        show_axis_triad=False,
+        show_gradient_background=False,
+        show_polylines=False,
+    )
+
+    apply_options = preview_widget._preview_scene_apply_options(options, align_camera=False)
+
+    assert apply_options.show_edges is True
+    assert apply_options.face_edges is False
+    assert apply_options.show_bounds is False
+    assert apply_options.show_axes is False
+    assert apply_options.align_camera is False
+    assert apply_options.show_object_fill is False
+    assert apply_options.show_polylines is False
+    assert apply_options.smooth_shading is True
+    assert apply_options.lighting is True
+    assert apply_options.specular == 0.2
+    assert apply_options.background == "#07111f"
+    assert apply_options.background_top is None
 
 
 def test_preview_render_command_records_and_queue_coalesce_by_lane(tmp_path: Path) -> None:
@@ -1409,6 +1444,78 @@ def test_window_preview_controller_launches_and_polls_payload(tmp_path: Path) ->
     assert applied == [payload]
     assert cleaned == [(payload, "completed")]
     assert window._preview_futures == []
+
+
+def test_window_preview_display_button_updates_live_surface(tmp_path: Path) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    artifact = tmp_path / "part.impress"
+    artifact.write_text('{"format": "impress"}\n')
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        "demo/part",
+        "demo",
+        source,
+        artifact_paths=(artifact,),
+    )
+    result = launch_workbench(fixture_records=(record,), offscreen=True)
+    window = result.engine.rootObjects()[0]
+    future: Future = Future()
+    request = PreviewPayloadRequest.from_source_record(
+        record,
+        owner="preview-payload",
+        request_id=7,
+        generation=1,
+    )
+    payload = PreviewPayload.success(request, payload_path=tmp_path / "payload.json")
+    applied_options = []
+
+    class FakePreviewController:
+        active_identity = payload.identity
+
+        def launch(self, record):
+            return SimpleNamespace(accepted=True, future=future, diagnostic=None, request=request)
+
+        def handle_completion(self, envelope, handoff, diagnostic_handoff=None):
+            handoff(SimpleNamespace(payload=payload))
+
+        def cleanup_payload(self, payload, *, reason: str):
+            return None
+
+        def close(self):
+            pass
+
+    window._preview_controller.close()
+    window._preview_futures = []
+    window._preview_controller = FakePreviewController()
+
+    def apply_payload(payload):
+        window.preview_surface._payload_state = preview_widget.PreviewWidgetPayloadState(
+            generation=payload.request.generation,
+            fixture_id=payload.request.fixture_id,
+            ready=True,
+        )
+        return window.preview_surface._payload_state
+
+    window.preview_surface.set_preview_payload = apply_payload
+    window.preview_surface.set_display_options = lambda options: applied_options.append(options)
+
+    window._load_artifact_preview(window._fixture_items[0])
+    future.set_result(SimpleNamespace(ok=True))
+    window._poll_preview_payloads()
+    window.preview_surface._drain_preview_render_queue()
+    window.preview_surface._drain_preview_render_queue()
+
+    button = window.findChild(QToolButton, "previewDisplayControl-triangle-wireframe")
+    assert button is not None
+    button.click()
+    window.preview_surface._drain_preview_render_queue()
+
+    assert applied_options[-1].show_triangle_wireframe is True
+    assert window.preview_display_controls.findChild(
+        QToolButton,
+        "previewDisplayControl-triangle-wireframe",
+    ).isChecked()
 
 
 def test_window_preview_controller_uses_thread_dispatcher_not_process_pool(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add immutable preview render commands and a latest-wins coalescing queue for lifecycle, payload, display, and camera lanes
- route preview payload completions and display-control changes through the preview widget drain instead of direct shell renderer mutation
- guard stale future exceptions by tracked preview request identity, and use a single Qt surface scene replacement for display option updates
- add Spec 75 implementation/test-spec docs and mark 75a1-75d complete in the progression

## Verification
- .venv/bin/python -m compileall -q src/impression/devtools/reference_review/ui/preview_render_queue.py src/impression/devtools/reference_review/ui/preview_widget.py src/impression/devtools/reference_review/ui/shell.py src/impression/preview_qt.py
- .venv/bin/python -m pytest tests/test_reference_review_async_core.py tests/test_reference_review_preview_payload.py tests/test_reference_review_preview_payload_builder.py tests/test_reference_review_preview_payload_controller.py tests/test_reference_review_ui_shell.py tests/test_preview_controller.py -q

## Note
- .venv/bin/python -m ruff check was not available because ruff is not installed in this venv.