### PR TITLE
Stabilize reference review launch and preview handoff

### DIFF
--- a/project/release-0.1.0a/architecture/README.md
+++ b/project/release-0.1.0a/architecture/README.md
@@ -63,6 +63,7 @@ Architecture documents define:
 - [Reference Review Preview Payload Boundary Architecture](reference-review-preview-payload-boundary-architecture.md)
 - [Reference Review Promotion And Notes Lifecycle](reference-review-promotion-and-notes-lifecycle.md)
 - [Reference Review Codex Sandbox](reference-review-codex-sandbox.md)
+- [Reference Review And Impression Bench GUI Delta Review](reference-review-impression-bench-gui-delta-review.md)
 
 ## Inference And Curve Fitting Documents
 
@@ -100,6 +101,7 @@ Architecture documents define:
 - [ACD: Branching Loft CSG Decomposition And Recomposition Policy](acd-branching-loft-csg-decomposition-and-recomposition-policy.md)
 - [ACD: Loft CSG Result Provenance And Color Propagation](acd-loft-csg-result-provenance-and-color-propagation.md)
 - [ACD: Reference Fixture Multi-Artifact Section Evidence Policy](acd-reference-fixture-multi-artifact-section-evidence-policy.md)
+- [ACD: Reference Review Hybrid Stabilization](acd-reference-review-hybrid-stabilization.md)
 
 ## Notes
 

--- a/project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md
+++ b/project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md
@@ -1,0 +1,379 @@
+# Reference Review Hybrid Stabilization Architectural Change Document
+
+Date: 2026-07-17
+Status: Proposed
+Canonical architecture targets:
+
+- `project/release-0.1.0a/architecture/reference-review-workbench-architecture.md`
+- `project/release-0.1.0a/architecture/reference-review-qt-workbench-ui.md`
+- `project/release-0.1.0a/architecture/reference-review-async-concurrency.md`
+- `project/release-0.1.0a/architecture/reference-review-preview-payload-boundary-architecture.md`
+- `project/release-0.1.0a/architecture/reference-review-preview-engine-sharing-architecture.md`
+- `project/release-0.1.0a/architecture/agentic-gui-shared-workbench-code-architecture.md`
+- `project/release-0.1.0a/architecture/reference-review-impression-bench-gui-delta-review.md`
+
+Related:
+
+- Release / plan / issue: `project/release-0.1.0a/planning/reference-review-hybrid-stabilization-plan.md`
+- Release / plan / issue: `project/release-0.1.0a/planning/reference-review-workbench-progression.md`
+- Parent ACD, if any: none
+
+## Change Intent
+
+Stabilize the current Reference Review app from its in-between launch-crashing
+state without attempting the full Workbench Kit migration.
+
+The intended path is a hybrid stabilization: preserve the app-specific review
+workflow, harden launch and preview ownership, and adopt only the lowest-risk
+`impression-workbench-kit` helpers where they directly remove current
+duplication or instability. Once the app launches, renders, and supports review
+actions through the real entrypoint, the branch should be pushed, opened as a
+pull request, and merged into the release working branch. The broader kit
+migration is planned separately after that stable checkpoint.
+
+## Current Architecture
+
+The current code and documentation are out of phase:
+
+- the Reference Review progression marks the workbench and preview
+  remediation specs complete;
+- the live app currently crashes, hangs, or beachballs on launch;
+- the branch contains in-flight renderer and review-app changes;
+- Reference Review still carries local copies of helpers that now exist in
+  `impression-workbench-kit`;
+- newer Impression Bench management code demonstrates stronger async and
+  diagnostic patterns, but those patterns are not yet cleanly part of the
+  Reference Review app.
+
+This ACD exists because canonical architecture should not be edited as though
+the stabilized hybrid structure is already true in code.
+
+## Target Architecture
+
+The stabilized Reference Review app keeps review-domain ownership local while
+using shared workbench infrastructure only at safe boundaries.
+
+### Stabilization Boundary
+
+Reference Review continues to own:
+
+- fixture discovery and fixture list state;
+- fixture status: approved, declined, and unreviewed;
+- notes loading and real-time persistence;
+- dirty-to-gold artifact promotion;
+- fixture context, purpose, methodology, and expected-render text;
+- review-specific source and artifact payload decisions;
+- the `impression-reference-review` console entrypoint.
+
+Impression core continues to own:
+
+- model construction APIs;
+- `.impress` loading and serialization behavior;
+- preview scene semantics shared with CLI preview;
+- renderer interaction semantics that must remain CLI-preview-like.
+
+`impression-workbench-kit` may own, during this stabilization pass:
+
+- sanitized Qt handoff helpers;
+- latest-request or staleness helpers;
+- durable write lane helpers;
+- preview display option records and icon-control state, if API-compatible;
+- markdown context rendering and style records, if API-compatible.
+
+The kit must not own, during this pass:
+
+- fixture review status;
+- promotion policy;
+- fixture queue behavior;
+- app-specific payload builder decisions;
+- Bench file browser, code editor, chat, prompt injector, or proposal
+  workflows.
+
+### Launch Ownership
+
+The app launch path must initialize only the shell, QML/widget hierarchy,
+lightweight models, and deferred task lanes.
+
+The launch path must not synchronously:
+
+- create or mutate expensive renderer content before the preview widget is
+  ready;
+- import fixture source modules;
+- build models;
+- tessellate geometry;
+- scan large fixture roots;
+- write notes, promotion state, or fixture files.
+
+Expensive work starts only after the event loop is alive and is routed through
+owned task lanes with UI-thread handoff.
+
+### Task Lane Model
+
+Each background producer has an owner, queue policy, stale-result policy, and
+UI handoff route.
+
+| Lane | Owner | Work | Queue policy | UI mutation rule |
+| --- | --- | --- | --- | --- |
+| launch/bootstrap | shell | create app shell and register bridges | no background work during visible bootstrap | UI thread only |
+| fixture list | fixture queue | load and filter fixture records | replace stale refreshes | model mutation through UI handoff |
+| preview payload | preview pane | load artifact/source payloads and prepare render input | one selected-fixture request; newer selection stales older work | result handoff only; no renderer mutation |
+| preview display command | preview pane | apply display toggles and camera/render options | coalesce to latest command set | renderer mutation on UI/render thread |
+| notes | notes panel | save selected fixture notes | serialized durable writes | selected fixture state handoff only |
+| promotion | review action panel | approve/decline and artifact move/write | serialized; never silently discard durable result | visible status handoff and diagnostic route |
+
+Workers must not mutate QML state, Qt models, widgets, `QtInteractor`,
+PyVista/VTK renderer objects, or live scene objects.
+
+### Preview Lifecycle
+
+The preview widget owns one live renderer for the widget lifetime.
+
+Fixture changes replace scene content inside that renderer. Cancellation, stale
+completion, payload failure, or non-renderable fixture selection must not
+destroy and recreate the renderer as a side effect.
+
+Preview behavior follows these rules:
+
+- renderable artifact fixtures enter the render path;
+- diagnostic or non-renderable fixtures enter a contextual message path;
+- stale success cannot overwrite a newer selected fixture;
+- stale failure cannot clear a newer good preview;
+- same-fixture failure after a successful render preserves the last good
+  render and marks the preview state stale or diagnostic;
+- display-control commands affect only the current preview surface through the
+  UI/render-thread command route.
+
+### Kit Adoption Boundary
+
+Shared-kit adoption is permitted only when all of the following are true:
+
+- the kit module is importable from the `.venv` used by
+  `impression-reference-review`;
+- the imported API is already compatible or has a narrow adapter;
+- focused tests cover the app route that consumes the helper;
+- replacing the local copy does not require importing `impression_gui`;
+- failure to import the kit cannot create a launch-time beachball.
+
+If those conditions are not true, keep the review-local module during the
+stabilization PR and record the migration as full-kit follow-up work.
+
+## Data Flow
+
+```text
+entrypoint
+-> shell bootstrap
+-> event loop alive
+-> fixture list refresh request
+-> fixture list completion handoff
+-> selected fixture changed
+-> preview payload request
+-> stale check
+-> UI-thread preview command
+-> renderer scene replacement or non-renderable message
+```
+
+Notes and status use a separate write flow:
+
+```text
+selected fixture
+-> notes/status edit
+-> serialized durable write lane
+-> completion handoff
+-> selected fixture stale check
+-> visible status/diagnostic update
+```
+
+Approve uses an artifact promotion flow:
+
+```text
+approve action
+-> promotion validation
+-> serialized artifact move/write
+-> fixture record status write
+-> completion handoff
+-> fixture list/status refresh
+```
+
+## Failure And Diagnostic Routing
+
+Failures must stay near the route that produced them:
+
+- launch/import failures surface as entrypoint or shell diagnostics;
+- fixture load failures surface in the fixture list/context region;
+- preview payload failures surface in the preview pane;
+- non-renderable fixtures surface as intentional context states, not preview
+  crashes;
+- notes write failures surface in the notes/status area;
+- promotion failures surface near approve/decline controls and preserve the
+  previous durable state.
+
+The UI must not silently turn failures into a blank preview or empty fixture
+state unless the empty state is the correct domain result and a diagnostic
+remains available.
+
+## Application Integration Contract
+
+- App type: mixed GUI and console entrypoint
+- User/caller surface: `impression-reference-review` and the Reference Review
+  desktop app window
+- Invocation route: console command starts the Qt shell; fixture selection,
+  preview controls, notes edits, approve, decline, and show-approved filtering
+  drive the live GUI route
+- Wiring owner/module: `src/impression/devtools/reference_review/ui/shell.py`,
+  `src/impression/devtools/reference_review/ui/preview_widget.py`,
+  `src/impression/devtools/reference_review/preview_payload_builder.py`, and
+  the existing reference review lifecycle modules
+- Observable result: the app launches responsively, selected renderable
+  fixtures preview correctly, non-renderable fixtures show context instead of
+  crashing, notes persist, and review status actions persist
+- Integration validation: focused shell and payload tests, notes/status tests,
+  display-control routing tests, `git diff --check`, and a manual smoke through
+  the `.venv` console entrypoint with real fixture data
+
+## Conformance Checklist
+
+- [ ] The `.venv` entrypoint launches the app without immediate crash, hang, or
+  beachball.
+- [ ] Launch performs no expensive fixture import, model build, tessellation,
+  renderer scene build, or durable write on the UI thread.
+- [ ] Kit imports used by Reference Review are importable from the `.venv` or
+  are deferred out of the stabilization PR.
+- [ ] Reference Review imports no modules from `impression_gui`.
+- [ ] Fixture selection routes preview payload work off the UI thread.
+- [ ] Preview renderer lifetime is owned by the preview widget and remains
+  stable across fixture selection, stale completion, and display-control
+  commands.
+- [ ] Non-renderable fixtures produce contextual visible state rather than
+  blank preview or renderer failure.
+- [ ] Notes and review status actions persist through durable write routes.
+- [ ] Focused tests and real-entrypoint smoke support the merge.
+- [ ] The stabilized branch is pushed, opened as a PR, and merged before the
+  full kit migration begins.
+
+## Non-Goals
+
+- Full `impression-workbench-kit` migration.
+- Copying the Impression Bench UI into Reference Review.
+- Adding Bench workspace file browsing, code editing, chat, snapshots, prompt
+  injection, or proposal workflows.
+- Reworking CSG, fixture generation, or reference-test expansion.
+- Replacing the Reference Review promotion and notes lifecycle.
+
+## Canonical Document Impact
+
+On closure, reconcile the canonical architecture documents so they describe
+the conformed stabilization state:
+
+- `reference-review-workbench-architecture.md` should name the stabilized app
+  boundaries and the deferred full-kit migration.
+- `reference-review-async-concurrency.md` should reflect the actual launch,
+  task-lane, and stale-result routes.
+- `reference-review-preview-payload-boundary-architecture.md` should reflect
+  the conformed payload and non-renderable fixture paths.
+- `reference-review-qt-workbench-ui.md` should reflect launch, status, notes,
+  preview, and filter behavior that is user-accessible through the app.
+- `agentic-gui-shared-workbench-code-architecture.md` should remain the broader
+  shared-code direction and should not be treated as fully implemented by this
+  stabilization pass.
+
+## Specification Sources
+
+### Candidate Spec: Launch Baseline And Import Boundary Stabilization
+
+Discovery purpose:
+- Establish the real launch failure mode and make the `.venv` entrypoint's
+  import boundary deterministic.
+
+Responsibilities:
+- confirm branch and fixture command;
+- classify the crash/hang root category;
+- verify kit importability from the app `.venv`;
+- prevent `impression_gui` imports from the review app;
+- preserve or adapt local helper imports when kit import risk is too high.
+
+Integration validation:
+- offscreen or shell-level bootstrap test where possible;
+- manual launch smoke through `impression-reference-review`.
+
+### Candidate Spec: Non-Blocking Shell Bootstrap And Task Handoff
+
+Discovery purpose:
+- Ensure launch creates only the shell and deferred lanes, with no UI-thread
+  blocking work.
+
+Responsibilities:
+- defer fixture scans, source imports, model builds, tessellation, preview
+  payload work, and durable writes until after event-loop startup;
+- ensure worker completions cross into UI through typed handoff;
+- reject stale completions before UI mutation.
+
+Integration validation:
+- focused shell test proving bootstrap does not select/build a fixture;
+- manual launch remains responsive before and after first fixture selection.
+
+### Candidate Spec: Preview Lifecycle And Non-Renderable Fixture Handling
+
+Discovery purpose:
+- Stabilize the preview route without changing the review workflow or full
+  renderer architecture.
+
+Responsibilities:
+- preserve one preview renderer per widget lifetime;
+- ensure payload work is off-thread and renderer mutation is UI/render-thread
+  only;
+- route renderable artifacts to preview;
+- route diagnostic/non-renderable fixtures to contextual message state;
+- preserve last-good preview on stale or failed completions.
+
+Integration validation:
+- focused preview payload and shell routing tests;
+- manual selection smoke across renderable and diagnostic fixtures.
+
+### Candidate Spec: Review Workflow Persistence Smoke
+
+Discovery purpose:
+- Confirm the stabilization did not regress the review app's core purpose.
+
+Responsibilities:
+- notes load and save for the selected fixture;
+- approve persists status and moves dirty artifacts to gold;
+- decline persists status without moving artifacts;
+- show-approved filtering reflects current fixture status;
+- status badge reflects approved, declined, and unreviewed.
+
+Integration validation:
+- focused fixture-record tests;
+- manual smoke against the active fixture file.
+
+### Candidate Spec: Stabilization Merge Gate
+
+Discovery purpose:
+- Define the proof required before merging the stabilization branch.
+
+Responsibilities:
+- run focused tests for preview payload, UI shell routing, notes/status, and
+  display-control command routing;
+- run `git diff --check`;
+- run a real-entrypoint manual smoke;
+- commit, push, open PR, and merge only after the stabilization definition is
+  satisfied.
+
+Integration validation:
+- PR checklist and merge evidence.
+
+## Closure Criteria
+
+This ACD can close only after:
+
+- the stabilized app conforms to the target architecture above;
+- the stabilization plan checklist is complete or superseded by a stricter
+  validated route;
+- the stabilization PR has merged;
+- canonical architecture documents have been reconciled to the implemented
+  state;
+- remaining full-kit migration work is represented in a separate plan or ACD.
+
+## Change History
+
+- 2026-07-17: Initial ACD created to support the short hybrid stabilization
+  path for the launch-crashing Reference Review app.

--- a/project/release-0.1.0a/architecture/reference-review-impression-bench-gui-delta-review.md
+++ b/project/release-0.1.0a/architecture/reference-review-impression-bench-gui-delta-review.md
@@ -1,0 +1,288 @@
+# Reference Review And Impression Bench GUI Delta Review
+
+Status: review document
+Created: 2026-07-16
+Scope: current Reference Review workbench in this repository, sibling `impression-gui`, and sibling `impression-workbench-kit`.
+
+## Purpose
+
+This document reviews the significant differences between the current Reference Review app and the newer Impression Bench GUI project. The two apps still share visible ancestry, but their UI goals, async model, design documentation, and management code have diverged.
+
+The goal is not to make the UIs identical. Reference Review remains a fixture and artifact review tool. Impression Bench is a file-centered modeling workbench. The useful work is to identify reusable infrastructure, decide what should move to or expand in `impression-workbench-kit`, and name which newer Bench refinements should be ported back into Reference Review.
+
+## Reviewed Inputs
+
+- Reference Review code:
+  - `src/impression/devtools/reference_review/ui/shell.py`
+  - `src/impression/devtools/reference_review/ui/preview_widget.py`
+  - `src/impression/devtools/reference_review/preview_payload*.py`
+  - `src/impression/devtools/reference_review/async_core/*.py`
+  - `src/impression/devtools/reference_review/ui/{preview_controls,packaging,markdown_context,style}.py`
+- Reference Review architecture:
+  - `project/release-0.1.0a/architecture/reference-review-workbench-architecture.md`
+  - `project/release-0.1.0a/architecture/reference-review-async-concurrency.md`
+  - `project/release-0.1.0a/architecture/agentic-gui-shared-workbench-code-architecture.md`
+- Impression Bench code:
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/ui/shell.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/document_state.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/document_dependencies.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/workspace_files.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/preview_payload*.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/agent_*.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/codex_sidecar.py`
+  - `/Users/k/Documents/Projects/impression-gui/src/impression_gui/prompt_injectors.py`
+- Impression Bench docs:
+  - `/Users/k/Documents/Projects/impression-gui/project/product/impression-bench.md`
+  - `/Users/k/Documents/Projects/impression-gui/project/design/impression-workbench-design-guide.md`
+  - `/Users/k/Documents/Projects/impression-gui/project/architecture/*.md`
+  - `/Users/k/Documents/Projects/impression-gui/project/specifications/**/*.md`
+- Shared kit:
+  - `/Users/k/Documents/Projects/impression-workbench-kit/src/impression_workbench/async_core/*.py`
+  - `/Users/k/Documents/Projects/impression-workbench-kit/src/impression_workbench/ui/*.py`
+
+## Executive Findings
+
+1. Impression Bench has a much more mature app architecture surface than Reference Review: product intent, design guide, architecture children, ACDs, and a large one-IWU spec tree.
+2. The shared-kit direction exists and is active. `impression-workbench-kit` already owns generic async records, diagnostics, owner routing, lane policy, durable writes, callback handoff, preview controls, style records, markdown context rendering, QML packaging, and a small file browser.
+3. Reference Review still carries local copies of helpers that now exist in the kit, especially async sanitization/staleness/durable writes, preview controls, packaging, markdown context rendering, and style tokens.
+4. Bench has a stronger async architecture than Reference Review: explicit task envelopes, route registration, task lanes, dependency parse lanes, active-document preview routing, source-revision identities, stale completion records, last-good preview preservation, telemetry, and shutdown cleanup.
+5. The UI differences are intentional. Bench should not be copied wholesale into Reference Review. The valuable ports are the management patterns and shared primitives, not the file-browser/code-editor/chat product shape.
+6. Reference Review can benefit immediately by depending on the shared kit for neutral helpers and by adopting selected Bench async and diagnostics patterns around preview, notes, promotion, and durable writes.
+
+## Intentional UI Differences
+
+| Area | Reference Review | Impression Bench | Port guidance |
+| --- | --- | --- | --- |
+| Primary object | Fixture record and artifact review state | Workspace root, active code document, renderable document | Keep app-specific. Do not replace fixture queue with file browser. |
+| Main navigation | Queue/list of fixtures with approve/decline state | File browser, open document tabs, preview/code panels | Keep app-specific. Reuse only file/list primitives if generalized. |
+| Preview target | Selected fixture artifact or fixture source | Active renderable document or affected renderable dependency | Share preview surface and display controls; keep request source app-specific. |
+| Context panel | Purpose, methodology, expected render, artifacts, notes | Chat, diagnostics, snapshots, editor, proposal/change review | Keep app-specific panels. Share markdown/diagnostic primitives. |
+| Approval workflow | Approve/decline/unreviewed, dirty to gold artifact promotion | Agent proposal accept/reject/revise/apply/save | Do not merge workflows. Share durable write and authority/diagnostic patterns where neutral. |
+| Editor | None, except notes text field | `qtmonaco` planned/adapter-backed code editor with open tabs and dirty buffers | Do not port editor into Reference Review unless review sources become editable. |
+| Chat/agent | Earlier sidecar concepts mostly domain-bound | Codex chat bridge, prompt injectors, agent context, proposal records, direct edit authority | Port only if Reference Review reopens Codex-assisted fixture regeneration. |
+
+## Documentation Differences
+
+Reference Review has strong release architecture for fixture review, preview payload boundaries, and async concurrency. Its UI documentation is mostly tied to the review workflow and the preview remediation history.
+
+Impression Bench has a more current and complete product-definition stack:
+
+- Product document: records the app as a modeling workbench, not a review queue.
+- Design guide: defines calm dense workbench styling, empty-state behavior, diagnostics placement, preview/editor/chat surfaces, and UI QA checklist.
+- Architecture set: splits shell/layout, workspace file model, preview/execution, threading/concurrency, code editor, sidecar lifecycle, chat preview context, snapshots, and prompt injectors.
+- ACDs: capture design-system conformance, tabbed-panel command routing, and agent diagnostics/direct edit reporting.
+- Specifications: many active one-IWU leaves for threading, preview, workspace files, prompt injectors, editor, panel commands, and agent lifecycle.
+
+The design guide is especially valuable for Reference Review. Even when the UI remains different, the guide's state placement rules apply well: routine absence should be quiet or action-oriented; blocking diagnostics should appear near the action; preview stale/failure status belongs in the preview header; input surfaces need output surfaces.
+
+## Async And Threading Differences
+
+### Reference Review Current Shape
+
+Reference Review already has a useful async core:
+
+- `ReviewWorkbenchMessage` and `WorkerResultEnvelope`.
+- `TaskDispatcher` with `WorkerPolicy`, pending limits, and coalescing.
+- `LatestRequestTracker` for stale completion decisions.
+- `UICompletionBridge` and sanitized diagnostics.
+- `DurableWriteLane` for serialized writes.
+- `PreviewPayloadProcessController` for fixture preview builds, stale payload rejection, and temporary payload cleanup.
+- UI-thread render command queue for preview surface mutation.
+
+This is good enough for a single selected fixture workflow. The weak point is that several helpers are app-local copies and the shell still owns many route-specific policies directly.
+
+### Impression Bench Current Shape
+
+Bench extends the copied model into a workbench-scale async topology:
+
+- Generic `WorkbenchTaskRequest` and `WorkbenchTaskCompletion` live in the shared kit.
+- `WorkbenchDiagnostic`, `WorkbenchLanePolicy`, `WorkbenchQueueState`, `OwnerRouteRegistry`, and `WorkerCallbackHandoffAdapter` live in the shared kit.
+- `DirtyDependencyParseLane` runs dependency parsing off the UI thread and routes stale completions.
+- `ActiveDocumentPreviewRouter` maps active documents or support files to renderable subjects.
+- `DependencyAwarePreviewRefresher` marks affected renderable subjects stale and debounces refresh.
+- `PreviewBuildRequestIdentity` includes owner, request id, subject path, entrypoint, kind, and source revision.
+- `BenchPreviewAsyncController` rejects stale preview task completions before UI mutation.
+- Preview payload cleanup can mark active payload ownership and delete stale payloads.
+- The shell uses timers for preview async polling and dependency refresh debounce.
+- `OwnerRouteRegistry` gives completion routing an explicit owner/kind registry instead of broad shape-based dispatch.
+- `WorkbenchTelemetryLane` records queue health and task duration events.
+
+### Async Patterns Worth Porting
+
+| Pattern | Bench implementation | Reference Review value |
+| --- | --- | --- |
+| Generic task records | shared kit `WorkbenchTaskRequest` / `WorkbenchTaskCompletion` | Allows review tasks to use neutral routing and diagnostics instead of review-specific copies. |
+| Owner route registry | shared kit `OwnerRouteRegistry` | Reduces ad hoc completion routing as notes, promotion, preview, and future Codex tasks grow. |
+| Lane policy records | shared kit `WorkbenchLanePolicy` / `WorkbenchQueueState` | Makes queue/backpressure state inspectable and testable. |
+| Workbench diagnostics | shared kit `WorkbenchDiagnostic` | Gives preview, notes, promotion, and fixture load failures one display contract. |
+| Source-revision identity | Bench `PreviewBuildRequestIdentity` | Useful for fixture/source preview if record generation alone is not enough, especially when source files or artifacts change. |
+| Last-good preview preservation | Bench preview flow | Already partially ported; should become a formal Reference Review invariant. |
+| Dependency parse lane | Bench `DirtyDependencyParseLane` | Not directly needed unless Reference Review starts editable source or generated modules. |
+| Telemetry lane | Bench `WorkbenchTelemetryLane` | Useful after queue health and preview timing become visible review concerns. |
+
+## Existing Shared Kit Surface
+
+The shared kit is currently narrow but real.
+
+### Async Core
+
+| Kit module | Responsibility | Reference Review adoption status |
+| --- | --- | --- |
+| `diagnostics.py` | severity and diagnostic record creation | Not adopted; review has local diagnostics. |
+| `task_records.py` | generic request/completion records | Not adopted; review still uses `ReviewWorkbenchMessage`. |
+| `lane_policy.py` | lane policy and queue-state snapshots | Not adopted; review uses `WorkerPolicy`. |
+| `owner_routes.py` | typed owner/kind completion routing | Not adopted. |
+| `callback_handoff.py` | worker callback handoff result adapter | Not adopted. |
+| `durable_writes.py` | serialized write lane | Review has local copy; should import from kit. |
+| `qt_handoff.py` | sanitizer and UI completion bridge | Review has local copy; should import from kit. |
+| `staleness.py` | latest-request tracker and cancellation | Review has local copy; should import from kit. |
+
+### UI Core
+
+| Kit module | Responsibility | Reference Review adoption status |
+| --- | --- | --- |
+| `preview_controls.py` | preview display options, icon toggles, grouped buttons | Review has local copy; should import from kit. |
+| `packaging.py` | QML resource layout and preview icon registry | Review has local copy; should import from kit after packaging dependency is solved. |
+| `markdown_context.py` | markdown rendering and blocked-link diagnostics by neutral `context_id` | Review has local fixture-specific copy; should import from kit and pass `context_id=fixture_id`. |
+| `style.py` | style token records and component contracts | Review has local copy; should either import kit records or define app-specific token values on top. |
+| `file_browser.py` | small workspace file browser widget | Bench-specific today; not useful to Reference Review unless generalized into a neutral tree/list primitive. |
+
+## Significant Bench Management Code Not In Reference Review
+
+These are mature enough to study, but not all should be ported.
+
+| Bench module | What it adds | Port decision |
+| --- | --- | --- |
+| `document_state.py` | open documents, dirty buffer state, source snapshots, save/close results | Keep Bench-specific unless review sources become editable. |
+| `document_dependencies.py` | dependency graph, parse lane, stale markers, workspace snapshot materialization | Keep Bench-specific for now; possible future shared library if Reference Review adds editable/generated source dependencies. |
+| `workspace_files.py` | workspace root records, file records, renderability detection | Mostly Bench-specific. Renderability detection may become shared after another consumer. |
+| `preview_payload.py` | source snapshot identities and Bench preview request records before legacy payload records | Keep Bench-specific until Reference Review needs source snapshots. |
+| `preview_payload_controller.py` | active document routing, dependency-aware refresh, Bench async controller, source-revision identity | Partially portable: identity/stale/payload cleanup patterns are broadly useful. |
+| `preview_snapshots.py` | named preview snapshot registry and name generator | Useful if Reference Review adds comparison snapshots or Codex attachments. |
+| `telemetry.py` | queue health and task duration events | Useful future port; not first priority. |
+| `agent_context.py` | active document, previewed renderable, dirty/dependency context payloads | Bench-specific. Review would need a fixture-context equivalent rather than direct port. |
+| `agent_proposals.py` | proposal records, authority gates, conflict detection, buffer application | Bench-specific, but authority/diagnostic gates may inform future review-side Codex edits. |
+| `prompt_injectors.py` | capability-aware prompt injector registry and diagnostics | Valuable conceptually; not a direct Reference Review port yet. |
+| `codex_sidecar.py` | Codex CLI bridge, task lifecycle, tool policy broker, candidate model store | Review has older sidecar concepts; port only after Reference Review's Codex workflow is redefined. |
+
+## Port And Extraction Recommendations
+
+### Priority 1: Replace Local Copies With Kit Imports
+
+These are the lowest-risk cleanup items because Bench already uses the kit and Reference Review still has local copies:
+
+- `async_core/qt_handoff.py` -> `impression_workbench.async_core.qt_handoff`
+- `async_core/staleness.py` -> `impression_workbench.async_core.staleness`
+- `async_core/durable_writes.py` -> `impression_workbench.async_core.durable_writes`
+- `ui/preview_controls.py` -> `impression_workbench.ui.preview_controls`
+- `ui/packaging.py` preview display icon registry and QML resource checks -> `impression_workbench.ui.packaging`
+- `ui/markdown_context.py` -> `impression_workbench.ui.markdown_context`
+- shared style record classes -> `impression_workbench.ui.style`
+
+This should be done before additional app behavior is ported, otherwise the fork keeps widening.
+
+### Priority 2: Adopt Shared Diagnostics And Route Records
+
+Reference Review should add or adapt to:
+
+- `WorkbenchDiagnostic` for user-facing operation diagnostics.
+- `WorkbenchLanePolicy` and `WorkbenchQueueState` for inspectable queue/backpressure state.
+- `OwnerRouteRegistry` for routing preview, notes, promotion, and future sidecar completions.
+- `WorkbenchTaskRequest` / `WorkbenchTaskCompletion` adapters around existing `ReviewWorkbenchMessage` and `WorkerResultEnvelope`.
+
+This can be staged through adapters so existing tests do not require a full async rewrite.
+
+### Priority 3: Formalize Preview State And Last-Good Render Behavior
+
+Bench's preview model has better language for current/stale/failure. Reference Review should document and test:
+
+- stale success cannot replace current preview;
+- stale failure cannot clear a newer good preview;
+- same-fixture failure after a good render preserves the last good render and marks it stale;
+- preview payload cleanup never deletes the active payload;
+- display-control commands mutate only the UI-thread render surface;
+- renderable artifact fixtures render artifact payloads, while diagnostic fixtures remain non-renderable context rows.
+
+Some of this behavior has been implemented recently, but it should become canonical architecture and regression coverage, not just a patch.
+
+### Priority 4: Port Design-System And Diagnostics Placement Rules
+
+Reference Review should adopt the design guide principles without copying the Bench layout:
+
+- preview stale/current/failure status belongs near the preview, not buried in a generic status line;
+- routine absence should be quiet or action-oriented;
+- diagnostic/evidence fixtures should clearly say they are non-renderable;
+- disabled controls should explain why or remain hidden until useful;
+- approve/decline and notes state should have compact, visible feedback;
+- design tokens should be centralized instead of scattered stylesheets.
+
+### Priority 5: Defer Bench-Specific Workflows
+
+Do not port these until Reference Review has a product requirement for them:
+
+- file browser and workspace-root selection;
+- open document tabs and `qtmonaco`;
+- dirty buffer source snapshots;
+- dependency parse lanes;
+- prompt injector registry;
+- named preview snapshots;
+- agent proposal application and direct edits;
+- Codex chat bridge changes.
+
+They are valuable patterns, but direct porting would blur Reference Review's purpose.
+
+## Shared Library Expansion Plan
+
+### Current Package Boundary
+
+`impression-workbench-kit` should remain a neutral application workbench kit. It should not import `impression.devtools.reference_review`, and it should not become the owner of fixture review, file editing, or Codex product workflows.
+
+### Proposed Package Areas
+
+| Package area | Move or expand | Notes |
+| --- | --- | --- |
+| `impression_workbench.async_core` | Expand | Add adapters for review envelopes, route registration helpers, lane telemetry hooks, and integration examples. |
+| `impression_workbench.ui` | Expand | Keep preview controls, style tokens, markdown rendering, QML packaging, and add neutral status/diagnostic widgets. |
+| `impression_workbench.preview` | Consider new package | Candidate home for render command records/queues, preview stale state records, and capture metadata if both apps use them. Avoid importing app payload builders. |
+| `impression_workbench.diagnostics` | Consider subpackage if diagnostics grow | Could own diagnostic placement/view-model helpers shared by Bench and Review. |
+| `impression_workbench.files` | Defer | File browser and workspace records are currently Bench-shaped. Extract only if another app needs a neutral file browser. |
+| `impression_workbench.agent` | Defer | Agent lifecycle and prompt injectors are still product-specific. Extract only stable contracts, not workflows. |
+
+### Extraction Rules
+
+- Extract protocols and records before controllers.
+- Keep app-specific nouns out of the kit: no fixture ids, dirty/gold status, active code tab assumptions, or proposal-specific labels.
+- Prefer adapter modules in consuming apps while migrating.
+- Shared code must have tests in the kit and at least one consuming-app integration smoke.
+- Reference Review should not import from `impression_gui`; both apps should import from `impression_workbench`.
+- Impression core should continue to own model/preview semantics such as `PreviewSceneController`, `QtPreviewSurface`, `.impress` IO, and tessellation.
+
+## Recommended Implementation Sequence
+
+1. Add `impression-workbench-kit` as a development dependency for the Reference Review UI environment.
+2. Replace Reference Review local imports for sanitizer, staleness, durable writes, preview controls, markdown context, packaging, and style records with kit imports.
+3. Delete or deprecate the app-local duplicate modules only after tests pass through the product entrypoint.
+4. Add adapter tests proving Review messages can become `WorkbenchTaskRequest` / `WorkbenchTaskCompletion`.
+5. Introduce `OwnerRouteRegistry` for one narrow route, likely preview completion, then expand to notes and promotion.
+6. Convert queue/backpressure state to `WorkbenchLanePolicy` / `WorkbenchQueueState` while preserving existing `TaskDispatcher` behavior.
+7. Formalize preview stale/current/failure state as shared records or a small `impression_workbench.preview` package.
+8. Update Reference Review architecture/specs after each extraction so they describe imported shared ownership instead of local copies.
+
+## Risks And Cautions
+
+- The current branch has active Reference Review renderer changes. Shared-kit extraction should be done as a separate branch or separate commit series to avoid mixing renderer bug fixes with architecture cleanup.
+- Bench code is not automatically better because it is newer. Some modules are product-shaped around active documents and should not be generalized prematurely.
+- Reference Review's fixture status/promotion lifecycle is durable and should not be rewritten around Bench proposals or editor buffers.
+- Any change touching preview or Qt lifecycle must preserve the rule that renderer creation, scene mutation, camera interaction, and disposal stay on the UI thread.
+- Shared package adoption introduces packaging/dependency work. The review app entrypoint must still launch from the Impression `.venv`.
+
+## Bottom Line
+
+The best next step is not to copy the Bench UI into Reference Review. The best next step is to make Reference Review consume the existing shared kit for neutral infrastructure, then selectively port Bench's stronger async and preview-state patterns.
+
+The most valuable immediate work is:
+
+1. converge duplicate helper modules into `impression-workbench-kit`;
+2. adopt shared diagnostics/task/lane records through adapters;
+3. codify last-good preview and stale-failure behavior;
+4. bring over the design guide's state-placement rules without changing the review workflow.

--- a/project/release-0.1.0a/planning/README.md
+++ b/project/release-0.1.0a/planning/README.md
@@ -15,6 +15,7 @@ Inference and curve-fitting planning lives under:
 Reference Review Workbench planning lives under:
 
 - [`reference-review-workbench-progression.md`](reference-review-workbench-progression.md)
+- [`reference-review-hybrid-stabilization-plan.md`](reference-review-hybrid-stabilization-plan.md)
 
 Reference test expansion planning lives under:
 

--- a/project/release-0.1.0a/planning/reference-review-hybrid-stabilization-plan.md
+++ b/project/release-0.1.0a/planning/reference-review-hybrid-stabilization-plan.md
@@ -1,0 +1,223 @@
+# Reference Review Hybrid Stabilization Plan
+
+Status: active stabilization plan
+Created: 2026-07-17
+Branch context: `codex/reference-review-diagnostic-render-state`
+
+## Purpose
+
+The Reference Review app is in an in-between state and currently crashes or
+hangs on launch. This plan defines a short, bounded march to stabilize the live
+review app while moving only the safest pieces toward `impression-workbench-kit`.
+
+This is not the full Workbench Kit migration. The goal is to get the current
+app responsive, rendering, and review-capable again, then push, open a pull
+request, and merge into the release working branch. The full kit migration gets
+planned after that stable checkpoint.
+
+## Related Documents
+
+- [Reference Review And Impression Bench GUI Delta Review](../architecture/reference-review-impression-bench-gui-delta-review.md)
+- [Agentic GUI Shared Workbench Code Architecture](../architecture/agentic-gui-shared-workbench-code-architecture.md)
+- [Reference Review Async Concurrency](../architecture/reference-review-async-concurrency.md)
+- [Reference Review Preview Remediation Plan](../architecture/reference-review-preview-remediation-plan.md)
+- [Reference Review Preview Payload Boundary Architecture](../architecture/reference-review-preview-payload-boundary-architecture.md)
+- [Reference Review Workbench Progression](reference-review-workbench-progression.md)
+
+## Stabilization Definition
+
+The app is stable enough to merge when all of these are true:
+
+- `impression-reference-review` launches through the installed `.venv`
+  entrypoint without an immediate crash, hang, or beachball.
+- The fixture list is populated and remains clickable after launch.
+- Selecting a renderable STL or `.impress` fixture shows a live preview.
+- Selecting a diagnostic or non-renderable fixture shows a contextual
+  non-renderable state and does not crash.
+- Preview interaction remains responsive and renderer lifetime stays owned by
+  the UI/render thread.
+- Preview display-control buttons still route to the preview surface.
+- Notes load for the selected fixture and save back to the fixture record.
+- Approve, decline, unreviewed status, status badge, and the show-approved
+  filter still work.
+- Focused tests for preview payloads, shell routing, notes/status behavior, and
+  display controls pass.
+- `git diff --check` is clean.
+- The stabilized branch is pushed, a PR is opened, and the PR is merged into
+  the release working branch.
+
+## Explicit Non-Goals
+
+- Do not port the Impression Bench UI wholesale.
+- Do not add the Bench file browser, code editor, prompt injectors, snapshots,
+  direct-edit proposal workflow, or chat workflow.
+- Do not rewrite the fixture queue, promotion lifecycle, or review state model.
+- Do not perform the full `impression-workbench-kit` migration in this pass.
+- Do not broaden this work into CSG, fixture generation, or reference-test
+  expansion.
+
+## Hybrid Strategy
+
+Use the kit only where it reduces active duplication or current instability.
+Keep review-domain behavior in the review app.
+
+| Area | Stabilization choice |
+| --- | --- |
+| Qt launch and shell ownership | Keep in Reference Review. Fix launch crash at the current app boundary. |
+| Fixture discovery, notes, approve/decline, dirty/gold promotion | Keep in Reference Review. These are product-specific. |
+| Preview payload builder and fixture-to-preview adapter | Keep local for now. Only harden imports, stale handling, and diagnostic fallback. |
+| Preview renderer interaction semantics | Keep aligned with `impression.preview`; do not invent a second renderer paradigm. |
+| Sanitized UI handoff, latest-request tracking, durable write lane | Prefer kit imports if packaging is already reliable; otherwise keep local temporarily and record the follow-up. |
+| Preview display options and icon/control records | Prefer kit imports if they are a direct drop-in; otherwise preserve current local controls for the stabilization PR. |
+| Markdown context rendering and style records | Adopt from kit only if it is low risk and does not affect launch stability. |
+| Owner route registry, lane policy records, generic task records | Defer to full migration unless a narrow adapter is needed to fix the crash safely. |
+
+## Work Plan
+
+### Draft Specification Handoff
+
+These draft specifications were created from the active hybrid stabilization
+ACD and remain unchecked until an independent `review specs` pass verifies
+their split, score, and readiness.
+
+- [ ] [Reference Review Spec 76: Launch Baseline And Import Boundary Stabilization](../specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md)
+- [ ] [Reference Review Spec 76 Test: Launch Baseline And Import Boundary Stabilization](../test-specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md)
+- [x] [Reference Review Spec 76a: Launch Failure Baseline](../specifications/reference-review-76a-launch-failure-baseline-v1_0.md)
+- [x] [Reference Review Spec 76a Test: Launch Failure Baseline](../test-specifications/reference-review-76a-launch-failure-baseline-v1_0.md)
+- [x] [Reference Review Spec 76b: Import Boundary And Kit Availability](../specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md)
+- [x] [Reference Review Spec 76b Test: Import Boundary And Kit Availability](../test-specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md)
+- [ ] [Reference Review Spec 77: Non-Blocking Shell Bootstrap And Task Handoff](../specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md)
+- [ ] [Reference Review Spec 77 Test: Non-Blocking Shell Bootstrap And Task Handoff](../test-specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md)
+- [x] [Reference Review Spec 77a: Non-Blocking Shell Startup](../specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md)
+- [x] [Reference Review Spec 77a Test: Non-Blocking Shell Startup](../test-specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md)
+- [x] [Reference Review Spec 77b: UI Handoff And Stale Completion Guard](../specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md)
+- [x] [Reference Review Spec 77b Test: UI Handoff And Stale Completion Guard](../test-specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md)
+- [ ] [Reference Review Spec 78: Preview Lifecycle And Non-Renderable Fixture Handling](../specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md)
+- [ ] [Reference Review Spec 78 Test: Preview Lifecycle And Non-Renderable Fixture Handling](../test-specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md)
+- [x] [Reference Review Spec 78a: Renderable Preview Lifecycle](../specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md)
+- [x] [Reference Review Spec 78a Test: Renderable Preview Lifecycle](../test-specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md)
+- [x] [Reference Review Spec 78b: Non-Renderable Preview State And Last-Good Guard](../specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md)
+- [x] [Reference Review Spec 78b Test: Non-Renderable Preview State And Last-Good Guard](../test-specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md)
+- [ ] [Reference Review Spec 79: Review Workflow Persistence Smoke](../specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+- [ ] [Reference Review Spec 79 Test: Review Workflow Persistence Smoke](../test-specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+- [x] [Reference Review Spec 79a: Notes Persistence Route](../specifications/reference-review-79a-notes-persistence-route-v1_0.md)
+- [x] [Reference Review Spec 79a Test: Notes Persistence Route](../test-specifications/reference-review-79a-notes-persistence-route-v1_0.md)
+- [x] [Reference Review Spec 79b: Approve/Decline Persistence And Promotion Route](../specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md)
+- [x] [Reference Review Spec 79b Test: Approve/Decline Persistence And Promotion Route](../test-specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md)
+- [x] [Reference Review Spec 79c: Status Badge And Approved Filter Route](../specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md)
+- [x] [Reference Review Spec 79c Test: Status Badge And Approved Filter Route](../test-specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md)
+- [ ] [Reference Review Spec 80: Stabilization Merge Gate](../specifications/reference-review-80-stabilization-merge-gate-v1_0.md)
+- [ ] [Reference Review Spec 80 Test: Stabilization Merge Gate](../test-specifications/reference-review-80-stabilization-merge-gate-v1_0.md)
+
+### 0. Baseline And Branch Hygiene
+
+- [x] Confirm the current branch and uncommitted change set.
+- [x] Record the exact launch command, fixture file, and observed failure mode.
+- [x] Classify the launch failure as one of:
+  - import/dependency failure;
+  - QML/bootstrap failure;
+  - UI-thread blocking/handoff failure;
+  - preview renderer construction failure;
+  - fixture/payload selection failure.
+- [x] Preserve current in-flight work on a named stabilization branch if the
+  active branch name no longer describes the work.
+
+### 1. Dependency And Import Stabilization
+
+- [x] Verify whether `impression-workbench-kit` is importable from the
+  repository `.venv` used by `impression-reference-review`.
+- [x] If kit is not reliably importable, choose one stabilization route:
+  - add the correct local development dependency; or
+  - temporarily keep review-local modules and defer imports to the full
+    migration.
+- [x] Ensure Reference Review never imports from `impression_gui`; both apps
+  must converge through `impression_workbench` or Impression core.
+- [ ] Replace duplicated helper imports with kit imports only when the imported
+  API is already compatible and covered by focused tests.
+
+### 2. Launch And Event-Loop Stability
+
+- [x] Make launch initialization cheap: no renderer build, fixture import,
+  model build, tessellation, filesystem scan, or durable write may block the
+  UI thread.
+- [x] Keep all UI model mutation, QML state updates, renderer mutation, and
+  widget disposal on the UI/render thread.
+- [x] Route worker completions through typed handoff and reject stale successes,
+  stale failures, and stale cancellations before mutating UI state.
+- [x] Add or update a focused launch smoke that proves the app can bootstrap
+  without selecting a fixture.
+
+### 3. Preview Stabilization
+
+- [x] Preserve one live renderer per preview widget and dispose it only when
+  the widget/app closes.
+- [x] Ensure fixture selection builds or loads payloads off the UI thread.
+- [x] Ensure renderable artifact fixtures render from their artifact payload.
+- [x] Ensure diagnostic/non-renderable fixtures show a clear contextual state
+  without entering the render path.
+- [x] Preserve last-good preview behavior: a stale or same-fixture failure must
+  not clear a newer good render.
+- [x] Confirm display-control commands mutate only the preview surface through
+  the UI-thread route.
+
+### 4. Review Workflow Smoke
+
+- [x] Verify notes load for the selected fixture.
+- [x] Verify notes save in real time to the fixture record or database.
+- [x] Verify approve updates fixture status and moves dirty artifacts to gold
+  using the same folder structure.
+- [x] Verify decline updates fixture status without moving the artifact.
+- [x] Verify unreviewed fixtures remain visible.
+- [x] Verify the show-approved checkbox filters only approved fixtures when
+  unchecked and includes them when checked.
+
+### 5. Validation And Merge
+
+- [x] Run focused tests for preview payload builder behavior.
+- [x] Run focused tests for UI shell routing and launch behavior.
+- [x] Run focused tests for notes/status/promotion behavior.
+- [x] Run focused tests for display-control state and command routing.
+- [x] Run `git diff --check`.
+- [x] Manually smoke the real app through the `.venv` console entrypoint.
+- [ ] Commit the stabilization unit.
+- [ ] Push the branch.
+- [ ] Open a PR.
+- [ ] Merge the PR into the release working branch after validation.
+
+## Stop Line
+
+When the stabilization definition is satisfied, stop expanding the scope.
+Any broader kit extraction, Bench management-code port, or shared-library
+redesign discovered during this pass should be written as follow-up work for
+the full Workbench Kit migration plan.
+
+## Follow-Up: Full Workbench Kit Migration Plan
+
+After the stabilized PR is merged, create a separate migration plan that covers:
+
+- replacing remaining duplicated async helpers with kit modules;
+- introducing owner-route and lane-policy records deliberately;
+- moving shared preview state and display-control records into the kit where
+  both apps can consume them;
+- deciding whether shared preview command records belong in a new
+  `impression_workbench.preview` package;
+- bringing over useful Bench design-system and diagnostics placement rules;
+- defining integration smokes for both Reference Review and Impression Bench.
+
+## Change History
+
+- 2026-07-17: Implemented the hybrid stabilization leaves through Spec 79c.
+  Baseline launch command: `.venv/bin/impression-reference-review
+  --fixture-file tests/reference_review_fixtures/dirty-stl-fixtures.json`.
+  The active failure class was fixture/payload selection work starting during
+  shell bootstrap; startup now opens with no selected fixture and no preview
+  controller launch until the user selects a row. Validation commands run:
+  `.venv/bin/python -m pytest tests/test_reference_review_ui_shell.py
+  tests/test_reference_review_preview_payload_builder.py -q`,
+  `.venv/bin/impression-reference-review --fixture-file
+  tests/reference_review_fixtures/dirty-stl-fixtures.json --check`,
+  `.venv/bin/impression-reference-review --fixture-file
+  tests/reference_review_fixtures/dirty-stl-fixtures.json --check --offscreen`,
+  timed real-platform Qt smoke with fixture selection, and `git diff --check`.
+- 2026-07-17: Initial hybrid stabilization plan created after the review app
+  entered an in-between launch-crashing state.

--- a/project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-001707.md
+++ b/project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-001707.md
@@ -1,0 +1,57 @@
+# Reference Review Hybrid Stabilization Spec Review Ledger
+
+## Review Pass 1
+
+- Request ledger path: `project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-001707.md`
+- Exact active specs re-read for this pass:
+  - `project/release-0.1.0a/specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md`
+- New leaf specs created by this review round:
+  - `project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md`
+- Parent specs that remain active only because split coverage is incomplete:
+  - none
+- Fixed-point status: continue
+- Next active spec set to review after ledger readback:
+  - `project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md`
+
+## Review Pass 2
+
+- Request ledger path: `project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-001707.md`
+- Exact active specs re-read for this pass:
+  - `project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md`
+- New leaf specs created by this review round:
+  - none
+- Parent specs that remain active only because split coverage is incomplete:
+  - none
+- Fixed-point status: reached
+- Next active spec set to review after ledger readback:
+  - none

--- a/project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-002626.md
+++ b/project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-002626.md
@@ -1,0 +1,23 @@
+# Reference Review Hybrid Stabilization Spec Review Ledger
+
+## Review Pass 1
+
+- Request ledger path: `project/release-0.1.0a/spec-refinement-history/reference-review-hybrid-stabilization-20260717-002626.md`
+- Exact active specs re-read for this pass:
+  - `project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md`
+  - `project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md`
+- New leaf specs created by this review round:
+  - none
+- Parent specs that remain active only because split coverage is incomplete:
+  - none
+- Fixed-point status: reached
+- Next active spec set to review after ledger readback:
+  - none

--- a/project/release-0.1.0a/specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md
@@ -1,0 +1,217 @@
+# Reference Review Spec 76: Launch Baseline And Import Boundary Stabilization (v1.0)
+
+Status: Split parent - superseded by child specs 76a and 76b
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own
+verification surface.
+Draft count: 1 IWU.
+Basis: one launch-baseline and import-boundary stabilization leaf. This count
+is a draft creation estimate and must be verified by `review specs`.
+
+## Overview
+
+Establish the Reference Review app's real launch failure mode and make the
+`.venv` entrypoint import boundary deterministic before deeper stabilization
+work proceeds.
+
+## Backlink
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+- [Reference Review Hybrid Stabilization Plan](../planning/reference-review-hybrid-stabilization-plan.md)
+
+## Source Manifest
+
+- Source candidate: `Launch Baseline And Import Boundary Stabilization`
+- Source artifact: `project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md`
+
+## Scope
+
+This specification covers:
+
+- launch command and fixture-file baseline capture
+- crash/hang classification
+- `.venv` importability for `impression_workbench`
+- guard against `impression_gui` imports from Reference Review
+- narrow keep-local vs import-from-kit decision for currently duplicated
+  helpers
+
+## Responsibilities
+
+- Functions/methods:
+  - entrypoint launch probe or shell bootstrap probe
+  - import-boundary probe
+  - optional import guard test
+- Data structures/models:
+  - launch baseline record or diagnostic text used by tests
+- Dependencies/services:
+  - `.venv` console entrypoint
+  - `impression_workbench` package when available
+  - Reference Review UI package imports
+- Returns/outputs/signals:
+  - deterministic pass/fail launch baseline result
+  - deterministic pass/fail import-boundary result
+- UI surfaces/components:
+  - Reference Review shell startup route
+- UI fields/elements:
+  - none
+- Reusable code plan:
+  - Existing code reused as-is:
+    - Reference Review console entrypoint
+    - current shell bootstrap code
+  - Additions to existing reusable library/module:
+    - none unless a narrow import probe helper is already present
+  - New reusable library/module to create:
+    - none expected
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - launch baseline must not start background work as part of the import probe
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - diagnostics must not expose unrelated local paths beyond the failing module
+    or expected workspace paths
+- Performance-sensitive behavior:
+  - launch/import probes must fail quickly and avoid model build/tessellation
+- Cross-screen reusable behavior:
+  - import boundary protects the full review app
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+- `src/impression/devtools/reference_review/ui/__init__.py`
+- existing entrypoint configuration for `impression-reference-review`
+- focused test modules under `tests/`
+
+Routes:
+
+- console route: `.venv/bin/impression-reference-review`
+- import route: importing Reference Review UI modules in a clean process
+
+Reuse/extraction decision:
+
+- Import from `impression_workbench` only when the package is available through
+  the same `.venv` route used by the app.
+- Do not import from `impression_gui`.
+- If a kit helper is not reliably importable, keep the local Reference Review
+  helper for this stabilization pass and leave the full-kit migration as
+  follow-up work.
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- baseline fixture file defaults to the current real Reference Review fixture
+  file used for manual smoke, not demo-only data
+- import probes run without selecting or rendering a fixture
+
+Data ownership:
+
+- launch diagnostic ownership stays with the shell/entrypoint route
+- kit availability is a packaging/import concern, not a fixture concern
+
+Open questions and resolved assumptions:
+
+- resolved: Reference Review must not depend on `impression_gui`
+- open for implementation: whether `impression_workbench` is already installed
+  into the active `.venv`
+
+Implementation prerequisites:
+
+- existing Reference Review entrypoint
+- existing ACD and stabilization plan
+
+## Behavior
+
+The implementation must:
+
+- record or encode the real launch command used for stabilization;
+- classify the current failure as import/dependency, QML/bootstrap,
+  UI-thread blocking/handoff, preview renderer construction, or
+  fixture/payload selection failure;
+- verify `impression_workbench` importability from the app `.venv` before
+  replacing local helpers with kit imports;
+- prevent Reference Review from importing `impression_gui`;
+- avoid fixture source import, model build, tessellation, or renderer scene
+  construction during import-boundary tests.
+
+## Verification
+
+Test strategy:
+
+- focused import-boundary test for Reference Review UI modules;
+- focused check that `impression_gui` is not imported by Reference Review;
+- focused or manual launch smoke through the `.venv` entrypoint.
+
+Additional verification requirements:
+
+- run `git diff --check`
+- record any manual launch command used for the stabilization evidence
+
+## Readiness Fields
+
+App type:
+
+- mixed GUI and console entrypoint
+
+User/caller surface:
+
+- `.venv/bin/impression-reference-review`
+
+Invocation route:
+
+- console command imports and starts the Reference Review Qt shell
+
+Wiring owner/module:
+
+- Reference Review entrypoint and UI shell modules
+
+Observable result:
+
+- the app reaches shell startup or fails with a classified diagnostic instead
+  of an unclassified crash/hang
+
+Integration validation:
+
+- import-boundary tests and manual or automated entrypoint smoke
+
+Readiness blockers:
+
+- none known from the ACD; `review specs` must verify this remains true
+
+## Review Score
+
+- Fresh review score: 33.5
+- IWU recount: 2 IWU
+- Split decision: split required. Launch failure classification and import
+  boundary/kit availability are independently failing stabilization routes.
+
+## Refinement Status
+
+Split parent. Do not implement directly.
+
+## Child Specifications
+
+- [Reference Review Spec 76a: Launch Failure Baseline](reference-review-76a-launch-failure-baseline-v1_0.md)
+- [Reference Review Spec 76b: Import Boundary And Kit Availability](reference-review-76b-import-boundary-and-kit-availability-v1_0.md)
+
+## Split Coverage
+
+| Parent responsibility | Child owner | Status |
+| --- | --- | --- |
+| launch command and fixture-file baseline capture | Spec 76a | Covered |
+| crash/hang classification | Spec 76a | Covered |
+| `.venv` importability for `impression_workbench` | Spec 76b | Covered |
+| guard against `impression_gui` imports | Spec 76b | Covered |
+| keep-local vs import-from-kit decision | Spec 76b | Covered |
+
+## Acceptance
+
+This specification is complete when the launch/import boundary is deterministic,
+Reference Review has no `impression_gui` dependency, and kit import decisions
+are explicit for the stabilization branch.

--- a/project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-76a-launch-failure-baseline-v1_0.md
@@ -1,0 +1,175 @@
+# Reference Review Spec 76a: Launch Failure Baseline (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one launch-baseline probe and failure-classification route.
+
+## Overview
+
+Capture the real Reference Review launch command and classify the current
+launch failure without importing fixtures, building models, tessellating, or
+constructing preview scene content during the probe.
+
+## Backlink
+
+- [Parent Spec 76](reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers:
+
+- launch command and fixture-file baseline capture
+- failure classification
+- controlled shell or entrypoint probe
+- diagnostic capture sufficient to choose the next stabilization route
+
+This specification excludes:
+
+- kit import decisions, owned by Spec 76b
+- shell deferral implementation, owned by Spec 77a
+- preview renderer fixes, owned by Specs 78a and 78b
+
+## Responsibilities
+
+- Functions/methods:
+  - launch probe
+  - failure classifier
+- Data structures/models:
+  - launch diagnostic record or equivalent captured result
+- Dependencies/services:
+  - `.venv` console entrypoint
+  - Reference Review shell import/start route
+- Returns/outputs/signals:
+  - classified launch result
+- UI surfaces/components:
+  - shell startup route only
+- UI fields/elements:
+  - none
+- Reusable code plan:
+  - Existing code reused as-is: console entrypoint and shell bootstrap
+  - Additions to existing reusable library/module: none
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - probe must not trigger background fixture/model/preview work
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - diagnostics avoid unrelated local data
+- Performance-sensitive behavior:
+  - probe fails quickly rather than hanging indefinitely
+- Cross-screen reusable behavior:
+  - none
+
+## Implementation Boundary
+
+Owner/module:
+
+- Reference Review entrypoint and `src/impression/devtools/reference_review/ui/shell.py`
+
+Routes:
+
+- `.venv/bin/impression-reference-review`
+- shell/bootstrap probe path used by tests
+
+Reuse/extraction decision:
+
+- no shared-kit adoption in this leaf
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- baseline uses real fixture data chosen for stabilization smoke
+- failure classes are import/dependency, QML/bootstrap, UI-thread
+  blocking/handoff, preview renderer construction, and fixture/payload
+  selection
+
+Data ownership:
+
+- launch diagnostics belong to the shell/entrypoint stabilization route
+
+Open questions and resolved assumptions:
+
+- resolved: the probe must not do render work
+
+Implementation prerequisites:
+
+- active hybrid stabilization ACD
+
+## Behavior
+
+The implementation must:
+
+- record the launch command used for stabilization;
+- expose or record the selected fixture file when one is used;
+- classify launch failure into one of the ACD-defined categories;
+- fail in a controlled way in test routes instead of beachballing indefinitely.
+
+## Verification
+
+Test strategy:
+
+- focused launch probe test or controlled shell probe test;
+- manual entrypoint smoke when automation cannot observe the GUI event loop.
+
+Additional verification requirements:
+
+- run `git diff --check`
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 0 x 1 = 0
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 19
+
+Split decision:
+
+- No split. Cohesion reason: this leaf only classifies launch failure and
+  provides the baseline for later implementation.
+
+## Readiness Fields
+
+App type: mixed GUI and console entrypoint.
+User/caller surface: `.venv/bin/impression-reference-review`.
+Invocation route: console command to shell startup probe.
+Wiring owner/module: Reference Review entrypoint and shell.
+Observable result: launch failure is classified or shell reaches startup.
+Integration validation: controlled shell/entrypoint probe plus manual smoke.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when the launch failure mode is reproducible,
+classified, and recorded without performing fixture/model/render work in the
+probe.

--- a/project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md
@@ -1,0 +1,158 @@
+# Reference Review Spec 76b: Import Boundary And Kit Availability (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one deterministic import-boundary and kit-availability decision.
+
+## Overview
+
+Make the Reference Review import boundary deterministic: the review app must
+not import `impression_gui`, and any `impression_workbench` helper adopted for
+stabilization must be importable from the same `.venv` entrypoint used by the
+app.
+
+## Backlink
+
+- [Parent Spec 76](reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers:
+
+- clean-process import tests for Reference Review UI modules
+- `impression_gui` import guard
+- `.venv` `impression_workbench` availability check when kit helpers are used
+- keep-local versus import-from-kit stabilization decision
+
+This specification excludes launch failure classification, owned by Spec 76a.
+
+## Responsibilities
+
+- Functions/methods:
+  - import-boundary probe
+  - forbidden-import guard
+  - kit availability probe
+- Data structures/models:
+  - import result or diagnostic record
+- Dependencies/services:
+  - `.venv` Python executable
+  - Reference Review UI modules
+  - `impression_workbench` package when helpers are used
+- Returns/outputs/signals:
+  - import pass/fail diagnostic
+  - kit adoption decision
+- UI surfaces/components:
+  - none
+- UI fields/elements:
+  - none
+- Reusable code plan:
+  - Existing code reused as-is: Reference Review package imports
+  - Additions to existing reusable library/module: none
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - import probes do not start app workers
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - diagnostic output avoids unrelated environment dumps
+- Performance-sensitive behavior:
+  - probes fail quickly
+- Cross-screen reusable behavior:
+  - import boundary protects all Reference Review app surfaces
+
+## Implementation Boundary
+
+Owner/module:
+
+- Reference Review UI package imports and focused tests
+
+Routes:
+
+- clean-process import route
+- `.venv` package availability route
+
+Reuse/extraction decision:
+
+- use kit helpers only when import-safe and API-compatible
+- keep local helpers for this stabilization PR when kit adoption would create
+  launch risk
+
+## Behavior
+
+The implementation must:
+
+- prove Reference Review does not import `impression_gui`;
+- prove any adopted `impression_workbench` helper is available from the app
+  `.venv`;
+- preserve local helpers when kit availability is not deterministic;
+- avoid model, fixture, and renderer work during import checks.
+
+## Verification
+
+Test strategy:
+
+- isolated subprocess import test;
+- forbidden import assertion for `impression_gui`;
+- kit availability assertion when kit imports are present.
+
+Additional verification requirements:
+
+- run `git diff --check`
+
+## Review Score
+
+- Functions/methods: 3 x 2 = 6
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 3 x 1 = 3
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 0 x 2 = 0
+- UI fields/elements: 0 x 1 = 0
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 22.5
+
+Split decision:
+
+- No split. Cohesion reason: all responsibilities serve one import-boundary
+  decision for the stabilization branch.
+
+## Readiness Fields
+
+App type: mixed GUI and console entrypoint.
+User/caller surface: import side of `.venv/bin/impression-reference-review`.
+Invocation route: package import and app bootstrap import path.
+Wiring owner/module: Reference Review UI package and tests.
+Observable result: app import path is deterministic and does not depend on
+`impression_gui`.
+Integration validation: clean-process import tests.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when the import boundary is deterministic and
+kit adoption decisions are explicit for the stabilization branch.

--- a/project/release-0.1.0a/specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md
@@ -1,0 +1,215 @@
+# Reference Review Spec 77: Non-Blocking Shell Bootstrap And Task Handoff (v1.0)
+
+Status: Split parent - superseded by child specs 77a and 77b
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own
+verification surface.
+Draft count: 1 IWU.
+Basis: one shell-bootstrap and task-handoff stabilization leaf. This count is a
+draft creation estimate and must be verified by `review specs`.
+
+## Overview
+
+Make Reference Review launch initialize only the shell, UI hierarchy,
+lightweight models, and deferred task lanes. Expensive work must start after
+the event loop is alive and must return through typed UI-thread handoff.
+
+## Backlink
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+- [Reference Review Hybrid Stabilization Plan](../planning/reference-review-hybrid-stabilization-plan.md)
+
+## Source Manifest
+
+- Source candidate: `Non-Blocking Shell Bootstrap And Task Handoff`
+- Source artifact: `project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md`
+
+## Scope
+
+This specification covers:
+
+- launch-time deferral of expensive work
+- UI-thread ownership of shell/QML/model mutation
+- typed handoff for worker completions
+- stale-completion rejection before UI mutation
+- focused launch smoke proving startup does not select/build/render a fixture
+
+## Responsibilities
+
+- Functions/methods:
+  - shell startup orchestration
+  - deferred fixture refresh trigger
+  - worker completion handoff handler
+  - stale-result check before UI mutation
+- Data structures/models:
+  - existing Review Workbench message/result records or compatible kit records
+- Dependencies/services:
+  - Qt event loop
+  - task dispatcher or equivalent worker lane
+  - latest-request/staleness helper
+- Returns/outputs/signals:
+  - UI-safe fixture refresh request
+  - UI-safe worker completion
+  - visible shell-ready state
+- UI surfaces/components:
+  - Reference Review shell
+  - fixture list model
+  - preview pane placeholder state
+- UI fields/elements:
+  - initial selected fixture state
+  - visible loading/diagnostic state where present
+- Reusable code plan:
+  - Existing code reused as-is:
+    - current shell and dispatcher scaffolding
+  - Additions to existing reusable library/module:
+    - narrow use of kit staleness or Qt handoff helpers if import-safe
+  - New reusable library/module to create:
+    - none expected
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - no blocking UI-thread fixture import, model build, tessellation,
+    renderer scene build, filesystem scan, or durable write during launch
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - sanitized failure handoff for background exceptions
+- Performance-sensitive behavior:
+  - startup must remain responsive before fixture data is loaded
+- Cross-screen reusable behavior:
+  - shell handoff behavior protects fixture list, preview, notes, and status
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+- `src/impression/devtools/reference_review/async_core/*` or compatible kit
+  imports if accepted by Spec 76
+
+Routes:
+
+- app startup
+- fixture list refresh
+- worker completion to UI shell
+
+Reuse/extraction decision:
+
+- prefer existing local async core during stabilization unless kit imports are
+  proven safe by Spec 76
+- do not introduce a broad owner-route rewrite in this leaf
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- startup selected fixture is none until fixture list data is safely available
+- initial preview state is placeholder or non-rendering shell state
+
+Data ownership:
+
+- shell owns UI model mutation
+- workers own expensive background work only
+
+Open questions and resolved assumptions:
+
+- resolved: no background completion may directly mutate UI state
+- open for implementation: exact probe used to prove no fixture build occurs
+  during shell bootstrap
+
+Implementation prerequisites:
+
+- Spec 76 import and launch baseline decisions
+
+## Behavior
+
+The implementation must:
+
+- start the Qt shell without synchronous fixture source import;
+- avoid renderer scene construction during visible bootstrap;
+- defer fixture refresh until after the event loop is alive;
+- route worker results through UI-safe handoff;
+- reject stale completions before changing selected fixture, preview, notes, or
+  status state;
+- surface launch/bootstrap failures as diagnostics rather than a silent
+  beachball where practical.
+
+## Verification
+
+Test strategy:
+
+- focused shell startup test proving no fixture is selected/built during
+  bootstrap;
+- focused handoff test proving stale worker completion cannot mutate current
+  UI-visible state;
+- manual launch smoke before and after first fixture selection.
+
+Additional verification requirements:
+
+- run relevant UI shell tests
+- run `git diff --check`
+
+## Readiness Fields
+
+App type:
+
+- mixed GUI and console entrypoint
+
+User/caller surface:
+
+- Reference Review desktop app window launched through the console entrypoint
+
+Invocation route:
+
+- shell startup, deferred refresh trigger, worker completion handoff
+
+Wiring owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+
+Observable result:
+
+- the app opens responsively and fixture/background work cannot freeze the UI at
+  launch
+
+Integration validation:
+
+- shell tests plus manual or automated launch smoke
+
+Readiness blockers:
+
+- depends on Spec 76 for import-boundary decisions
+
+## Review Score
+
+- Fresh review score: 42.5
+- IWU recount: 2 IWU
+- Split decision: split required. Non-blocking startup and completion handoff
+  are independently failing async routes.
+
+## Refinement Status
+
+Split parent. Do not implement directly.
+
+## Child Specifications
+
+- [Reference Review Spec 77a: Non-Blocking Shell Startup](reference-review-77a-non-blocking-shell-startup-v1_0.md)
+- [Reference Review Spec 77b: UI Handoff And Stale Completion Guard](reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md)
+
+## Split Coverage
+
+| Parent responsibility | Child owner | Status |
+| --- | --- | --- |
+| launch-time deferral of expensive work | Spec 77a | Covered |
+| UI-thread shell/QML/model ownership during startup | Spec 77a | Covered |
+| typed handoff for worker completions | Spec 77b | Covered |
+| stale-completion rejection before UI mutation | Spec 77b | Covered |
+| startup smoke proving no selected/built/rendered fixture | Spec 77a | Covered |
+
+## Acceptance
+
+This specification is complete when shell bootstrap is non-blocking and worker
+handoff cannot mutate UI state without current owner/request validation.

--- a/project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md
@@ -1,0 +1,146 @@
+# Reference Review Spec 77a: Non-Blocking Shell Startup (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one shell-startup deferral boundary.
+
+## Overview
+
+Ensure app startup creates the shell, UI hierarchy, lightweight models, and
+deferred task triggers without synchronously importing fixture sources,
+building models, tessellating, constructing preview scene content, scanning
+large fixture roots, or writing durable state.
+
+## Backlink
+
+- [Parent Spec 77](reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers startup deferral only. Worker completion handoff and
+stale-result rejection are owned by Spec 77b.
+
+## Responsibilities
+
+- Functions/methods:
+  - shell startup orchestration
+  - deferred fixture refresh trigger
+- Data structures/models:
+  - initial shell/selected-fixture state
+- Dependencies/services:
+  - Qt event loop
+  - fixture refresh lane trigger
+- Returns/outputs/signals:
+  - shell-ready state
+  - deferred refresh signal
+- UI surfaces/components:
+  - shell
+  - fixture list placeholder
+  - preview placeholder
+- UI fields/elements:
+  - initial selection state
+  - loading/empty state where present
+- Reusable code plan:
+  - Existing code reused as-is: shell scaffolding
+  - Additions to existing reusable library/module: none
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - expensive work starts after event loop startup
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - none
+- Performance-sensitive behavior:
+  - startup remains responsive
+- Cross-screen reusable behavior:
+  - shell startup protects all panels
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+
+Routes:
+
+- app startup
+- deferred fixture refresh trigger
+
+## Behavior
+
+The implementation must:
+
+- start with no selected fixture until fixture data is safely available;
+- avoid fixture source import and preview scene construction during bootstrap;
+- defer fixture refresh until the event loop is alive;
+- expose shell-ready/placeholder state suitable for tests.
+
+## Verification
+
+Test strategy:
+
+- focused shell bootstrap test with doubles proving expensive calls were not
+  made;
+- manual launch smoke confirming responsive startup.
+
+Additional verification requirements:
+
+- run `git diff --check`
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 3 x 2 = 6
+- UI fields/elements: 2 x 1 = 2
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 24.5
+
+Split decision:
+
+- No split. Cohesion reason: although the score is high, every item is part of
+  one startup deferral boundary and has one shell-bootstrap verification route.
+
+## Readiness Fields
+
+App type: mixed GUI and console entrypoint.
+User/caller surface: Reference Review app window.
+Invocation route: shell startup.
+Wiring owner/module: `src/impression/devtools/reference_review/ui/shell.py`.
+Observable result: shell opens responsive before expensive fixture work.
+Integration validation: shell bootstrap test and manual launch smoke.
+Prerequisites: Spec 76a and Spec 76b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when shell startup is non-blocking and fixture
+work begins only after the event loop is alive.

--- a/project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md
@@ -1,0 +1,147 @@
+# Reference Review Spec 77b: UI Handoff And Stale Completion Guard (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one UI-thread handoff and stale-completion guard route.
+
+## Overview
+
+Ensure background worker completions cross into the Reference Review UI through
+typed handoff and are rejected when stale before mutating selected fixture,
+preview, notes, status, or fixture-list state.
+
+## Backlink
+
+- [Parent Spec 77](reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers worker completion handoff and stale-result rejection.
+Startup deferral is owned by Spec 77a.
+
+## Responsibilities
+
+- Functions/methods:
+  - worker completion handoff handler
+  - owner/request currentness check
+  - sanitized failure handoff
+- Data structures/models:
+  - existing message/result envelope or compatible kit record
+- Dependencies/services:
+  - task dispatcher or worker lane
+  - latest-request/staleness helper
+  - Qt handoff helper
+- Returns/outputs/signals:
+  - UI-safe completion
+  - rejected stale completion
+- UI surfaces/components:
+  - fixture list, preview, notes, and status state routes
+- UI fields/elements:
+  - selected fixture state
+  - visible diagnostic state
+- Reusable code plan:
+  - Existing code reused as-is: current async core where import-safe
+  - Additions to existing reusable library/module: optional kit staleness and
+    Qt handoff helpers when Spec 76b allows
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - UI mutation only after currentness check
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - worker failures are sanitized before display
+- Performance-sensitive behavior:
+  - stale rejection is cheap and synchronous in the UI route
+- Cross-screen reusable behavior:
+  - protects all selected-fixture panels
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/shell.py`
+- Reference Review async core or accepted kit handoff/staleness helpers
+
+Routes:
+
+- worker completion to UI shell
+
+## Behavior
+
+The implementation must:
+
+- route worker completions through UI-safe handoff;
+- reject stale success, failure, and cancellation before UI mutation;
+- sanitize worker error text before display;
+- preserve current selected fixture, preview, notes, and status when stale
+  completions arrive.
+
+## Verification
+
+Test strategy:
+
+- focused handoff test;
+- stale success/failure/cancellation tests for visible state routes.
+
+Additional verification requirements:
+
+- run `git diff --check`
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 24.5
+
+Split decision:
+
+- No split. Cohesion reason: this is one currentness-checked UI handoff route;
+  the review challenged panel-by-panel splitting and rejected it as duplicate
+  implementation of the same invariant.
+
+## Readiness Fields
+
+App type: GUI route inside mixed app.
+User/caller surface: all selected-fixture panels receiving worker completions.
+Invocation route: worker completion handoff.
+Wiring owner/module: shell and async handoff helpers.
+Observable result: stale completions cannot corrupt current visible state.
+Integration validation: focused stale-result and handoff tests.
+Prerequisites: Spec 76b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None.
+
+## Acceptance
+
+This specification is complete when stale completions are rejected before UI
+mutation across the selected-fixture state routes.

--- a/project/release-0.1.0a/specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md
@@ -1,0 +1,230 @@
+# Reference Review Spec 78: Preview Lifecycle And Non-Renderable Fixture Handling (v1.0)
+
+Status: Split parent - superseded by child specs 78a and 78b
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own
+verification surface.
+Draft count: 1 IWU.
+Basis: one preview lifecycle and non-renderable fixture handling leaf. This
+count is a draft creation estimate and must be verified by `review specs`.
+
+## Overview
+
+Stabilize the Reference Review preview route so renderable fixtures render,
+diagnostic fixtures show contextual non-renderable state, and stale or failed
+preview work cannot destroy the live renderer or clear a newer good preview.
+
+## Backlink
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+- [Reference Review Preview Payload Boundary Architecture](../architecture/reference-review-preview-payload-boundary-architecture.md)
+- [Reference Review Preview Engine Sharing Architecture](../architecture/reference-review-preview-engine-sharing-architecture.md)
+
+## Source Manifest
+
+- Source candidate: `Preview Lifecycle And Non-Renderable Fixture Handling`
+- Source artifact: `project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md`
+
+## Scope
+
+This specification covers:
+
+- one renderer lifetime per preview widget
+- off-thread payload work
+- UI/render-thread renderer mutation
+- renderable artifact preview routing
+- diagnostic/non-renderable fixture state routing
+- last-good preview preservation
+- display-control command routing to current preview surface
+
+## Responsibilities
+
+- Functions/methods:
+  - selected fixture to preview request route
+  - preview payload completion handler
+  - non-renderable fixture state handler
+  - display-control command handler
+  - preview stale/failure guard
+- Data structures/models:
+  - existing preview payload result records
+  - preview state fields for current, stale, failure, or non-renderable state
+- Dependencies/services:
+  - preview payload builder/controller
+  - preview widget
+  - shared Impression preview semantics
+- Returns/outputs/signals:
+  - render command or payload application request
+  - non-renderable context state
+  - preview diagnostic
+- UI surfaces/components:
+  - preview pane
+  - display-control button row
+- UI fields/elements:
+  - preview visible state
+  - display-control toggles
+  - contextual diagnostic text
+- Reusable code plan:
+  - Existing code reused as-is:
+    - current Reference Review preview widget and payload builder
+    - Impression preview controller/surface semantics already in use
+  - Additions to existing reusable library/module:
+    - optional kit preview display option records if Spec 76 proves safe
+  - New reusable library/module to create:
+    - none expected
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - payload work is off-thread
+  - renderer mutation is UI/render-thread only
+  - stale preview completions are rejected before renderer mutation
+- Destructive/write behavior:
+  - no artifact writes or promotions in this leaf
+- Security/privacy-sensitive behavior:
+  - preview diagnostics are sanitized before display
+- Performance-sensitive behavior:
+  - renderer is not recreated for every fixture selection or stale/failure path
+- Cross-screen reusable behavior:
+  - preview display controls remain shared across renderable fixture previews
+
+## Implementation Boundary
+
+Owner/module:
+
+- `src/impression/devtools/reference_review/ui/preview_widget.py`
+- `src/impression/devtools/reference_review/ui/shell.py`
+- `src/impression/devtools/reference_review/preview_payload_builder.py`
+
+Routes:
+
+- fixture selection to preview payload request
+- preview payload completion to preview widget
+- display-control command to preview widget
+
+Reuse/extraction decision:
+
+- keep fixture-specific payload decisions in Reference Review
+- keep renderer semantics aligned with Impression CLI preview
+- do not introduce Bench-specific file/document preview routing
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- a fixture with a renderable artifact enters the render path
+- a fixture without a renderable artifact enters the contextual
+  non-renderable path
+- stale or failed work preserves last good render when one exists
+
+Data ownership:
+
+- payload builder owns render input preparation
+- preview widget owns renderer lifetime and scene mutation
+- shell owns selected fixture and visible preview state
+
+Open questions and resolved assumptions:
+
+- resolved: diagnostic fixtures are valid review rows and must not crash the
+  renderer
+- resolved: stale failures cannot clear newer good preview state
+
+Implementation prerequisites:
+
+- Spec 76 import decisions
+- Spec 77 UI-thread handoff and stale-result route
+
+## Behavior
+
+The implementation must:
+
+- preserve one live renderer per preview widget lifetime;
+- avoid renderer creation/destruction as a fixture-selection side effect;
+- perform artifact/source payload preparation off the UI thread;
+- apply preview payloads only through the UI/render thread;
+- route non-renderable fixtures to contextual state without calling renderer
+  scene replacement;
+- preserve last-good render when stale or failed completions arrive;
+- keep display-control commands functional for the current preview surface.
+
+## Verification
+
+Test strategy:
+
+- focused preview payload tests for renderable artifact records;
+- focused shell/preview routing tests for non-renderable diagnostics;
+- stale success/failure rejection test where available;
+- display-control routing test confirming commands reach the preview surface.
+
+Additional verification requirements:
+
+- manual selection smoke across renderable STL or `.impress` fixtures and
+  diagnostic/non-renderable fixtures
+- run `git diff --check`
+
+## Readiness Fields
+
+App type:
+
+- GUI route inside mixed console-launched app
+
+User/caller surface:
+
+- preview pane in the Reference Review app
+
+Invocation route:
+
+- fixture list selection and preview display-control buttons
+
+Wiring owner/module:
+
+- shell, preview widget, and preview payload builder
+
+Observable result:
+
+- renderable fixtures preview; non-renderable fixtures show context; preview
+  remains responsive across selection and control changes
+
+Integration validation:
+
+- preview payload tests, shell routing tests, display-control tests, manual GUI
+  smoke
+
+Readiness blockers:
+
+- depends on Spec 77 for non-blocking handoff
+
+## Review Score
+
+- Fresh review score: 47.5
+- IWU recount: 2 IWU
+- Split decision: split required. Renderable preview lifecycle and
+  non-renderable/stale failure state are independently failing preview routes.
+
+## Refinement Status
+
+Split parent. Do not implement directly.
+
+## Child Specifications
+
+- [Reference Review Spec 78a: Renderable Preview Lifecycle](reference-review-78a-renderable-preview-lifecycle-v1_0.md)
+- [Reference Review Spec 78b: Non-Renderable Preview State And Last-Good Guard](reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md)
+
+## Split Coverage
+
+| Parent responsibility | Child owner | Status |
+| --- | --- | --- |
+| one renderer lifetime per preview widget | Spec 78a | Covered |
+| off-thread renderable payload work | Spec 78a | Covered |
+| UI/render-thread renderer mutation | Spec 78a | Covered |
+| renderable artifact preview routing | Spec 78a | Covered |
+| diagnostic/non-renderable fixture state routing | Spec 78b | Covered |
+| last-good preview preservation | Spec 78b | Covered |
+| display-control command routing | Spec 78a | Covered |
+
+## Acceptance
+
+This specification is complete when preview renderer lifetime is stable,
+renderable and non-renderable fixture paths are separated, and stale/failure
+preview work cannot corrupt the current live preview.

--- a/project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md
@@ -1,0 +1,133 @@
+# Reference Review Spec 78a: Renderable Preview Lifecycle (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one renderable fixture preview lifecycle route.
+
+## Overview
+
+Stabilize the renderable fixture preview path: one renderer per preview widget
+lifetime, off-thread payload preparation, UI/render-thread scene mutation, and
+display-control routing to the current preview surface.
+
+## Backlink
+
+- [Parent Spec 78](reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers renderable artifacts and display-control routing.
+Non-renderable fixtures and stale/failure last-good behavior are owned by Spec
+78b.
+
+## Responsibilities
+
+- Functions/methods:
+  - selected fixture to preview request route
+  - renderable payload completion handler
+  - display-control command handler
+- Data structures/models:
+  - preview payload result records
+  - current preview identity/state
+- Dependencies/services:
+  - preview payload builder/controller
+  - preview widget
+  - Impression preview semantics
+- Returns/outputs/signals:
+  - payload application command
+  - display-control command
+- UI surfaces/components:
+  - preview pane
+  - display-control button row
+- UI fields/elements:
+  - preview visible state
+  - display-control toggles
+- Reusable code plan:
+  - Existing code reused as-is: preview widget, payload builder, display controls
+  - Additions to existing reusable library/module: optional kit display records
+    if Spec 76b allows
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - payload work off-thread; renderer mutation UI/render-thread only
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - sanitized diagnostics for payload failure
+- Performance-sensitive behavior:
+  - renderer is not recreated per fixture selection
+- Cross-screen reusable behavior:
+  - display controls apply to every renderable preview
+
+## Behavior
+
+The implementation must:
+
+- preserve one live renderer per preview widget lifetime;
+- prepare renderable payloads off the UI thread;
+- apply payloads only through the UI/render thread;
+- keep display-control commands functional for the current preview surface.
+
+## Verification
+
+Test strategy:
+
+- renderable artifact payload routing test;
+- renderer lifetime test using a preview widget double where needed;
+- display-control command routing test;
+- manual real-render smoke.
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 2 x 1 = 2
+- Dependencies/services: 3 x 1 = 3
+- Returns/outputs/signals: 1 x 1 = 1
+- Existing reusable code reused as-is: 3 x 0.5 = 1.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 22.5
+
+Split decision:
+
+- No split. Cohesion reason: renderable payload application and display-control
+  routing are one current-preview mutation route.
+
+## Readiness Fields
+
+App type: GUI route inside mixed app.
+User/caller surface: preview pane and display-control button row.
+Invocation route: fixture selection and display-control toggle.
+Wiring owner/module: shell, preview widget, payload builder.
+Observable result: renderable fixtures display and controls affect the current
+preview.
+Integration validation: payload tests, display-control route tests, manual
+real-render smoke.
+Prerequisites: Spec 76b and Spec 77b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Acceptance
+
+This specification is complete when renderable fixtures preview through a
+stable widget-owned renderer and display controls still route to that preview.

--- a/project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md
@@ -1,0 +1,124 @@
+# Reference Review Spec 78b: Non-Renderable Preview State And Last-Good Guard (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one non-renderable/stale preview state guard.
+
+## Overview
+
+Route diagnostic or non-renderable fixtures to contextual preview state and
+preserve last-good render state when stale or failed preview completions arrive.
+
+## Backlink
+
+- [Parent Spec 78](reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers non-renderable fixture state and stale/failure
+last-good guards. Renderable preview lifecycle is owned by Spec 78a.
+
+## Responsibilities
+
+- Functions/methods:
+  - non-renderable fixture state handler
+  - preview stale/failure guard
+- Data structures/models:
+  - preview state fields for current, stale, failure, and non-renderable state
+- Dependencies/services:
+  - shell selected-fixture state
+  - preview payload completion route
+- Returns/outputs/signals:
+  - non-renderable context state
+  - preview diagnostic
+- UI surfaces/components:
+  - preview pane
+- UI fields/elements:
+  - contextual diagnostic text
+  - stale/last-good state indicator where present
+- Reusable code plan:
+  - Existing code reused as-is: shell and preview visible-state plumbing
+  - Additions to existing reusable library/module: none expected
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - stale failures rejected before preview mutation
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - diagnostics are sanitized before display
+- Performance-sensitive behavior:
+  - non-renderable route must not call renderer scene replacement
+- Cross-screen reusable behavior:
+  - none
+
+## Behavior
+
+The implementation must:
+
+- detect diagnostic/non-renderable fixtures before renderer scene replacement;
+- show contextual non-renderable state;
+- reject stale successes and stale failures before preview mutation;
+- preserve last-good render when same-fixture failure occurs after success.
+
+## Verification
+
+Test strategy:
+
+- non-renderable routing test proving renderer replacement is not called;
+- stale success/failure tests;
+- same-fixture failure after success test;
+- manual renderable-to-non-renderable-to-renderable smoke.
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 1 x 3 = 3
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 2 x 1 = 2
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 23.5
+
+Split decision:
+
+- No split. Cohesion reason: non-renderable state and last-good preservation
+  are one failure-state route for the preview pane.
+
+## Readiness Fields
+
+App type: GUI route inside mixed app.
+User/caller surface: preview pane.
+Invocation route: fixture selection and preview completion.
+Wiring owner/module: shell and preview widget visible-state route.
+Observable result: non-renderable fixtures do not crash or blank the app.
+Integration validation: preview routing tests and manual GUI smoke.
+Prerequisites: Spec 77b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Acceptance
+
+This specification is complete when diagnostic/non-renderable fixtures show
+context and stale/failure preview work cannot clear last-good render state.

--- a/project/release-0.1.0a/specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md
@@ -1,0 +1,236 @@
+# Reference Review Spec 79: Review Workflow Persistence Smoke (v1.0)
+
+Status: Split parent - superseded by child specs 79a, 79b, and 79c
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own
+verification surface.
+Draft count: 1 IWU.
+Basis: one review workflow persistence smoke leaf. This count is a draft
+creation estimate and must be verified by `review specs`.
+
+## Overview
+
+Confirm the stabilization work preserves the Reference Review app's core review
+workflow: notes, approve, decline, unreviewed status, status badge, and
+show-approved filtering.
+
+## Backlink
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+- [Reference Review Promotion And Notes Lifecycle](../architecture/reference-review-promotion-and-notes-lifecycle.md)
+- [Reference Review Hybrid Stabilization Plan](../planning/reference-review-hybrid-stabilization-plan.md)
+
+## Source Manifest
+
+- Source candidate: `Review Workflow Persistence Smoke`
+- Source artifact: `project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md`
+
+## Scope
+
+This specification covers:
+
+- selected fixture notes load
+- real-time notes persistence
+- approve status persistence and dirty-to-gold artifact move
+- decline status persistence without artifact move
+- unreviewed fixture visibility
+- status badge state
+- show-approved filtering behavior
+
+## Responsibilities
+
+- Functions/methods:
+  - selected fixture notes load route
+  - notes save route
+  - approve action route
+  - decline action route
+  - show-approved filter route
+  - status badge state update route
+- Data structures/models:
+  - fixture review status
+  - selected fixture notes
+  - fixture list filter state
+- Dependencies/services:
+  - fixture record file or database store
+  - durable write lane
+  - artifact promotion service
+- Returns/outputs/signals:
+  - notes save completion
+  - approve/decline completion
+  - filtered fixture list update
+  - visible status badge state
+- UI surfaces/components:
+  - fixture list
+  - notes tab/panel
+  - approve/decline controls
+  - status badge
+  - show-approved checkbox
+- UI fields/elements:
+  - notes text
+  - status label/badge
+  - checkbox checked state
+  - fixture row visibility
+- Reusable code plan:
+  - Existing code reused as-is:
+    - current promotion and notes lifecycle modules
+  - Additions to existing reusable library/module:
+    - optional durable write helper imported from kit if Spec 76 proves safe
+  - New reusable library/module to create:
+    - none expected
+- Database queries/tables/migrations:
+  - none expected; existing file/db fixture persistence route is used
+- Async/concurrency behavior:
+  - writes are serialized
+  - stale selected fixture completions cannot update the wrong visible fixture
+- Destructive/write behavior:
+  - approve can move artifacts from dirty to gold
+  - notes and status write to fixture record or database
+- Security/privacy-sensitive behavior:
+  - notes contents stay in the fixture persistence path; no new external sink
+- Performance-sensitive behavior:
+  - notes writes must not block the UI thread
+- Cross-screen reusable behavior:
+  - fixture status drives list, badge, and filter behavior
+
+## Implementation Boundary
+
+Owner/module:
+
+- Reference Review lifecycle modules for notes, status, and promotion
+- `src/impression/devtools/reference_review/ui/shell.py`
+- relevant fixture store modules and tests
+
+Routes:
+
+- notes edit/save
+- approve action
+- decline action
+- fixture filter toggle
+- selected fixture change
+
+Reuse/extraction decision:
+
+- keep review persistence and promotion policy local
+- use shared durable write helper only if import-safe and API-compatible
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- approved fixtures are hidden by default unless show-approved is checked
+- declined and unreviewed fixtures remain visible
+- decline does not move dirty artifacts
+- approve moves dirty artifact paths to matching gold paths
+
+Data ownership:
+
+- fixture store owns persisted notes and status
+- promotion service owns artifact movement
+- shell owns visible selected fixture state
+
+Open questions and resolved assumptions:
+
+- resolved: status has exactly approved, declined, and unreviewed states for
+  this stabilization pass
+
+Implementation prerequisites:
+
+- Spec 77 task handoff for UI safety
+
+## Behavior
+
+The implementation must:
+
+- load notes when selected fixture changes;
+- save notes in real time to the selected fixture record or database;
+- avoid applying stale notes completions to a newer selected fixture;
+- approve a fixture by persisting approved status and moving dirty artifacts to
+  gold with matching folder structure;
+- decline a fixture by persisting declined status without moving artifacts;
+- keep unreviewed fixtures visible;
+- hide approved fixtures when show-approved is unchecked and show them when it
+  is checked;
+- show a wide status badge whose state matches the selected fixture.
+
+## Verification
+
+Test strategy:
+
+- focused fixture-store tests for notes/status persistence;
+- focused promotion tests for approve artifact movement;
+- focused decline test proving artifacts are not moved;
+- focused UI/shell model test for show-approved filtering and badge state.
+
+Additional verification requirements:
+
+- manual smoke on a real fixture file
+- run `git diff --check`
+
+## Readiness Fields
+
+App type:
+
+- GUI route with durable file side effects
+
+User/caller surface:
+
+- notes panel, approve/decline controls, fixture list, status badge
+
+Invocation route:
+
+- text edit, button click, checkbox toggle, fixture selection
+
+Wiring owner/module:
+
+- Reference Review shell and lifecycle modules
+
+Observable result:
+
+- review notes and statuses persist and are reflected in the visible fixture
+  list and selected fixture badge
+
+Integration validation:
+
+- persistence tests, shell model tests, and manual GUI smoke
+
+Readiness blockers:
+
+- depends on Spec 77 for non-blocking durable write handoff
+
+## Review Score
+
+- Fresh review score: 61
+- IWU recount: 3 IWU
+- Split decision: split required. Notes persistence, approve/decline
+  promotion, and visible status projection are independently failing routes.
+
+## Refinement Status
+
+Split parent. Do not implement directly.
+
+## Child Specifications
+
+- [Reference Review Spec 79a: Notes Persistence Route](reference-review-79a-notes-persistence-route-v1_0.md)
+- [Reference Review Spec 79b: Approve/Decline Persistence And Promotion Route](reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md)
+- [Reference Review Spec 79c: Status Badge And Approved Filter Route](reference-review-79c-status-badge-and-approved-filter-route-v1_0.md)
+
+## Split Coverage
+
+| Parent responsibility | Child owner | Status |
+| --- | --- | --- |
+| selected fixture notes load | Spec 79a | Covered |
+| real-time notes persistence | Spec 79a | Covered |
+| approve status persistence and dirty-to-gold artifact move | Spec 79b | Covered |
+| decline status persistence without artifact move | Spec 79b | Covered |
+| unreviewed fixture visibility | Spec 79c | Covered |
+| status badge state | Spec 79c | Covered |
+| show-approved filtering behavior | Spec 79c | Covered |
+
+## Acceptance
+
+This specification is complete when the stabilized app still supports the core
+review workflow through persistent notes, approve/decline state, status badge,
+and show-approved filtering.

--- a/project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-79a-notes-persistence-route-v1_0.md
@@ -1,0 +1,125 @@
+# Reference Review Spec 79a: Notes Persistence Route (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one selected-fixture notes load/save route.
+
+## Overview
+
+Ensure notes load for the selected fixture, save in real time to the fixture
+record or database, and stale notes completions cannot update a newer selected
+fixture.
+
+## Backlink
+
+- [Parent Spec 79](reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers notes only. Approve/decline is owned by Spec 79b;
+filter and badge state are owned by Spec 79c.
+
+## Responsibilities
+
+- Functions/methods:
+  - selected fixture notes load route
+  - notes save route
+  - stale notes completion guard
+- Data structures/models:
+  - selected fixture notes
+- Dependencies/services:
+  - fixture record file or database store
+  - durable write lane
+- Returns/outputs/signals:
+  - notes load value
+  - notes save completion
+- UI surfaces/components:
+  - notes tab/panel
+- UI fields/elements:
+  - notes text
+- Reusable code plan:
+  - Existing code reused as-is: current notes lifecycle
+  - Additions to existing reusable library/module: optional durable write helper
+    if Spec 76b allows
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none expected
+- Async/concurrency behavior:
+  - writes serialized; stale completion rejected
+- Destructive/write behavior:
+  - notes write to fixture persistence
+- Security/privacy-sensitive behavior:
+  - notes remain in fixture persistence path
+- Performance-sensitive behavior:
+  - notes writes do not block UI thread
+- Cross-screen reusable behavior:
+  - selected fixture notes route
+
+## Behavior
+
+The implementation must:
+
+- load notes on selected fixture change;
+- save notes in real time;
+- serialize notes writes;
+- reject stale notes completions before visible state mutation.
+
+## Verification
+
+Test strategy:
+
+- fixture-store notes load/save test;
+- stale selected-fixture notes completion test;
+- manual note edit/select-away/select-back smoke.
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 1 x 1 = 1
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 1 x 3 = 3
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 23.5
+
+Split decision:
+
+- No split. Cohesion reason: notes load, save, and stale guard form one
+  selected-fixture notes route.
+
+## Readiness Fields
+
+App type: GUI route with durable file side effect.
+User/caller surface: notes panel.
+Invocation route: fixture selection and notes edit.
+Wiring owner/module: shell and notes lifecycle modules.
+Observable result: selected fixture notes persist and reload.
+Integration validation: notes persistence tests and manual smoke.
+Prerequisites: Spec 77b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Acceptance
+
+This specification is complete when notes persist in real time for the selected
+fixture and stale completions cannot corrupt newer fixture notes.

--- a/project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md
@@ -1,0 +1,128 @@
+# Reference Review Spec 79b: Approve/Decline Persistence And Promotion Route (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one paired review-action persistence route.
+
+## Overview
+
+Ensure approve and decline persist fixture status correctly: approve moves dirty
+artifacts to matching gold paths and decline leaves dirty artifacts in place.
+
+## Backlink
+
+- [Parent Spec 79](reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers approve and decline actions. Notes are owned by Spec
+79a; list filter and badge state are owned by Spec 79c.
+
+## Responsibilities
+
+- Functions/methods:
+  - approve action route
+  - decline action route
+  - promotion validation/completion handoff
+- Data structures/models:
+  - fixture review status
+  - artifact dirty/gold path mapping
+- Dependencies/services:
+  - fixture store
+  - artifact promotion service
+  - durable write lane
+- Returns/outputs/signals:
+  - approve completion
+  - decline completion
+  - promotion diagnostic
+- UI surfaces/components:
+  - approve/decline controls
+- UI fields/elements:
+  - action enabled/status state where present
+- Reusable code plan:
+  - Existing code reused as-is: promotion and status lifecycle modules
+  - Additions to existing reusable library/module: optional durable write helper
+    if Spec 76b allows
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none expected
+- Async/concurrency behavior:
+  - durable writes serialized; stale durable results remain visible diagnostics
+- Destructive/write behavior:
+  - approve moves artifacts; decline writes status only
+- Security/privacy-sensitive behavior:
+  - diagnostics avoid unrelated paths
+- Performance-sensitive behavior:
+  - promotion work does not block UI thread
+- Cross-screen reusable behavior:
+  - status feeds list and badge after completion
+
+## Behavior
+
+The implementation must:
+
+- persist approved status and move dirty artifacts to matching gold paths;
+- persist declined status without moving artifacts;
+- report promotion failures near the review action route;
+- avoid silently discarding durable completion results.
+
+## Verification
+
+Test strategy:
+
+- approve test using temporary fixture/artifact copies;
+- decline test proving artifacts are not moved;
+- status persistence test for both actions.
+
+## Review Score
+
+- Functions/methods: 2 x 2 = 4
+- Data structures/models: 2 x 1 = 2
+- Dependencies/services: 3 x 1 = 3
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 1 x 1 = 1
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 1 x 3 = 3
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 0 x 2 = 0
+- Readiness blockers: 0 x 2 = 0
+- Total: 24
+
+Split decision:
+
+- No split. Cohesion reason: approve and decline are one review-action
+  persistence route with opposite artifact movement policies.
+
+## Readiness Fields
+
+App type: GUI route with durable file side effects.
+User/caller surface: approve and decline controls.
+Invocation route: button click.
+Wiring owner/module: shell, promotion service, fixture store.
+Observable result: approved/declined status persists and artifacts move only
+for approve.
+Integration validation: temporary-artifact promotion tests and manual smoke.
+Prerequisites: Spec 77b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Acceptance
+
+This specification is complete when approve and decline persist correct status
+and artifact side effects through the real review action route.

--- a/project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md
@@ -1,0 +1,129 @@
+# Reference Review Spec 79c: Status Badge And Approved Filter Route (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own verification surface. An IWU is intentionally abstract so the same unit can size software, documentation, tooling, service, research, design, and process projects.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one visible fixture-status projection route.
+
+## Overview
+
+Ensure fixture review status drives the selected-fixture badge and the
+show-approved list filter.
+
+## Backlink
+
+- [Parent Spec 79](reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Scope
+
+This specification covers status badge and show-approved filtering only.
+Status writes are owned by Spec 79b.
+
+## Responsibilities
+
+- Functions/methods:
+  - show-approved filter route
+  - status badge state update route
+- Data structures/models:
+  - fixture review status
+  - fixture list filter state
+- Dependencies/services:
+  - fixture list model
+  - selected fixture state
+- Returns/outputs/signals:
+  - filtered fixture list update
+  - visible badge state
+- UI surfaces/components:
+  - fixture list
+  - status badge
+  - show-approved checkbox
+- UI fields/elements:
+  - checkbox checked state
+  - fixture row visibility
+  - badge label/color state
+- Reusable code plan:
+  - Existing code reused as-is: shell fixture list/status model
+  - Additions to existing reusable library/module: none
+  - New reusable library/module to create: none
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - selected fixture status updates route through UI state
+- Destructive/write behavior:
+  - none
+- Security/privacy-sensitive behavior:
+  - none
+- Performance-sensitive behavior:
+  - filtering remains cheap for current fixture file scale
+- Cross-screen reusable behavior:
+  - fixture status projects to list and selected context
+
+## Behavior
+
+The implementation must:
+
+- hide approved fixtures by default;
+- show approved fixtures when show-approved is checked;
+- keep declined and unreviewed fixtures visible;
+- update the selected fixture badge to approved, declined, or unreviewed.
+
+## Verification
+
+Test strategy:
+
+- fixture list filter tests;
+- selected fixture badge view-model tests;
+- manual checkbox and badge smoke.
+
+## Review Score
+
+- Functions/methods: 1 x 2 = 2
+- Data structures/models: 2 x 1 = 2
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 1 x 0.5 = 0.5
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 0 x 3 = 0
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 2 x 2 = 4
+- UI fields/elements: 2 x 1 = 2
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 1 x 3 = 3
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 23.5
+
+Split decision:
+
+- No split. Cohesion reason: badge and filter are the same visible projection
+  of fixture status; splitting would create two incomplete projections of one
+  state contract.
+
+## Readiness Fields
+
+App type: GUI route.
+User/caller surface: fixture list, show-approved checkbox, status badge.
+Invocation route: fixture selection, status update, checkbox toggle.
+Wiring owner/module: Reference Review shell/list model.
+Observable result: approved filtering and selected status badge match fixture
+status.
+Integration validation: shell model tests and manual GUI smoke.
+Prerequisites: Spec 79b.
+Readiness blockers: none.
+
+## Refinement Status
+
+Final leaf.
+
+## Acceptance
+
+This specification is complete when fixture status projects correctly to both
+the selected badge and approved-filter behavior.

--- a/project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md
+++ b/project/release-0.1.0a/specifications/reference-review-80-stabilization-merge-gate-v1_0.md
@@ -1,0 +1,221 @@
+# Reference Review Spec 80: Stabilization Merge Gate (v1.0)
+
+Status: Final leaf after review pass 1
+
+## Work Units
+
+Unit: Implementation Work Unit (IWU).
+Definition: one independently deliverable, reviewable change set with its own
+verification surface.
+Standard measures: count 1 IWU when the work has one primary outcome, one coherent responsibility boundary, one reviewable artifact or change set, one explicit verification method, declared inputs and outputs, and explicitly named unresolved assumptions or decisions. Split the work when any measure becomes plural, ambiguous, or unnamed.
+Count: 1 IWU.
+Basis: one stabilization validation and merge-gate leaf.
+
+## Overview
+
+Define the proof required before the hybrid stabilization branch can be pushed,
+opened as a pull request, and merged into the release working branch.
+
+## Backlink
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+- [Reference Review Hybrid Stabilization Plan](../planning/reference-review-hybrid-stabilization-plan.md)
+
+## Source Manifest
+
+- Source candidate: `Stabilization Merge Gate`
+- Source artifact: `project/release-0.1.0a/architecture/acd-reference-review-hybrid-stabilization.md`
+
+## Scope
+
+This specification covers:
+
+- focused stabilization test command set
+- real-entrypoint manual smoke
+- merge readiness evidence
+- PR handoff boundary
+- post-merge full-kit migration handoff
+
+## Responsibilities
+
+- Functions/methods:
+  - no product code functions required unless a test runner helper is added
+- Data structures/models:
+  - none expected
+- Dependencies/services:
+  - pytest or existing test runner
+  - git
+  - GitHub PR route
+- Returns/outputs/signals:
+  - passing focused tests
+  - clean `git diff --check`
+  - manual smoke evidence
+  - pushed branch and PR
+- UI surfaces/components:
+  - full Reference Review app through manual smoke
+- UI fields/elements:
+  - fixture list, preview, notes, status, approve/decline, show-approved filter
+- Reusable code plan:
+  - Existing code reused as-is:
+    - existing tests and entrypoint
+  - Additions to existing reusable library/module:
+    - none expected
+  - New reusable library/module to create:
+    - none expected
+- Database queries/tables/migrations:
+  - none
+- Async/concurrency behavior:
+  - validation must include route-level coverage for async preview and UI
+    handoff behavior from the preceding specs
+- Destructive/write behavior:
+  - manual smoke should use fixture data or temporary copies that do not
+    accidentally promote unintended artifacts
+- Security/privacy-sensitive behavior:
+  - PR and smoke notes must not include unrelated local secrets or paths beyond
+    workspace evidence
+- Performance-sensitive behavior:
+  - launch smoke must confirm the app is responsive enough to interact with
+- Cross-screen reusable behavior:
+  - merge gate validates fixture list, preview, notes, and review action routes
+
+## Implementation Boundary
+
+Owner/module:
+
+- release validation commands
+- Git/GitHub workflow for the stabilization branch
+- focused tests under `tests/`
+
+Routes:
+
+- test command route
+- `.venv/bin/impression-reference-review` manual smoke route
+- branch push and PR route
+
+Reuse/extraction decision:
+
+- this leaf should not introduce new product abstractions
+- full Workbench Kit migration is deferred until after merge
+
+## Data And Defaults
+
+Chosen defaults / parameters:
+
+- test set includes preview payload, UI shell routing, notes/status, and
+  display-control routing tests
+- manual smoke uses real fixture data
+
+Data ownership:
+
+- validation evidence belongs to the branch/PR
+
+Open questions and resolved assumptions:
+
+- open for implementation: exact release working branch name to merge into
+- resolved: no full-kit migration work should be added to satisfy this gate
+
+Implementation prerequisites:
+
+- Specs 76a, 76b, 77a, 77b, 78a, 78b, 79a, 79b, and 79c
+
+## Behavior
+
+The implementation must:
+
+- run focused tests for preview payload behavior;
+- run focused tests for UI shell launch/routing behavior;
+- run focused tests for notes/status/promotion behavior;
+- run focused tests for display-control state and command routing;
+- run `git diff --check`;
+- manually smoke the real app through the `.venv` entrypoint;
+- commit the stabilization unit after validation;
+- push the branch;
+- create a PR;
+- merge only after stabilization criteria are satisfied;
+- leave full Workbench Kit migration as follow-up planning.
+
+## Verification
+
+Test strategy:
+
+- this specification is itself the validation gate; it is verified by executing
+  the listed tests and manual smoke
+
+Additional verification requirements:
+
+- record any commands that failed and the fixes applied before merge
+
+## Readiness Fields
+
+App type:
+
+- mixed GUI and console entrypoint validation workflow
+
+User/caller surface:
+
+- tests, console entrypoint, GitHub PR
+
+Invocation route:
+
+- test commands, manual app launch, git push, PR creation, PR merge
+
+Wiring owner/module:
+
+- stabilization branch owner
+
+Observable result:
+
+- the stabilized app is validated and merged, and full kit migration remains
+  separate follow-up work
+
+Integration validation:
+
+- focused tests, manual app smoke, and PR merge evidence
+
+Prerequisites:
+
+- Specs 76a, 76b, 77a, 77b, 78a, 78b, 79a, 79b, and 79c
+
+Readiness blockers:
+
+- none.
+
+## Review Score
+
+- Functions/methods: 1 x 2 = 2
+- Data structures/models: 0 x 1 = 0
+- Dependencies/services: 2 x 1 = 2
+- Returns/outputs/signals: 2 x 1 = 2
+- Existing reusable code reused as-is: 2 x 0.5 = 1
+- Adding code to an existing library/module: 0 x 1 = 0
+- Creating a new reusable library/module: 0 x 3 = 0
+- Destructive/write behavior: 1 x 3 = 3
+- Security/privacy-sensitive behavior: 0 x 3 = 0
+- Performance-sensitive behavior: 1 x 2 = 2
+- UI surfaces/components: 1 x 2 = 2
+- UI fields/elements: 1 x 1 = 1
+- Database queries/tables/migrations: 0 x 2 = 0
+- Async/concurrency behavior: 0 x 3 = 0
+- Cross-screen reusable behavior: 1 x 2 = 2
+- Readiness blockers: 0 x 2 = 0
+- Total: 17
+
+Split decision:
+
+- No split. Cohesion reason: this is one validation gate, not product
+  implementation; splitting test commands from PR/merge evidence would weaken
+  the merge criterion.
+
+## Refinement Status
+
+Final leaf.
+
+## Child Specifications
+
+None at draft creation time.
+
+## Acceptance
+
+This specification is complete when the stabilization branch has passed the
+defined validation gate, has been pushed, has a PR, and is merged into the
+release working branch.

--- a/project/release-0.1.0a/test-specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md
@@ -1,0 +1,48 @@
+# Reference Review Test Spec 76: Launch Baseline And Import Boundary Stabilization (v1.0)
+
+Status: Split parent test spec - superseded by test specs 76a and 76b
+
+## Paired Specification
+
+- [Reference Review Spec 76](../specifications/reference-review-76-launch-baseline-and-import-boundary-stabilization-v1_0.md)
+
+## Architecture Ancestor
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Manual Smoke Check
+
+- Launch the app through the `.venv` entrypoint with the real fixture file used
+  for stabilization.
+- Confirm any failure is classified as import/dependency, QML/bootstrap,
+  UI-thread blocking/handoff, preview renderer construction, or fixture/payload
+  selection.
+- Confirm no `impression_gui` dependency is required for launch.
+
+## Automated Smoke Tests
+
+- Import Reference Review UI modules in a clean process without selecting or
+  rendering a fixture.
+- Verify `impression_workbench` importability from the same `.venv` when kit
+  helpers are used.
+- Verify Reference Review imports do not import `impression_gui`.
+
+## Automated Acceptance Tests
+
+- Import-boundary test fails quickly and clearly when a required kit import is
+  unavailable.
+- Import-boundary test does not build models, tessellate geometry, or construct
+  a preview scene.
+- Launch baseline route records or exposes enough diagnostic information to
+  classify a failure.
+
+## Implementation Notes
+
+- Use isolated subprocess import tests where module-cache leakage would hide an
+  accidental `impression_gui` import.
+
+## Acceptance
+
+- paired automated tests pass
+- manual or automated launch smoke is recorded
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-76a-launch-failure-baseline-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-76a-launch-failure-baseline-v1_0.md
@@ -1,0 +1,23 @@
+# Reference Review Test Spec 76a: Launch Failure Baseline (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 76a](../specifications/reference-review-76a-launch-failure-baseline-v1_0.md)
+
+## Manual Smoke Check
+
+- Launch `.venv/bin/impression-reference-review` with the stabilization fixture
+  file and record whether the shell starts or which failure class is observed.
+
+## Automated Smoke Tests
+
+- Controlled launch or shell probe returns a classified result.
+- Probe does not import fixture sources, build models, tessellate, or construct
+  preview scene content.
+
+## Acceptance
+
+- launch failure is classified or startup succeeds
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md
@@ -1,0 +1,19 @@
+# Reference Review Test Spec 76b: Import Boundary And Kit Availability (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 76b](../specifications/reference-review-76b-import-boundary-and-kit-availability-v1_0.md)
+
+## Automated Smoke Tests
+
+- Clean-process Reference Review UI import succeeds or fails with controlled
+  diagnostic.
+- Import guard proves Reference Review does not import `impression_gui`.
+- `impression_workbench` availability is asserted when kit helpers are used.
+
+## Acceptance
+
+- import-boundary tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md
@@ -1,0 +1,47 @@
+# Reference Review Test Spec 77: Non-Blocking Shell Bootstrap And Task Handoff (v1.0)
+
+Status: Split parent test spec - superseded by test specs 77a and 77b
+
+## Paired Specification
+
+- [Reference Review Spec 77](../specifications/reference-review-77-non-blocking-shell-bootstrap-and-task-handoff-v1_0.md)
+
+## Architecture Ancestor
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Manual Smoke Check
+
+- Launch the app through `.venv/bin/impression-reference-review`.
+- Confirm the shell becomes responsive before any selected fixture preview is
+  built.
+- Select a fixture and confirm fixture work starts after launch rather than
+  during shell bootstrap.
+
+## Automated Smoke Tests
+
+- Shell bootstrap test confirms no fixture source import, model build,
+  tessellation, preview scene build, or durable write is triggered during
+  startup.
+- Worker completion handoff test confirms UI-visible state changes happen only
+  through the shell/UI route.
+
+## Automated Acceptance Tests
+
+- A stale worker completion cannot mutate the selected fixture, preview state,
+  notes state, or status state.
+- A shell startup failure produces a diagnostic or controlled failure instead
+  of an unclassified hang in the test route.
+- Deferred fixture refresh starts only after the shell/event-loop startup route
+  is established.
+
+## Implementation Notes
+
+- Prefer doubles for expensive fixture/model work so tests can assert the work
+  was not called during bootstrap.
+
+## Acceptance
+
+- paired automated tests pass
+- manual shell responsiveness smoke is recorded where automation is impractical
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md
@@ -1,0 +1,23 @@
+# Reference Review Test Spec 77a: Non-Blocking Shell Startup (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 77a](../specifications/reference-review-77a-non-blocking-shell-startup-v1_0.md)
+
+## Manual Smoke Check
+
+- Launch the app and confirm the shell becomes responsive before fixture
+  preview work begins.
+
+## Automated Smoke Tests
+
+- Shell bootstrap test proves fixture import, model build, tessellation,
+  preview scene build, large fixture scan, and durable writes are not called
+  during startup.
+
+## Acceptance
+
+- startup deferral tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md
@@ -1,0 +1,23 @@
+# Reference Review Test Spec 77b: UI Handoff And Stale Completion Guard (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 77b](../specifications/reference-review-77b-ui-handoff-and-stale-completion-guard-v1_0.md)
+
+## Automated Smoke Tests
+
+- Worker completion reaches visible state only through the UI handoff route.
+- Stale success, stale failure, and stale cancellation are rejected before UI
+  mutation.
+
+## Automated Acceptance Tests
+
+- Stale completion cannot mutate selected fixture, preview, notes, status, or
+  fixture-list state.
+
+## Acceptance
+
+- stale-result handoff tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md
@@ -1,0 +1,50 @@
+# Reference Review Test Spec 78: Preview Lifecycle And Non-Renderable Fixture Handling (v1.0)
+
+Status: Split parent test spec - superseded by test specs 78a and 78b
+
+## Paired Specification
+
+- [Reference Review Spec 78](../specifications/reference-review-78-preview-lifecycle-and-non-renderable-fixture-handling-v1_0.md)
+
+## Architecture Ancestor
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Manual Smoke Check
+
+- Select a renderable STL or `.impress` fixture and confirm it renders.
+- Select a diagnostic or non-renderable fixture and confirm it shows contextual
+  non-renderable state without crashing or blanking the app.
+- Return to a renderable fixture and confirm the preview still renders and
+  display-control buttons still affect the preview.
+
+## Automated Smoke Tests
+
+- Preview payload routing test confirms renderable artifact fixtures enter the
+  render path.
+- Preview routing test confirms diagnostic/non-renderable fixtures do not call
+  renderer scene replacement.
+- Display-control routing test confirms commands reach the preview surface
+  through the UI route.
+
+## Automated Acceptance Tests
+
+- Preview widget renderer is not recreated for every fixture selection.
+- Stale preview success cannot overwrite a newer selected fixture.
+- Stale preview failure cannot clear a newer good preview.
+- Same-fixture failure after a good render preserves last-good preview state and
+  exposes a diagnostic/stale state.
+- Renderer mutation happens only on the UI/render-thread route exposed to the
+  test harness.
+
+## Implementation Notes
+
+- Use a lightweight preview widget double when real Qt/VTK integration is too
+  heavy for automated acceptance.
+- Keep one manual real-render smoke for the actual app route.
+
+## Acceptance
+
+- paired automated tests pass
+- manual renderable/non-renderable selection smoke is recorded
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md
@@ -1,0 +1,24 @@
+# Reference Review Test Spec 78a: Renderable Preview Lifecycle (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 78a](../specifications/reference-review-78a-renderable-preview-lifecycle-v1_0.md)
+
+## Manual Smoke Check
+
+- Select a renderable STL or `.impress` fixture and confirm it renders.
+- Toggle display controls and confirm they affect the current preview.
+
+## Automated Smoke Tests
+
+- Renderable artifact fixture enters preview payload path.
+- Preview widget renderer is not recreated for every fixture selection.
+- Display-control command reaches current preview surface.
+
+## Acceptance
+
+- renderable preview lifecycle tests pass
+- manual real-render smoke is recorded where needed
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md
@@ -1,0 +1,24 @@
+# Reference Review Test Spec 78b: Non-Renderable Preview State And Last-Good Guard (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 78b](../specifications/reference-review-78b-non-renderable-preview-state-and-last-good-guard-v1_0.md)
+
+## Manual Smoke Check
+
+- Select renderable, non-renderable, then renderable fixtures and confirm the
+  app does not blank, crash, or lose future preview capability.
+
+## Automated Smoke Tests
+
+- Non-renderable fixture does not call renderer scene replacement.
+- Stale success and stale failure cannot corrupt current preview.
+- Same-fixture failure preserves last-good preview state.
+
+## Acceptance
+
+- non-renderable/stale preview tests pass
+- manual selection smoke is recorded where needed
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md
@@ -1,0 +1,48 @@
+# Reference Review Test Spec 79: Review Workflow Persistence Smoke (v1.0)
+
+Status: Split parent test spec - superseded by test specs 79a, 79b, and 79c
+
+## Paired Specification
+
+- [Reference Review Spec 79](../specifications/reference-review-79-review-workflow-persistence-smoke-v1_0.md)
+
+## Architecture Ancestor
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Manual Smoke Check
+
+- Select a fixture and edit notes; confirm notes persist after selecting away
+  and returning.
+- Approve a fixture using disposable or expected test fixture data; confirm
+  status persists and dirty artifact paths move to matching gold paths.
+- Decline a fixture; confirm status persists and dirty artifacts remain in
+  place.
+- Toggle show-approved and confirm approved fixture visibility changes.
+
+## Automated Smoke Tests
+
+- Fixture-store test verifies selected fixture notes load and save.
+- Status persistence test verifies approved, declined, and unreviewed states.
+- Filter model test verifies approved fixtures are hidden by default and shown
+  when show-approved is checked.
+
+## Automated Acceptance Tests
+
+- Notes write completion for an older selected fixture cannot update a newer
+  selected fixture's visible notes.
+- Approve persists approved status and performs dirty-to-gold artifact movement
+  with matching folder structure.
+- Decline persists declined status without moving artifacts.
+- Status badge view model matches selected fixture status.
+
+## Implementation Notes
+
+- Use temporary fixture copies for tests that move artifacts.
+- Avoid mutating canonical fixture data during automated tests.
+
+## Acceptance
+
+- paired automated tests pass
+- manual review workflow smoke is recorded where needed
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-79a-notes-persistence-route-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-79a-notes-persistence-route-v1_0.md
@@ -1,0 +1,21 @@
+# Reference Review Test Spec 79a: Notes Persistence Route (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 79a](../specifications/reference-review-79a-notes-persistence-route-v1_0.md)
+
+## Manual Smoke Check
+
+- Edit notes, select away, return, and confirm notes persisted.
+
+## Automated Smoke Tests
+
+- Notes load/save fixture-store test.
+- Stale selected-fixture notes completion test.
+
+## Acceptance
+
+- notes persistence tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md
@@ -1,0 +1,22 @@
+# Reference Review Test Spec 79b: Approve/Decline Persistence And Promotion Route (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 79b](../specifications/reference-review-79b-approve-decline-persistence-and-promotion-route-v1_0.md)
+
+## Manual Smoke Check
+
+- Approve and decline disposable fixture copies and verify status/artifact side
+  effects.
+
+## Automated Smoke Tests
+
+- Approve moves dirty artifacts to matching gold paths and persists approved.
+- Decline persists declined and does not move artifacts.
+
+## Acceptance
+
+- approve/decline persistence tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md
@@ -1,0 +1,22 @@
+# Reference Review Test Spec 79c: Status Badge And Approved Filter Route (v1.0)
+
+Status: Final test leaf after review pass 1
+
+## Paired Specification
+
+- [Reference Review Spec 79c](../specifications/reference-review-79c-status-badge-and-approved-filter-route-v1_0.md)
+
+## Manual Smoke Check
+
+- Toggle show-approved and confirm approved fixture visibility changes.
+- Select approved, declined, and unreviewed fixtures and confirm badge state.
+
+## Automated Smoke Tests
+
+- Filter model hides approved by default and shows approved when checked.
+- Badge state matches selected fixture status.
+
+## Acceptance
+
+- filter and badge tests pass
+- `git diff --check` passes

--- a/project/release-0.1.0a/test-specifications/reference-review-80-stabilization-merge-gate-v1_0.md
+++ b/project/release-0.1.0a/test-specifications/reference-review-80-stabilization-merge-gate-v1_0.md
@@ -1,0 +1,50 @@
+# Reference Review Test Spec 80: Stabilization Merge Gate (v1.0)
+
+Status: Final test leaf after review pass 2
+
+## Paired Specification
+
+- [Reference Review Spec 80](../specifications/reference-review-80-stabilization-merge-gate-v1_0.md)
+
+## Architecture Ancestor
+
+- [ACD: Reference Review Hybrid Stabilization](../architecture/acd-reference-review-hybrid-stabilization.md)
+
+## Manual Smoke Check
+
+- Launch the real app through `.venv/bin/impression-reference-review` with real
+  fixture data.
+- Confirm fixture list, renderable preview, non-renderable fixture context,
+  notes, approve/decline, status badge, and show-approved filtering behave as
+  expected.
+- Record the command and any notable environment assumptions in the PR.
+
+## Automated Smoke Tests
+
+- Run focused preview payload tests.
+- Run focused UI shell launch/routing tests.
+- Run focused notes/status/promotion tests.
+- Run focused display-control state and command-routing tests.
+- Run `git diff --check`.
+
+## Automated Acceptance Tests
+
+- The stabilization branch cannot be treated as merge-ready until Specs 76a,
+  76b, 77a, 77b, 78a, 78b, 79a, 79b, and 79c have their focused tests and
+  manual route evidence satisfied.
+- Validation evidence distinguishes helper-level tests from the real
+  console-launched GUI route.
+- Full Workbench Kit migration work is not included as a hidden prerequisite
+  for this merge gate.
+
+## Implementation Notes
+
+- This test spec is a merge gate, not product behavior. It should be satisfied
+  by the validation transcript, PR checklist, and final focused test results.
+
+## Acceptance
+
+- focused test set passes
+- real-entrypoint smoke is recorded
+- branch is pushed and PR is created only after stabilization evidence exists
+- `git diff --check` passes

--- a/src/impression/devtools/reference_review/preview_payload_builder.py
+++ b/src/impression/devtools/reference_review/preview_payload_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import json
+import struct
 import sys
 import tempfile
 from contextlib import contextmanager
@@ -14,6 +15,8 @@ from threading import Lock
 from types import ModuleType
 from typing import Any, Callable, Iterator
 
+import numpy as np
+
 from impression.mesh import Mesh, Polyline
 from impression.modeling import (
     SurfaceBody,
@@ -21,6 +24,10 @@ from impression.modeling import (
     preview_tessellation_request,
     tessellate_surface_body,
 )
+from impression.modeling.drawing2d import Path2D
+from impression.modeling.group import MeshGroup
+from impression.modeling.path3d import Path3D
+from impression.modeling.topology import Region, Section
 
 from .preview_payload import (
     PreviewPayload,
@@ -31,6 +38,7 @@ from .preview_payload import (
 
 PREVIEW_PAYLOAD_FORMAT = "impression.reference-review.preview-payload.v1"
 _PREVIEW_SOURCE_IMPORT_LOCK = Lock()
+_RENDERABLE_ARTIFACT_SUFFIXES = frozenset({".stl", ".impress"})
 
 
 @dataclass(frozen=True)
@@ -103,6 +111,27 @@ def load_impress_preview_datasets(artifact_path: Path) -> tuple[object, ...]:
     return tuple(tessellate_surface_body(body, request).mesh for body in loaded.bodies)
 
 
+def load_artifact_preview_dataset(request: PreviewPayloadRequest) -> LoadedPreviewDataset | None:
+    """Load the selected renderable artifact when a fixture has STL/.impress output."""
+
+    artifact_path = _first_renderable_artifact_path(request)
+    if artifact_path is None:
+        return None
+    if artifact_path.suffix.lower() == ".impress":
+        datasets = load_impress_preview_datasets(artifact_path)
+    elif artifact_path.suffix.lower() == ".stl":
+        datasets = (_load_stl_preview_mesh(artifact_path),)
+    else:
+        return None
+    if not datasets:
+        raise ValueError("artifact produced no preview datasets")
+    return LoadedPreviewDataset(
+        request=request,
+        datasets=tuple(datasets),
+        source_type=f"artifact:{artifact_path.suffix.lower()}",
+    )
+
+
 def build_impress_preview_result(generation: int, artifact_path: Path) -> ImpressPreviewBuildResult:
     """Build preview datasets for `.impress` artifacts in a non-UI worker."""
 
@@ -124,6 +153,7 @@ def load_preview_source(
     kwargs = {parameter.name: parameter.value for parameter in request.parameters}
     with _PREVIEW_SOURCE_IMPORT_LOCK:
         with _temporary_import_roots(_source_import_roots(request, import_roots)):
+            _evict_preview_source_modules(request)
             if "." in entrypoint and not request.source_path.is_file():
                 module_name, function_name = entrypoint.rsplit(".", 1)
                 module = importlib.import_module(module_name)
@@ -145,8 +175,23 @@ def tessellate_preview_source(
     datasets: list[Mesh | Polyline] = []
     tessellation_request = preview_tessellation_request(require_watertight=False)
 
+    def loop_to_polyline(loop_points: np.ndarray) -> Polyline:
+        pts = np.asarray(loop_points, dtype=float).reshape(-1, 2)
+        pts3 = np.column_stack([pts, np.zeros((pts.shape[0], 1), dtype=float)])
+        return Polyline(pts3, closed=True, color=None)
+
+    def region_to_polylines(region: Region) -> list[Polyline]:
+        normalized = region.normalized()
+        polylines = [loop_to_polyline(normalized.outer.points)]
+        polylines.extend(loop_to_polyline(hole.points) for hole in normalized.holes)
+        return polylines
+
     def visit(item: object) -> None:
         if item is None:
+            return
+        if isinstance(item, MeshGroup) or (hasattr(item, "to_meshes") and callable(getattr(item, "to_meshes"))):
+            for mesh in item.to_meshes():
+                visit(mesh)
             return
         if isinstance(item, Mesh):
             datasets.append(item)
@@ -161,13 +206,22 @@ def tessellate_preview_source(
             for record in item.items:
                 visit(record.body)
             return
-        if hasattr(item, "to_meshes") and callable(getattr(item, "to_meshes")):
-            for mesh in item.to_meshes():
-                visit(mesh)
+        if isinstance(item, Path2D):
+            datasets.append(item.to_polyline())
             return
         if hasattr(item, "to_polylines") and callable(getattr(item, "to_polylines")):
             for polyline in item.to_polylines():
                 visit(polyline)
+            return
+        if isinstance(item, Region):
+            datasets.extend(region_to_polylines(item))
+            return
+        if isinstance(item, Section):
+            for region in item.normalized().regions:
+                datasets.extend(region_to_polylines(region))
+            return
+        if isinstance(item, Path3D):
+            datasets.append(item.to_polyline())
             return
         if isinstance(item, (list, tuple, set)):
             for value in item:
@@ -194,8 +248,10 @@ def build_preview_dataset(
     """Load and tessellate a preview request, returning sanitized diagnostics."""
 
     try:
-        source = load_preview_source(request, import_roots=(() if cwd is None else (cwd,)))
-        dataset = tessellate_preview_source(request, source)
+        dataset = load_artifact_preview_dataset(request)
+        if dataset is None:
+            source = load_preview_source(request, import_roots=(() if cwd is None else (cwd,)))
+            dataset = tessellate_preview_source(request, source)
     except Exception as exc:
         return PreviewDatasetBuildResult(
             request=request,
@@ -301,6 +357,103 @@ def _load_module_from_path(path: Path, request: PreviewPayloadRequest) -> Module
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _first_renderable_artifact_path(request: PreviewPayloadRequest) -> Path | None:
+    for path in request.artifact_paths:
+        artifact_path = Path(path)
+        if artifact_path.suffix.lower() not in _RENDERABLE_ARTIFACT_SUFFIXES:
+            continue
+        if artifact_path.is_file():
+            return artifact_path
+    return None
+
+
+def _load_stl_preview_mesh(artifact_path: Path) -> Mesh:
+    data = artifact_path.read_bytes()
+    vertices, faces = _read_binary_stl(data)
+    if faces.size == 0:
+        vertices, faces = _read_ascii_stl(data)
+    if faces.size == 0:
+        raise ValueError("STL artifact has no faces")
+    return Mesh(
+        vertices=vertices,
+        faces=faces,
+        metadata={"source_artifact": artifact_path.as_posix()},
+    )
+
+
+def _read_binary_stl(data: bytes) -> tuple[np.ndarray, np.ndarray]:
+    if len(data) < 84:
+        return np.empty((0, 3), dtype=float), np.empty((0, 3), dtype=int)
+    triangle_count = struct.unpack_from("<I", data, 80)[0]
+    expected_size = 84 + triangle_count * 50
+    if triangle_count < 1 or expected_size != len(data):
+        return np.empty((0, 3), dtype=float), np.empty((0, 3), dtype=int)
+    vertices = np.empty((triangle_count * 3, 3), dtype=float)
+    faces = np.empty((triangle_count, 3), dtype=int)
+    offset = 84
+    for index in range(triangle_count):
+        values = struct.unpack_from("<12fH", data, offset)
+        vertices[index * 3 : index * 3 + 3] = np.asarray(values[3:12], dtype=float).reshape(3, 3)
+        faces[index] = (index * 3, index * 3 + 1, index * 3 + 2)
+        offset += 50
+    return vertices, faces
+
+
+def _read_ascii_stl(data: bytes) -> tuple[np.ndarray, np.ndarray]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        text = data.decode("latin-1", errors="ignore")
+    vertices: list[tuple[float, float, float]] = []
+    for line in text.splitlines():
+        parts = line.strip().split()
+        if len(parts) != 4 or parts[0].lower() != "vertex":
+            continue
+        try:
+            vertices.append((float(parts[1]), float(parts[2]), float(parts[3])))
+        except ValueError:
+            continue
+    usable_count = len(vertices) - (len(vertices) % 3)
+    if usable_count < 3:
+        return np.empty((0, 3), dtype=float), np.empty((0, 3), dtype=int)
+    vertex_array = np.asarray(vertices[:usable_count], dtype=float)
+    faces = np.arange(usable_count, dtype=int).reshape(-1, 3)
+    return vertex_array, faces
+
+
+def _evict_preview_source_modules(request: PreviewPayloadRequest) -> None:
+    source_paths = _preview_source_cache_paths(request)
+    if not source_paths:
+        return
+    for module_name, module in tuple(sys.modules.items()):
+        module_file = getattr(module, "__file__", None)
+        if not module_file:
+            continue
+        try:
+            module_path = Path(module_file).expanduser().resolve()
+        except OSError:
+            continue
+        if module_path in source_paths or _is_previous_preview_temp_module(module_path):
+            sys.modules.pop(module_name, None)
+
+
+def _preview_source_cache_paths(request: PreviewPayloadRequest) -> set[Path]:
+    paths = {Path(request.source_path).expanduser().resolve()}
+    metadata_paths = request.metadata.get("source_snapshot_paths", ())
+    if isinstance(metadata_paths, (list, tuple)):
+        for value in metadata_paths:
+            if isinstance(value, str):
+                paths.add(Path(value).expanduser().resolve())
+    original_subject = request.metadata.get("original_subject_path")
+    if isinstance(original_subject, str):
+        paths.add(Path(original_subject).expanduser().resolve())
+    return paths
+
+
+def _is_previous_preview_temp_module(path: Path) -> bool:
+    return any(part.startswith("impression-bench-preview-source-") for part in path.parts)
 
 
 def _source_import_roots(

--- a/src/impression/devtools/reference_review/ui/__init__.py
+++ b/src/impression/devtools/reference_review/ui/__init__.py
@@ -60,6 +60,9 @@ from .preview_bridge import (
     choose_preview_adapter,
 )
 from .preview_widget import (
+    PreviewCameraDisplayMetadata,
+    PreviewImageCaptureRecord,
+    PreviewImageFileReference,
     PreviewPaneVisibleState,
     PreviewRendererLifecycleState,
     PreviewRendererLifecycleWidget,
@@ -157,6 +160,9 @@ __all__ = [
     "PreviewDisplayCommandRecord",
     "PreviewDisplayControlBar",
     "PreviewDisplayOptions",
+    "PreviewCameraDisplayMetadata",
+    "PreviewImageCaptureRecord",
+    "PreviewImageFileReference",
     "PreviewRenderCommand",
     "PreviewRenderCommandKind",
     "PreviewRenderCommandQueue",

--- a/src/impression/devtools/reference_review/ui/preview_widget.py
+++ b/src/impression/devtools/reference_review/ui/preview_widget.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import json
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
 
 os.environ.setdefault("QT_OPENGL", "desktop")
 
@@ -104,6 +105,40 @@ class PreviewWrapperSmokeRecord:
     command: tuple[str, ...]
     expected_fixture_type: str = ".impress"
     verifies_lifecycle: bool = True
+
+
+@dataclass(frozen=True)
+class PreviewCameraDisplayMetadata:
+    width: int
+    height: int
+    payload_generation: int | None = None
+    fixture_id: str | None = None
+    display_options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "display_options", MappingProxyType(dict(self.display_options)))
+
+
+@dataclass(frozen=True)
+class PreviewImageFileReference:
+    path: Path
+    image_format: str
+    mime_type: str
+    byte_count: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", Path(self.path))
+
+
+@dataclass(frozen=True)
+class PreviewImageCaptureRecord:
+    file_reference: PreviewImageFileReference | None
+    metadata: PreviewCameraDisplayMetadata | None = None
+    diagnostic: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.file_reference is not None and self.diagnostic is None
 
 
 @dataclass(frozen=True)
@@ -284,6 +319,7 @@ class PreviewRendererLifecycleWidget(QWidget):
     """Widget host that owns one long-lived embedded preview renderer."""
 
     renderCommandApplied = Signal(object)
+    captureDiagnostic = Signal(object)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         _ensure_widget_app()
@@ -468,6 +504,38 @@ class PreviewRendererLifecycleWidget(QWidget):
         if callable(render):
             render()
 
+    def capture_visible_preview_image(
+        self,
+        output_dir: Path | str,
+        *,
+        basename: str = "preview-capture",
+        image_format: str = "png",
+    ) -> PreviewImageCaptureRecord:
+        if self._render_drain_scheduled or self._render_queue.state.pending_count:
+            return self._capture_diagnostic("preview-capture-busy")
+        if self._plotter is None or not self._payload_state.ready:
+            return self._capture_diagnostic("preview-capture-missing-render")
+        image_format = image_format.lower()
+        if image_format != "png":
+            return self._capture_diagnostic("preview-capture-unsupported-format")
+        output_root = Path(output_dir)
+        output_root.mkdir(parents=True, exist_ok=True)
+        output_path = _unique_capture_path(output_root, basename, image_format)
+        target = self._plotter if isinstance(self._plotter, QWidget) else self
+        pixmap = target.grab()
+        if pixmap.isNull():
+            return self._capture_diagnostic("preview-capture-empty-image")
+        if not pixmap.save(str(output_path), image_format.upper()):
+            return self._capture_diagnostic("preview-capture-save-failed")
+        metadata = self._capture_metadata(target)
+        reference = PreviewImageFileReference(
+            output_path,
+            image_format,
+            "image/png",
+            output_path.stat().st_size,
+        )
+        return PreviewImageCaptureRecord(reference, metadata)
+
     def set_preview_payload(
         self,
         payload: PreviewPayload,
@@ -475,6 +543,8 @@ class PreviewRendererLifecycleWidget(QWidget):
         renderer_factory: Callable[[QWidget], object] | None = None,
         previewer_factory: Callable[[], object] | None = None,
     ) -> PreviewWidgetPayloadState:
+        if payload.diagnostic is not None:
+            return self._fail_payload(payload, payload.diagnostic.message)
         if payload.payload_path is None:
             return self._fail_payload(payload, "preview-payload-missing-path")
         try:
@@ -499,6 +569,26 @@ class PreviewRendererLifecycleWidget(QWidget):
         except Exception as exc:
             return self._fail_payload(payload, str(exc) or exc.__class__.__name__)
 
+    def _capture_metadata(self, target: QWidget) -> PreviewCameraDisplayMetadata:
+        return PreviewCameraDisplayMetadata(
+            width=max(target.width(), 0),
+            height=max(target.height(), 0),
+            payload_generation=self._payload_state.generation,
+            fixture_id=self._payload_state.fixture_id,
+            display_options={
+                "show_object_fill": self._display_options.show_object_fill,
+                "show_object_edges": self._display_options.show_object_edges,
+                "show_gradient_background": self._display_options.show_gradient_background,
+                "color_mode": self._display_options.color_mode,
+                "lighting_mode": self._display_options.lighting_mode,
+            },
+        )
+
+    def _capture_diagnostic(self, code: str) -> PreviewImageCaptureRecord:
+        record = PreviewImageCaptureRecord(None, diagnostic=code)
+        self.captureDiagnostic.emit(record)
+        return record
+
     def dispose_renderer(self) -> None:
         self._render_queue.clear()
         self._render_drain_scheduled = False
@@ -508,10 +598,25 @@ class PreviewRendererLifecycleWidget(QWidget):
         self._renderer_state = PreviewRendererLifecycleState(disposed=True)
 
     def _fail_payload(self, payload: PreviewPayload, diagnostic: str) -> PreviewWidgetPayloadState:
+        sanitized = sanitize_error_text(diagnostic)
+        if (
+            self._payload_state.ready
+            and self._payload_state.fixture_id == payload.request.fixture_id
+            and self._current_datasets
+        ):
+            self._payload_state = PreviewWidgetPayloadState(
+                generation=self._payload_state.generation,
+                fixture_id=self._payload_state.fixture_id,
+                ready=True,
+                diagnostic=sanitized,
+            )
+            self._status.setText(f"Preview stale: {sanitized}")
+            self._status.show()
+            return self._payload_state
         self._payload_state = PreviewWidgetPayloadState(
             generation=payload.request.generation,
             fixture_id=payload.request.fixture_id,
-            diagnostic=sanitize_error_text(diagnostic),
+            diagnostic=sanitized,
         )
         self._current_datasets = []
         self._status.setText(f"Preview unavailable: {self._payload_state.diagnostic}")
@@ -742,6 +847,19 @@ def _should_use_pyvistaqt_preview() -> bool:
         os.environ.get("IMPRESSION_REFERENCE_REVIEW_FORCE_SOFTWARE") != "1"
         and qt_preview_supported_environment()
     )
+
+
+def _unique_capture_path(output_dir: Path, basename: str, image_format: str) -> Path:
+    safe_basename = "".join(
+        character if character.isalnum() or character in {"-", "_"} else "-"
+        for character in basename
+    )
+    candidate = output_dir / f"{safe_basename or 'preview-capture'}.{image_format}"
+    index = 2
+    while candidate.exists():
+        candidate = output_dir / f"{safe_basename or 'preview-capture'}-{index:02d}.{image_format}"
+        index += 1
+    return candidate
 
 
 def _apply_pyvistaqt_scene(

--- a/src/impression/devtools/reference_review/ui/qml/Main.qml
+++ b/src/impression/devtools/reference_review/ui/qml/Main.qml
@@ -157,7 +157,7 @@ ApplicationWindow {
                             }
                             Text {
                                 width: parent.width
-                                text: (modelData.status || "unreviewed") + " - " + (modelData.artifact_display_path || modelData.source_display_path)
+                                text: (modelData.status || "unreviewed") + " - " + (modelData.artifact_kind_label || modelData.source_display_path)
                                 color: "#565a51"
                                 font.pixelSize: 11
                                 elide: Text.ElideMiddle
@@ -244,7 +244,7 @@ ApplicationWindow {
                         anchors.centerIn: parent
                         width: Math.min(parent.width - 48, 520)
                         text: root.hasFixture && root.currentFixture().artifact_preview_url === ""
-                            ? "No STL preview available for " + root.currentFixture().artifact_display_path
+                            ? (root.currentFixture().preview_empty_message || "No STL or .impress preview is available.")
                             : root.selectedMessageText
                         horizontalAlignment: Text.AlignHCenter
                         wrapMode: Text.WordWrap

--- a/src/impression/devtools/reference_review/ui/shell.py
+++ b/src/impression/devtools/reference_review/ui/shell.py
@@ -63,6 +63,7 @@ options:
   --offscreen   use Qt's offscreen platform plugin
   -h, --help    show this help message and exit
 """
+_RENDERABLE_ARTIFACT_SUFFIXES = frozenset({".stl", ".impress"})
 
 
 @dataclass(frozen=True)
@@ -137,6 +138,42 @@ def map_artifact_evidence_rows(record: ReviewSourceModelRecord) -> tuple[Artifac
                 )
             )
     return tuple(rows)
+
+
+def _renderable_artifact_paths(record: ReviewSourceModelRecord) -> tuple[Path, ...]:
+    return tuple(
+        path for path in record.artifact_paths if path.suffix.lower() in _RENDERABLE_ARTIFACT_SUFFIXES
+    )
+
+
+def _fixture_artifact_kind_label(record: ReviewSourceModelRecord) -> str:
+    renderable_paths = _renderable_artifact_paths(record)
+    if renderable_paths:
+        return renderable_paths[0].name
+    expected = (record.expected_output or "").lower()
+    if "diagnostic" in expected:
+        return "diagnostic evidence"
+    if "evidence" in expected:
+        return "evidence payload"
+    if not record.artifact_paths:
+        return "no renderable artifact"
+    return "non-renderable artifact"
+
+
+def _fixture_preview_empty_message(record: ReviewSourceModelRecord) -> str:
+    renderable_paths = _renderable_artifact_paths(record)
+    if renderable_paths:
+        path = renderable_paths[0]
+        if path.is_file():
+            return ""
+        return f"Renderable artifact missing: {path.name}"
+    expected = (record.expected_output or "").lower()
+    if "diagnostic" in expected or "evidence" in expected:
+        return (
+            "Diagnostic/evidence fixture: no STL or .impress artifact to render. "
+            "Review the Context and Artifacts tabs."
+        )
+    return "No STL or .impress artifact is declared for this fixture."
 
 
 def _ensure_qt_app(argv: Sequence[str], *, offscreen: bool, widgets: bool = False) -> object:
@@ -395,7 +432,7 @@ class ReferenceReviewWindow(QWidget):
         self._fixture_databases = fixture_databases
         self._offscreen = offscreen
         self._interactive_preview_ready = True
-        self._selected_index = queue.selected_index if queue.selected_index is not None else -1
+        self._selected_index = -1
         self._all_fixture_items = _fixture_items_for_qml(queue, artifact_previews)
         self._show_approved = False
         self._visible_record_indices: list[int] = []
@@ -483,10 +520,14 @@ class ReferenceReviewWindow(QWidget):
         self.preview_frame.setMinimumSize(360, 260)
         self.preview_layout = QVBoxLayout(self.preview_frame)
         self.preview_layout.setContentsMargins(0, 0, 0, 0)
+        self.preview_stale_label = QLabel("Preview current.")
+        self.preview_stale_label.setObjectName("reviewPreviewStaleIndicator")
+        self.preview_stale_label.setStyleSheet("color: #9fb0c2; padding: 4px 8px;")
         self.preview_surface = InteractiveStlPreviewLabel(self.preview_frame)
         self.preview_surface.renderCommandApplied.connect(
             self._handle_preview_render_command_result
         )
+        self.preview_layout.addWidget(self.preview_stale_label)
         self.preview_layout.addWidget(self.preview_surface)
         main_layout.addWidget(self.preview_frame, 1, 0, 2, 1)
 
@@ -560,10 +601,7 @@ class ReferenceReviewWindow(QWidget):
         self.show()
         self.raise_()
         self.activateWindow()
-        if self._selected_index >= 0:
-            self._select_initial_fixture(self._selected_index)
-        else:
-            self._sync_properties()
+        self._sync_properties()
 
     def _select_initial_fixture(self, index: int) -> None:
         row = self._visible_row_for_record_index(index)
@@ -603,9 +641,10 @@ class ReferenceReviewWindow(QWidget):
         try:
             self.list_widget.clear()
             for row, item in enumerate(self._fixture_items):
+                artifact_label = item["artifact_kind_label"]
                 label = (
                     f"{item['fixture_id']} [{item['status']}]\n"
-                    f"{item['artifact_display_path'] or item['source_display_path']}"
+                    f"{artifact_label}"
                 )
                 widget_item = QListWidgetItem(label)
                 widget_item.setData(256, item["fixture_id"])
@@ -816,18 +855,28 @@ class ReferenceReviewWindow(QWidget):
         return True
 
     def _load_artifact_preview(self, item: dict[str, object]) -> None:
-        record = self.queue.records[self._selected_index]
-        artifact_path = record.artifact_paths[0] if record.artifact_paths else None
+        record_index = self._record_index_for_fixture_id(str(item.get("fixture_id", "")))
+        if record_index is None:
+            self.preview_surface.enqueue_render_command(
+                PreviewRenderCommand.clear("No fixture selected.")
+            )
+            return
+        record = self.queue.records[record_index]
+        renderable_paths = _renderable_artifact_paths(record)
+        artifact_path = renderable_paths[0] if renderable_paths else None
         live_artifact = artifact_path if artifact_path and artifact_path.is_file() else None
         self._preview_load_generation += 1
-        self.artifact_thumb.setText(str(item.get("artifact_display_path", "")))
+        self.artifact_thumb.setText(str(item.get("artifact_kind_label", "")))
         if item.get("artifact_evidence_text"):
             self.artifact_thumb.setText(str(item["artifact_evidence_text"]))
         self.preview_surface.prepare_artifact(live_artifact)
         self.preview_surface.enqueue_render_command(PreviewRenderCommand.loading())
+        self.preview_stale_label.setText("Preview loading...")
         self.preview_display_controls.set_ready(False)
         if live_artifact is None:
-            self.preview_surface.enqueue_render_command(PreviewRenderCommand.clear())
+            self.preview_surface.enqueue_render_command(
+                PreviewRenderCommand.clear(str(item.get("preview_empty_message", "")) or "No fixture selected.")
+            )
             return
         result = self._preview_controller.launch(record)
         if not result.accepted or result.future is None:
@@ -856,6 +905,12 @@ class ReferenceReviewWindow(QWidget):
         if generation != self._preview_load_generation:
             return
         self.preview_surface.set_artifact(artifact_path)
+
+    def _record_index_for_fixture_id(self, fixture_id: str) -> int | None:
+        for index, record in enumerate(self.queue.records):
+            if record.fixture_id == fixture_id:
+                return index
+        return None
 
     def _poll_preview_payloads(self) -> None:
         pending: list[Future[WorkerResultEnvelope]] = []
@@ -921,6 +976,7 @@ class ReferenceReviewWindow(QWidget):
             self._preview_poll_timer.start()
 
     def _apply_preview_payload_ready(self, event: PreviewPayloadReadyEvent) -> None:
+        self.preview_stale_label.setText("Preview current.")
         self.preview_surface.enqueue_render_command(
             PreviewRenderCommand.payload_ready(
                 event.payload,
@@ -929,6 +985,10 @@ class ReferenceReviewWindow(QWidget):
         )
 
     def _apply_preview_payload_failed(self, event: PreviewPayloadFailedEvent) -> None:
+        if self.preview_surface.payload_state.ready:
+            self.preview_stale_label.setText(f"Preview stale: {event.diagnostic.message}")
+            self.preview_display_controls.set_ready(True)
+            return
         self.preview_surface.enqueue_render_command(
             PreviewRenderCommand.failure(
                 f"Preview unavailable: {event.diagnostic.message}",
@@ -936,6 +996,7 @@ class ReferenceReviewWindow(QWidget):
                 identity=self._preview_controller.active_identity,
             )
         )
+        self.preview_stale_label.setText("Preview unavailable.")
         self.preview_display_controls.set_ready(False)
 
     def _handle_preview_render_command_result(
@@ -1078,6 +1139,9 @@ def _fixture_items_for_qml(
                 "methodology": item.methodology or "",
                 "render_description": item.render_description or "",
                 "artifact_display_path": item.artifact_display_path or "",
+                "artifact_kind_label": _fixture_artifact_kind_label(record),
+                "renderable_artifact": bool(_renderable_artifact_paths(record)),
+                "preview_empty_message": _fixture_preview_empty_message(record),
                 "artifact_preview_url": getattr(preview, "preview_url", "") if preview is not None else "",
                 "artifact_preview_status": getattr(preview, "diagnostic", None)
                 if preview is not None and getattr(preview, "diagnostic", None)

--- a/tests/test_reference_review_preview_payload_builder.py
+++ b/tests/test_reference_review_preview_payload_builder.py
@@ -108,6 +108,46 @@ def test_preview_dataset_builder_tessellates_real_dirty_impress_source_fixture(
     assert result.diagnostic is None
 
 
+def test_preview_dataset_builder_prefers_renderable_stl_artifact_over_source_dict(
+    project_root: Path,
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "triangle.stl"
+    artifact_path.write_text(
+        "\n".join(
+            (
+                "solid triangle",
+                "  facet normal 0 0 1",
+                "    outer loop",
+                "      vertex 0 0 0",
+                "      vertex 1 0 0",
+                "      vertex 0 1 0",
+                "    endloop",
+                "  endfacet",
+                "endsolid triangle",
+            )
+        )
+    )
+    source = tmp_path / "evidence_source.py"
+    source.write_text("def build():\n    return {'expected_output': 'diagnostic evidence'}\n")
+    record = ReviewSourceModelRecord(
+        fixture_id="fixture/artifact-first",
+        feature_name="Artifact First",
+        source_path=source,
+        artifact_paths=(artifact_path,),
+    )
+    request = _request_from_record(record, request_id=14)
+
+    result = build_preview_dataset(request, cwd=project_root)
+
+    assert result.ok
+    assert result.dataset is not None
+    assert result.dataset.source_type == "artifact:.stl"
+    assert result.dataset.dataset_count == 1
+    assert result.dataset.datasets[0].faces.tolist() == [[0, 1, 2]]
+    assert result.diagnostic is None
+
+
 def test_preview_dataset_builder_adds_workspace_root_for_fixture_imports(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_reference_review_ui_shell.py
+++ b/tests/test_reference_review_ui_shell.py
@@ -48,6 +48,7 @@ from impression.devtools.reference_review.ui import (
     map_artifact_evidence_rows,
     map_context_evidence_summary,
     PreviewRendererLifecycleWidget,
+    PreviewWidgetPayloadState,
     SoftwarePreviewSurface,
     preview_display_control_icon_record,
     preview_display_control_icon_records,
@@ -58,6 +59,7 @@ from impression.devtools.reference_review.ui import (
 from impression.devtools.reference_review import (
     LoadedPreviewDataset,
     PreviewPayload,
+    PreviewPayloadDiagnostic,
     PreviewPayloadRequest,
     build_impress_preview_result,
     write_preview_payload_file,
@@ -431,8 +433,54 @@ def test_shell_loads_fixture_file_into_selectable_queue(tmp_path: Path) -> None:
     assert result.launched
     assert diagnostics == ()
     assert root.property("queueStatusText") == "1 fixture shown"
+    assert root.property("selectedMessageText") == "No fixture selected."
+    assert not root.property("hasFixture")
+    queue = root.findChild(QObject, "fixtureQueueList")
+    assert isinstance(queue, QListWidget)
+    queue.setCurrentRow(0)
     assert root.property("selectedMessageText") == "demo/selectable"
     assert root.property("hasFixture")
+
+
+def test_shell_startup_does_not_launch_preview_controller(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    artifact = tmp_path / "part.impress"
+    artifact.write_text('{"format": "impress"}\n')
+    source = tmp_path / "model.py"
+    source.write_text("def build():\n    return None\n")
+    record = ReviewSourceModelRecord(
+        "demo/no-startup-preview",
+        "demo",
+        source,
+        artifact_paths=(artifact,),
+    )
+    launches = []
+
+    class StartupProbePreviewController:
+        active_identity = None
+
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def launch(self, record):
+            launches.append(record)
+            return SimpleNamespace(accepted=False, future=None, diagnostic="unexpected-launch")
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(shell, "PreviewPayloadProcessController", StartupProbePreviewController)
+
+    result = launch_workbench(fixture_records=(record,), offscreen=True)
+    root = result.engine.rootObjects()[0]
+
+    assert result.launched
+    assert launches == []
+    assert root.property("selectedMessageText") == "No fixture selected."
+    assert not root.property("hasFixture")
 
 
 def test_context_tab_shows_fixture_purpose_methodology_and_render_description(tmp_path: Path) -> None:
@@ -450,8 +498,11 @@ def test_context_tab_shows_fixture_purpose_methodology_and_render_description(tm
 
     result = launch_workbench(fixture_records=(record,), offscreen=True)
     root = result.engine.rootObjects()[0]
+    queue = root.findChild(QObject, "fixtureQueueList")
     context = root.findChild(QObject, "selectedFixtureContextText")
 
+    assert isinstance(queue, QListWidget)
+    queue.setCurrentRow(0)
     assert isinstance(context, QLabel)
     assert "Purpose: Validate bevel edge visibility." in context.text()
     assert "Methodology: Render with object edges enabled and inspect the silhouette." in context.text()
@@ -508,7 +559,7 @@ def test_fixture_queue_hides_approved_until_checkbox_is_checked(tmp_path: Path) 
     assert "demo/approved" not in "\n".join(queue.item(index).text() for index in range(queue.count()))
     assert root.property("reviewFixtures")[0]["status"] == "declined"
     assert root.property("reviewFixtures")[1]["status"] == "unreviewed"
-    assert root.property("selectedMessageText") == "demo/unreviewed"
+    assert root.property("selectedMessageText") == "No fixture selected."
     assert badge.text() == "UNREVIEWED"
     assert "#5f6368" in badge.styleSheet()
 
@@ -555,8 +606,11 @@ def test_decline_button_marks_fixture_file_declined(tmp_path: Path) -> None:
         offscreen=True,
     )
     root = result.engine.rootObjects()[0]
+    queue = root.findChild(QObject, "fixtureQueueList")
     decline = root.findChild(QObject, "declineFixtureButton")
 
+    assert isinstance(queue, QListWidget)
+    queue.setCurrentRow(0)
     assert isinstance(decline, QPushButton)
     decline.click()
 
@@ -609,6 +663,8 @@ def test_notes_editor_persists_to_selected_fixture_file_and_loads_on_selection(t
 
     assert isinstance(queue, QListWidget)
     assert isinstance(notes, QTextEdit)
+    assert notes.toPlainText() == ""
+    queue.setCurrentRow(0)
     assert notes.toPlainText() == "Existing first note."
 
     notes.setPlainText("Edited first note.")
@@ -1100,6 +1156,28 @@ def test_dirty_impress_fixture_launch_exposes_artifact_without_startup_render(pr
     assert fixtures[0]["artifact_preview_status"] == "ready"
 
 
+def test_diagnostic_fixture_queue_item_is_marked_non_renderable(project_root: Path) -> None:
+    source = project_root / "tests/reference_review_fixtures/stl_review_sources.py"
+    record = ReviewSourceModelRecord(
+        "loft/csg/diagnostic",
+        "loft",
+        source,
+        expected_output="diagnostic evidence",
+        purpose="Explain a refusal.",
+        methodology="Build diagnostic evidence only.",
+        render_description="No STL should render.",
+        artifact_paths=(),
+    )
+    queue = shell.FixtureQueueViewModel((record,))
+
+    item = shell._fixture_items_for_qml(queue)[0]
+
+    assert item["artifact_display_path"] == ""
+    assert item["artifact_kind_label"] == "diagnostic evidence"
+    assert item["renderable_artifact"] is False
+    assert "no STL or .impress artifact to render" in item["preview_empty_message"]
+
+
 def test_dirty_impress_fixture_selects_embedded_preview_surface(project_root: Path) -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     source = project_root / "tests/reference_review_fixtures/stl_review_sources.py"
@@ -1119,8 +1197,13 @@ def test_dirty_impress_fixture_selects_embedded_preview_surface(project_root: Pa
         offscreen=True,
     )
     root = result.engine.rootObjects()[0]
+    queue = root.findChild(QObject, "fixtureQueueList")
 
     assert result.launched
+    assert isinstance(queue, QListWidget)
+    assert root.property("selectedMessageText") == "No fixture selected."
+    assert not root.property("hasFixture")
+    queue.setCurrentRow(0)
     assert root.property("selectedMessageText") == "surfacebody/box"
     assert root.property("hasFixture")
     assert root.findChild(QObject, "openPreviewButton") is None
@@ -1379,6 +1462,131 @@ def test_preview_renderer_lifecycle_widget_applies_payload_without_recreating_re
     assert len(created) == 1
     assert len(created[0].datasets) == 2
     assert created[0].datasets[-1][0].n_faces == 1
+
+
+def test_preview_renderer_lifecycle_widget_failure_payload_shows_payload_diagnostic() -> None:
+    widget = PreviewRendererLifecycleWidget()
+    request = PreviewPayloadRequest(
+        owner="test",
+        request_id=1,
+        fixture_id="fixture",
+        generation=1,
+        source_path=Path("model.py"),
+        entrypoint="build",
+    )
+    payload = PreviewPayload.failure(
+        request,
+        PreviewPayloadDiagnostic(
+            "preview-source-load-failed",
+            "difference base must be a SurfaceBody.",
+            "fixture",
+            "test",
+            1,
+            1,
+        ),
+    )
+
+    state = widget.set_preview_payload(payload)
+
+    assert not state.ready
+    assert state.diagnostic == "difference base must be a SurfaceBody."
+    assert widget._status.text() == "Preview unavailable: difference base must be a SurfaceBody."
+
+
+def test_preview_renderer_lifecycle_widget_preserves_last_good_same_fixture_failure(
+    tmp_path: Path,
+) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    widget = PreviewRendererLifecycleWidget()
+    record = ReviewSourceModelRecord(
+        fixture_id="fixture/last-good",
+        feature_name="Last Good",
+        source_path=tmp_path / "model.py",
+    )
+    request = PreviewPayloadRequest.from_source_record(
+        record,
+        owner="preview-payload",
+        request_id=1,
+        generation=1,
+    )
+    loaded = LoadedPreviewDataset(
+        request=request,
+        datasets=(
+            Mesh(
+                vertices=np.asarray(((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0))),
+                faces=np.asarray(((0, 1, 2),)),
+            ),
+        ),
+        source_type="SurfaceBody",
+    )
+    payload = write_preview_payload_file(loaded, payload_dir=tmp_path)
+    ready_state = widget.set_preview_payload(payload)
+    failure = PreviewPayload.failure(
+        PreviewPayloadRequest.from_source_record(
+            record,
+            owner="preview-payload",
+            request_id=2,
+            generation=2,
+        ),
+        PreviewPayloadDiagnostic(
+            "preview-source-load-failed",
+            "temporary build failure",
+            record.fixture_id,
+            "preview-payload",
+            2,
+            2,
+        ),
+    )
+
+    failed_state = widget.set_preview_payload(failure)
+
+    assert ready_state.ready
+    assert failed_state.ready
+    assert failed_state.generation == 1
+    assert failed_state.diagnostic == "temporary build failure"
+    assert len(widget._current_datasets) == 1
+    assert widget._status.text() == "Preview stale: temporary build failure"
+
+
+def test_preview_image_capture_reports_missing_render(tmp_path: Path) -> None:
+    widget = PreviewRendererLifecycleWidget()
+
+    result = widget.capture_visible_preview_image(tmp_path)
+
+    assert not result.ok
+    assert result.diagnostic == "preview-capture-missing-render"
+
+
+def test_preview_image_capture_reports_busy_render_queue(tmp_path: Path) -> None:
+    widget = PreviewRendererLifecycleWidget()
+    widget.ensure_renderer(renderer_factory=lambda parent: QLabel("rendered", parent))
+    widget._payload_state = PreviewWidgetPayloadState(generation=1, fixture_id="fixture", ready=True)
+    widget._render_drain_scheduled = True
+
+    result = widget.capture_visible_preview_image(tmp_path)
+
+    assert not result.ok
+    assert result.diagnostic == "preview-capture-busy"
+
+
+def test_preview_image_capture_writes_local_png_with_metadata(tmp_path: Path) -> None:
+    widget = PreviewRendererLifecycleWidget()
+    widget.resize(320, 240)
+    widget.ensure_renderer(renderer_factory=lambda parent: QLabel("rendered", parent))
+    widget._payload_state = PreviewWidgetPayloadState(generation=3, fixture_id="fixture", ready=True)
+    widget.show()
+
+    result = widget.capture_visible_preview_image(tmp_path, basename="test preview")
+
+    assert result.ok
+    assert result.file_reference is not None
+    assert result.metadata is not None
+    assert result.file_reference.path.is_file()
+    assert result.file_reference.mime_type == "image/png"
+    assert result.file_reference.byte_count > 0
+    assert result.file_reference.path.name == "test-preview.png"
+    assert result.metadata.fixture_id == "fixture"
+    assert result.metadata.payload_generation == 3
 
 
 def test_preview_renderer_lifecycle_widget_applies_payload_to_software_surface(
@@ -1964,6 +2172,7 @@ def test_window_preview_retries_latest_coalesced_request(tmp_path: Path) -> None
     window._preview_future_identities = {}
     window._pending_preview_record = None
     window._preview_controller = CoalescingPreviewController()
+    window._selected_index = 0
 
     window._load_artifact_preview(window._fixture_items[0])
     window._load_artifact_preview(window._fixture_items[0])
@@ -2069,9 +2278,11 @@ def test_shell_next_button_selects_fixture_record(tmp_path: Path) -> None:
     root = result.engine.rootObjects()[0]
     next_button = root.findChild(QObject, "nextFixtureButton")
 
-    assert root.property("selectedMessageText") == "demo/first"
+    assert root.property("selectedMessageText") == "No fixture selected."
     assert next_button is not None
     assert isinstance(next_button, QPushButton)
+    next_button.click()
+    assert root.property("selectedMessageText") == "demo/first"
     next_button.click()
     assert root.property("selectedMessageText") == "demo/second"
 


### PR DESCRIPTION
## Summary
- add the hybrid stabilization ACD, progression plan, specs, and paired test specs
- make Reference Review launch with no selected fixture and no preview controller work until explicit selection
- preserve last-good preview state on same-fixture failures and harden stale/coalesced preview handoff tests

## Verification
- .venv/bin/python -m pytest tests/test_reference_review_ui_shell.py tests/test_reference_review_preview_payload_builder.py -q
- .venv/bin/impression-reference-review --fixture-file tests/reference_review_fixtures/dirty-stl-fixtures.json --check
- .venv/bin/impression-reference-review --fixture-file tests/reference_review_fixtures/dirty-stl-fixtures.json --check --offscreen
- timed real-platform Qt smoke with fixture selection
- git diff --check