### PR TITLE
Prepare v1.0.0a2 corrective release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-### Release Line Cleanup
+## 1.0.0a2
+
+### Corrective Release Line Cleanup
 
 - Removed the accidentally merged shelved SDF/endcap experiment, its public
   exports, examples, fixtures, and core runtime dependency. The experiment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "impression"
-version = "1.0.0a1"
+version = "1.0.0a2"
 description = "Parametric modeling playground with real-time preview and STL export goals."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/impression/__init__.py
+++ b/src/impression/__init__.py
@@ -12,7 +12,7 @@ from ._config import ensure_user_config
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.0a1"
+__version__ = "1.0.0a2"
 
 # Allow VTK to load side-by-side libs without crashing and repair any missing symlinked dylibs.
 os.environ.setdefault("VTK_PYTHON_ALLOW_DUPLICATE_LIBS", "1")


### PR DESCRIPTION
Refs #230.

## Candidate scope

- bump package and runtime versions to `1.0.0a2`
- finalize the corrective release-line changelog
- retain the release regression gate proving the SDF/endcap experiment is absent

This is intentionally a **draft release-candidate PR**. Do not merge, tag, or publish until candidate validation is reviewed and explicitly approved.

## Artifact validation

Built locally from commit `e3e521b`:

- `impression-1.0.0a2-py3-none-any.whl`
  - SHA-256 `c80c72dca931eb403ecf23a1e80beae49be1a145643336f598a2000ebe6f7d1c`
- `impression-1.0.0a2.tar.gz`
  - SHA-256 `50c6b01bec226a3c36a102773853ff35a02434af893c13dd6e3a21a2f83dddbc`
- `impression-docs-v1.0.0a2.zip`
  - SHA-256 `14c8671557734173c9b6247024121ee6d03b5b45d47b2ec82b593b8a901f7e9e`

## Validation

- exact candidate wheel installed into a fresh Python 3.13 venv
- runtime and package metadata both report `1.0.0a2`
- module and executable CLI entrypoints pass
- `pip check` passes
- core modeling imports without hinges or SDF
- SDF import fails as expected
- wheel and sdist contain no `sdf.py`, `extrude.py`, or `_profile2d.py`
- candidate sdist rebuilds into a clean `1.0.0a2` wheel
- docs ZIP contains the expected `docs/` tree
- repository installer clean-install smoke passes as `1.0.0a2`
- 29 configured CI tests pass locally
- 33 desktop-preview/modeling/CLI tests pass locally

One deliberately invalid combined test environment produced a preview assertion (`QT_OPENGL=software` versus the macOS test contract of `desktop`); rerunning CI and desktop suites in their intended environments passed completely.