### PR TITLE
Route exact release references through macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,34 @@ on:
     branches: [ main, working ]
 
 jobs:
+  candidate-suite:
+    runs-on: macos-14
+    env:
+      CMAKE_ARGS: "-DMANIFOLD_PAR=OFF"
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      PYTHONPATH: "src"
+      PYVISTA_OFF_SCREEN: "true"
+      QT_OPENGL: "software"
+      QT_QPA_PLATFORM: "offscreen"
+    steps:
+      - name: Checkout exact reference artifacts
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install candidate dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run full candidate suite
+        run: python -m pytest
+
   build-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       CMAKE_ARGS: "-DMANIFOLD_PAR=OFF"
       LIBGL_ALWAYS_SOFTWARE: "1"
@@ -28,24 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-
-      - name: Install Qt runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            fonts-dejavu-core \
-            libegl1 \
-            libgl1 \
-            libxkbcommon-x11-0 \
-            libxcb-cursor0 \
-            libxcb-icccm4 \
-            libxcb-image0 \
-            libxcb-keysyms1 \
-            libxcb-randr0 \
-            libxcb-render-util0 \
-            libxcb-shape0 \
-            libxcb-xinerama0 \
-            libxcb-xfixes0
 
       - name: Install test dependencies
         run: |

--- a/project/release-1.0.0a3/planning/progression.md
+++ b/project/release-1.0.0a3/planning/progression.md
@@ -78,6 +78,8 @@ separate completion state.
   - Specification: [Fix 13A](../specifications/fix-13a-release-artifact-build-qualification-v1_0.md)
 - [x] Make the preview PNG help assertion independent of CI terminal width and ANSI rendering.
   - Test specification: [Fix 13A Test](../test-specifications/fix-13a-release-artifact-build-qualification-v1_0.md)
+- [x] Run exact serialized-reference comparisons on macOS while retaining Linux build and integration CI.
+  - Specification: [Fix 13A](../specifications/fix-13a-release-artifact-build-qualification-v1_0.md)
 - [ ] Pass the complete tag-triggered test and artifact-qualification jobs.
   - Test specification: [Fix 13A Test](../test-specifications/fix-13a-release-artifact-build-qualification-v1_0.md)
 - [ ] [Fix 13B: Qualified Prerelease Publication](../specifications/fix-13b-qualified-prerelease-publication-v1_0.md)

--- a/project/release-1.0.0a3/specifications/fix-13a-release-artifact-build-qualification-v1_0.md
+++ b/project/release-1.0.0a3/specifications/fix-13a-release-artifact-build-qualification-v1_0.md
@@ -69,7 +69,7 @@ Owns:
 
 - release test gate, one-time wheel/sdist/docs build, artifact manifest, content/version
   inspection, fresh wheel/sdist/docs smoke, hydrated Git LFS references, and the
-  Linux runtime/font dependencies required by the complete candidate suite.
+  platform routing required by the complete candidate suite.
 
 Does not own:
 
@@ -101,8 +101,10 @@ Does not own:
 - Build each artifact once after tests pass; tag and project version must match.
 - Every release-job checkout hydrates Git LFS so qualification reads reference
   artifact contents rather than pointer records.
-- Linux qualification installs DejaVu Sans; the default Arial request may use
-  Liberation Sans or DejaVu Sans when Arial is unavailable.
+- The default Arial request may use Liberation Sans or DejaVu Sans when Arial
+  is unavailable, preserving text behavior in Linux environments.
+- Exact serialized-reference comparison runs on the macOS authoring platform;
+  Linux CI retains package build, installer, CLI, and reference-review integration coverage.
 - Qualify wheel and sdist in separate fresh environments; install the docs ZIP to temp.
 - Manifest records names, types, versions, and hashes; forbidden experiment payload fails.
 
@@ -176,8 +178,8 @@ Does not own:
 ## Acceptance Criteria
 
 - Tests pass before one-time artifact build.
-- The complete Linux test job runs against hydrated LFS references and a
-  glyph-capable font, with help assertions independent of terminal rendering width.
+- The complete macOS test job runs against hydrated LFS references; Linux CI
+  retains its integration route, and help assertions are independent of terminal styling.
 - Exact wheel, sdist, and docs outputs pass version/content/install smoke.
 - A qualified immutable manifest is emitted only after every check passes.
 

--- a/project/release-1.0.0a3/test-specifications/fix-13a-release-artifact-build-qualification-v1_0.md
+++ b/project/release-1.0.0a3/test-specifications/fix-13a-release-artifact-build-qualification-v1_0.md
@@ -28,16 +28,17 @@ artifacts pass version/content/clean-install checks before a manifest is emitted
 ## Automated Smoke Tests
 
 - Parse tag/project versions, build artifacts once, and assert expected manifest entries.
-- Assert every release checkout enables Git LFS and the Linux test environment
-  installs the glyph-capable font used by text fixtures.
+- Assert every release checkout enables Git LFS, exact references run on macOS,
+  and the existing Linux build/integration job remains present.
 - Exercise preview help at a fixed terminal width with ANSI color disabled.
 - Install the wheel and run import/model-load/preview-export non-GUI smoke.
 
 ## Automated Acceptance Tests
 
 - Unit/helper behavior: version agreement, artifact names/hashes/types, forbidden payload.
-- Integrated route behavior: hydrated references and Linux font support feed the
-  full tests; tests precede build; exact outputs feed wheel/sdist/docs smoke.
+- Integrated route behavior: hydrated references feed the macOS full suite while
+  Linux retains build/integration coverage; tests precede build; exact outputs
+  feed wheel/sdist/docs smoke.
 - Failure behavior: injected test/build/content/install failure prevents manifest emission.
 
 ## App-Type Proof

--- a/tests/test_cli_preview.py
+++ b/tests/test_cli_preview.py
@@ -6,6 +6,7 @@ import sys
 import time
 from pathlib import Path
 
+import click
 import pytest
 from typer.testing import CliRunner
 
@@ -121,10 +122,10 @@ def test_preview_help_describes_one_shot_png_export() -> None:
     result = CliRunner().invoke(
         cli.app,
         ["preview", "--help"],
-        env={"COLUMNS": "160"},
+        env={"COLUMNS": "160", "FORCE_COLOR": "1"},
         color=False,
     )
-    normalized_output = " ".join(result.output.replace("│", " ").split())
+    normalized_output = " ".join(click.unstyle(result.output).replace("│", " ").split())
 
     assert result.exit_code == 0, result.output
     assert "--screenshot" in normalized_output

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -177,7 +177,7 @@ def test_release_workflow_gates_build_qualification_and_publication(project_root
     workflow = (project_root / ".github" / "workflows" / "release.yml").read_text()
 
     assert workflow.count("uses: actions/checkout@v4\n        with:\n          lfs: true") == 3
-    assert "fonts-dejavu-core" in workflow
+    assert "test:\n    runs-on: macos-14" in workflow
     assert "qualify:\n    needs: test" in workflow
     assert "publish:\n    needs: qualify" in workflow
     assert workflow.index("Run full candidate suite") < workflow.index("Build package artifacts once")
@@ -192,6 +192,16 @@ def test_release_workflow_gates_build_qualification_and_publication(project_root
     assert "prerelease: ${{ steps.verify.outputs.prerelease }}" in workflow
     assert "files: ${{ steps.verify.outputs.files }}" in workflow
     assert "Verify published release metadata" in workflow
+
+
+def test_pr_ci_runs_exact_references_on_the_authoring_platform(project_root: Path) -> None:
+    workflow = (project_root / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert "candidate-suite:\n    runs-on: macos-14" in workflow
+    assert "Checkout exact reference artifacts" in workflow
+    assert "lfs: true" in workflow
+    assert "Run full candidate suite\n        run: python -m pytest" in workflow
+    assert "build-test:\n    runs-on: ubuntu-latest" in workflow
 
 
 def test_installed_candidate_smoke_invokes_the_real_cli_app(project_root: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve exact STL reference comparison on its macOS authoring platform
- add a hosted macOS full-candidate PR gate with hydrated LFS artifacts
- retain the existing Linux build, installer, CLI, and reference-review integration job
- normalize forced ANSI styling in the preview help assertion

## Evidence
- complete Linux regeneration: 102 reference STL constructors passed; 32 platform serializations differed
- exact macOS local candidate suite: 1718 passed in 186.85s
- focused workflow/help tests: 12 passed
- failed release run published no release or assets