### PR TITLE
Honor named hole identities in loft planning

### DIFF
--- a/project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md
+++ b/project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md
@@ -84,6 +84,20 @@ Current relevant code paths:
 This works for simple symmetric or similarly authored profiles. It is not a
 complete topology correspondence model.
 
+## Implemented Loop Identity Boundary
+
+`PlannedLoopRef` now carries the stable `TopologyPath.id` and the authored path
+record for actual named holes. During each station interval, the planner maps
+authored topology paths onto canonical hole-loop slots, validates unique names,
+and resolves matching names before any geometric assignment. The existing
+minimum-cost matcher receives only anonymous residue.
+
+Duplicate names and unequal source/target name sets fail with stable
+`invalid_hole_identity` diagnostics before ambiguity enumeration. The resolved
+loop references are stored in the immutable plan consumed by surface execution;
+the executor does not repeat or override hole pairing. Unnamed sections retain
+their existing deterministic geometric behavior.
+
 ## Failure Mode
 
 The failure is not merely that a heuristic can pick the wrong start vertex. The
@@ -2919,6 +2933,8 @@ Split decision:
 
 ## Change History
 
+- 2026-08-04: Added the implemented identity-first named-hole planner boundary
+  and executor handoff contract.
 - 2026-05-27: Critically reviewed active manifest candidates beyond score
   thresholds and split the topology builder core API into point and segment
   builder specs.

--- a/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
+++ b/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
@@ -115,6 +115,7 @@ internal resets.
 ## Conformance Checklist
 
 - [ ] Implementation conforms to the target architecture.
+- [x] Fix 03 named-hole identity resolution conforms through public planning and execution routes.
 - [x] Final leaves are independently reviewed and canonicalized.
 - [x] Paired test specs point to canonical leaves.
 - [x] Final progression preserves prerequisite order.
@@ -134,6 +135,9 @@ through public routes with closed-valid surface output.
 
 ## Change History
 
+- 2026-08-04 - Completed Fix 03 and reconciled canonical loft correspondence
+  architecture. Reason: named holes now resolve before anonymous geometric
+  residue and execution consumes the resolved plan.
 - 2026-08-04 - Linked the final dependency-ordered progression. Reason: preserve identity, lineage, junction-plan, and execution prerequisites.
 - 2026-08-04 - Recorded the six canonical loft leaves and archived split parents after fixed-point review.
 - 2026-08-04 - Linked the full-template Fix 03-06 and paired test drafts. Reason: complete the `do specs` creation handoff.

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -72,13 +72,13 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 03: Named Hole Identity Pairing
 
-- [ ] Implement identity-first named-hole pairing with deterministic anonymous fallback and conflict diagnostics.
+- [x] Implement identity-first named-hole pairing with deterministic anonymous fallback and conflict diagnostics.
   - Specification: [Fix 03](../specifications/fix-03-named-hole-identity-pairing-v1_0.md)
   - Prerequisites: none
-- [ ] Wire pairing through public loft planning and `Loft(...)` execution.
-- [ ] Validate crossed-name, duplicate/conflict, and anonymous-control routes.
+- [x] Wire pairing through public loft planning and `Loft(...)` execution.
+- [x] Validate crossed-name, duplicate/conflict, and anonymous-control routes.
   - Test specification: [Fix 03 Test](../test-specifications/fix-03-named-hole-identity-pairing-v1_0.md)
-- [ ] Update progression and loft ACD status after route validation.
+- [x] Update progression and loft ACD status after route validation.
 
 ### Fix 06: Expanded Planner Configuration Propagation
 

--- a/project/release-1.0.0a4/specifications/fix-03-named-hole-identity-pairing-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-03-named-hole-identity-pairing-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 03: Named Hole Identity Pairing
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Source artifact: [GitHub issue #244](https://github.com/kellyjanderson/Impression/issues/244)

--- a/project/release-1.0.0a4/test-specifications/fix-03-named-hole-identity-pairing-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-03-named-hole-identity-pairing-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 03 Test: Named Hole Identity Pairing
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 03: Named Hole Identity Pairing](../specifications/fix-03-named-hole-identity-pairing-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
@@ -58,8 +58,8 @@ This canonical paired contract verifies the complete retained feature boundary f
 ## Acceptance
 
 - [x] Feature spec is canonical.
-- [ ] Route-level proof exists for the declared app type.
-- [ ] Helper-only tests cannot satisfy this contract.
-- [ ] Every observable result and feature acceptance criterion is asserted through the intended route.
-- [ ] Failure, stale-result, refusal, or no-cut behavior is covered where applicable.
-- [ ] Focused and full configured suites pass without mesh modeling fallback or test-model workaround geometry.
+- [x] Route-level proof exists for the declared app type.
+- [x] Helper-only tests cannot satisfy this contract.
+- [x] Every observable result and feature acceptance criterion is asserted through the intended route.
+- [x] Failure, stale-result, refusal, or no-cut behavior is covered where applicable.
+- [x] Focused and full configured suites pass without mesh modeling fallback or test-model workaround geometry.

--- a/src/impression/modeling/loft.py
+++ b/src/impression/modeling/loft.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Iterable, Mapping, Sequence
 
@@ -831,6 +831,8 @@ class PlannedLoopRef:
 
     kind: str  # actual | synthetic
     index: int
+    identity: str | None = None
+    topology_path: TopologyPath | None = None
 
 
 @dataclass(frozen=True)
@@ -3274,6 +3276,7 @@ def loft_plan_sections(
     probabilistic_selected_candidate_ids: dict[str, str] = {}
     identity_resolved_pair_count = 0
     identity_residual_region_count = 0
+    hole_identity_resolved_pair_count = 0
     previous_interval_vectors: dict[int, np.ndarray] | None = None
     for idx in range(len(planned_stations) - 1):
         prev_station = planned_stations[idx]
@@ -3285,6 +3288,14 @@ def loft_plan_sections(
             len(curr_regions),
         )
         interval = (idx, idx + 1)
+        prev_hole_identity_index = _section_hole_identity_index(
+            effective_stations[idx].section,
+            side="source",
+        )
+        curr_hole_identity_index = _section_hole_identity_index(
+            effective_stations[idx + 1].section,
+            side="target",
+        )
         try:
             (
                 identity_assignment,
@@ -3442,6 +3453,43 @@ def loft_plan_sections(
                 detail=message,
             )
 
+        for region_pair in tuple(
+            _as_planned_region_pair(transition, interval=interval, pair_index=pair_index)
+            for pair_index, transition in enumerate(transitions)
+        ):
+            if region_pair.prev_region_ref.kind != "actual" or region_pair.curr_region_ref.kind != "actual":
+                continue
+            prev_region_index = region_pair.prev_region_ref.index
+            curr_region_index = region_pair.curr_region_ref.index
+            assignment, resolved_count = _identity_first_hole_assignment(
+                list(prev_regions[prev_region_index][1:]),
+                list(curr_regions[curr_region_index][1:]),
+                prev_hole_identity_index[prev_region_index],
+                curr_hole_identity_index[curr_region_index],
+            )
+            if assignment is None:
+                continue
+            selected_hole_assignments[_transition_hole_assignment_key(region_pair)] = assignment
+            hole_identity_resolved_pair_count += resolved_count
+        if selected_hole_assignments:
+            transitions = _pair_sections_for_transition(
+                prev_regions,
+                curr_regions,
+                split_merge_mode=split_merge_mode,
+                split_merge_steps=split_merge_steps,
+                split_merge_bias=split_merge_bias,
+                ambiguity_mode=resolved_ambiguity_mode,
+                ambiguity_cost_profile=ambiguity_cost_profile,
+                ambiguity_max_branches=int(ambiguity_max_branches),
+                fairness_mode=fairness_mode,
+                fairness_weight=fairness_weight,
+                skeleton_mode=skeleton_mode,
+                fairness_iterations=fairness_iterations,
+                region_order_override=region_order_override,
+                many_to_many_assignment_override=selected_region_assignment,
+                hole_assignment_overrides=selected_hole_assignments,
+            )
+
         if ambiguity_class == "none":
             hole_candidate_reports: list[LoftAmbiguityCandidate] = []
             for region_pair in tuple(
@@ -3449,6 +3497,8 @@ def loft_plan_sections(
                 for pair_index, transition in enumerate(transitions)
             ):
                 if region_pair.prev_region_ref.kind != "actual" or region_pair.curr_region_ref.kind != "actual":
+                    continue
+                if _transition_hole_assignment_key(region_pair) in selected_hole_assignments:
                     continue
                 prev_region = prev_regions[region_pair.prev_region_ref.index]
                 curr_region = curr_regions[region_pair.curr_region_ref.index]
@@ -3531,10 +3581,18 @@ def loft_plan_sections(
             transitions=transitions,
         )
         planned_pairs = tuple(
-            _as_planned_region_pair(
-                transition,
-                interval=interval,
-                pair_index=pair_index,
+            _annotate_planned_hole_identities(
+                _as_planned_region_pair(
+                    transition,
+                    interval=interval,
+                    pair_index=pair_index,
+                ),
+                prev_hole_identity_index[
+                    transition.prev_region_ref.index
+                ] if transition.prev_region_ref.kind == "actual" else (),
+                curr_hole_identity_index[
+                    transition.curr_region_ref.index
+                ] if transition.curr_region_ref.kind == "actual" else (),
             )
             for pair_index, transition in enumerate(transitions)
         )
@@ -3614,6 +3672,7 @@ def loft_plan_sections(
             "probabilistic_selected_candidate_ids": dict(probabilistic_selected_candidate_ids),
             "identity_resolved_pair_count": int(identity_resolved_pair_count),
             "identity_residual_region_count": int(identity_residual_region_count),
+            "hole_identity_resolved_pair_count": int(hole_identity_resolved_pair_count),
             "region_topology_case_counts": _count_region_topology_cases(planned_transitions),
             "region_action_counts": _count_region_actions(planned_transitions),
             "fairness_mode": fairness_mode,
@@ -4238,6 +4297,7 @@ def _loft_execute_plan_surface(
             "station_count": len(plan.stations),
             "identity_resolved_pair_count": plan.metadata.get("identity_resolved_pair_count", 0),
             "identity_residual_region_count": plan.metadata.get("identity_residual_region_count", 0),
+            "hole_identity_resolved_pair_count": plan.metadata.get("hole_identity_resolved_pair_count", 0),
             "loft_boundary_graph": boundary_graph.canonical_payload(),
             "loft_cap_validity": cap_validity.canonical_payload(),
             "loft_closure_evidence": closure_evidence.canonical_payload(),
@@ -6070,6 +6130,120 @@ def _loop_sort_key(loop: np.ndarray) -> tuple[float, ...]:
     # Rounded coordinates keep deterministic ordering while avoiding noise-level drift.
     signature = tuple(np.round(anchor.reshape(-1), decimals=9).tolist())
     return (float(centroid[0]), float(centroid[1]), area, perimeter, *signature)
+
+
+def _section_hole_identity_index(
+    section: Section,
+    *,
+    side: str,
+) -> tuple[tuple[tuple[str | None, TopologyPath | None], ...], ...]:
+    """Map authored topology paths onto canonical hole-loop slots."""
+
+    canonical = _canonicalize_section_for_loft(section)
+    assert isinstance(canonical, Section)
+    indexed: list[list[tuple[str | None, TopologyPath | None]]] = [
+        [(None, None) for _hole in region.holes]
+        for region in canonical.regions
+    ]
+    candidates = tuple(
+        (region_index, hole_index, _loop_sort_key(hole.points)[:4])
+        for region_index, region in enumerate(canonical.regions)
+        for hole_index, hole in enumerate(region.holes)
+    )
+    identities: dict[str, tuple[int, int]] = {}
+    for path in tuple(section.metadata.get("topology_paths", ())):
+        if not isinstance(path, TopologyPath):
+            continue
+        path_key = _loop_sort_key(path.to_section_loop().points)[:4]
+        matches = tuple(
+            (region_index, hole_index)
+            for region_index, hole_index, hole_key in candidates
+            if np.allclose(path_key, hole_key, atol=1e-8, rtol=0.0)
+        )
+        if not matches:
+            continue
+        if len(matches) != 1:
+            raise ValueError(
+                f"invalid_hole_identity contradictory path {path.id!r} matches multiple normalized holes"
+            )
+        slot = matches[0]
+        identity = str(path.id).strip()
+        if not identity:
+            raise ValueError("invalid_hole_identity authored hole id must be non-empty")
+        if identity in identities:
+            raise ValueError(
+                f"invalid_hole_identity duplicate {side} id {identity!r} on holes "
+                f"{identities[identity]} and {slot}"
+            )
+        if indexed[slot[0]][slot[1]][0] is not None:
+            raise ValueError(f"invalid_hole_identity contradictory paths map to hole {slot}")
+        identities[identity] = slot
+        indexed[slot[0]][slot[1]] = (identity, path)
+    return tuple(tuple(region) for region in indexed)
+
+
+def _identity_first_hole_assignment(
+    prev_holes: list[np.ndarray],
+    curr_holes: list[np.ndarray],
+    prev_identity_slots: tuple[tuple[str | None, TopologyPath | None], ...],
+    curr_identity_slots: tuple[tuple[str | None, TopologyPath | None], ...],
+) -> tuple[tuple[int, ...] | None, int]:
+    """Resolve matching named holes before assigning anonymous residue geometrically."""
+
+    if len(prev_holes) != len(curr_holes):
+        return None, 0
+    prev_by_id = {
+        identity: index
+        for index, (identity, _path) in enumerate(prev_identity_slots)
+        if identity is not None
+    }
+    curr_by_id = {
+        identity: index
+        for index, (identity, _path) in enumerate(curr_identity_slots)
+        if identity is not None
+    }
+    if not prev_by_id and not curr_by_id:
+        return None, 0
+    if set(prev_by_id) != set(curr_by_id):
+        raise ValueError(
+            "invalid_hole_identity contradictory exact id sets "
+            f"source={tuple(sorted(prev_by_id))} target={tuple(sorted(curr_by_id))}"
+        )
+    assignment: list[int | None] = [None] * len(prev_holes)
+    for identity in sorted(prev_by_id):
+        assignment[prev_by_id[identity]] = curr_by_id[identity]
+    prev_residue = tuple(index for index, value in enumerate(assignment) if value is None)
+    used_targets = {value for value in assignment if value is not None}
+    curr_residue = tuple(index for index in range(len(curr_holes)) if index not in used_targets)
+    if len(prev_residue) != len(curr_residue):
+        raise ValueError("invalid_hole_identity named pairing left contradictory anonymous residue")
+    if prev_residue:
+        residue_order = _minimum_cost_hole_assignment(
+            [prev_holes[index] for index in prev_residue],
+            [curr_holes[index] for index in curr_residue],
+        )
+        for source_offset, target_offset in enumerate(residue_order):
+            assignment[prev_residue[source_offset]] = curr_residue[target_offset]
+    return tuple(int(value) for value in assignment if value is not None), len(prev_by_id)
+
+
+def _annotate_planned_hole_identities(
+    region_pair: PlannedRegionPair,
+    prev_identity_slots: tuple[tuple[str | None, TopologyPath | None], ...],
+    curr_identity_slots: tuple[tuple[str | None, TopologyPath | None], ...],
+) -> PlannedRegionPair:
+    loop_pairs: list[PlannedLoopPair] = []
+    for loop_pair in region_pair.loop_pairs:
+        prev_ref = loop_pair.prev_loop_ref
+        curr_ref = loop_pair.curr_loop_ref
+        if prev_ref.kind == "actual" and prev_ref.index > 0 and prev_ref.index - 1 < len(prev_identity_slots):
+            identity, path = prev_identity_slots[prev_ref.index - 1]
+            prev_ref = replace(prev_ref, identity=identity, topology_path=path)
+        if curr_ref.kind == "actual" and curr_ref.index > 0 and curr_ref.index - 1 < len(curr_identity_slots):
+            identity, path = curr_identity_slots[curr_ref.index - 1]
+            curr_ref = replace(curr_ref, identity=identity, topology_path=path)
+        loop_pairs.append(replace(loop_pair, prev_loop_ref=prev_ref, curr_loop_ref=curr_ref))
+    return replace(region_pair, loop_pairs=tuple(loop_pairs))
 
 
 def _identity_first_region_assignment(

--- a/tests/test_loft_identity_first_pairing.py
+++ b/tests/test_loft_identity_first_pairing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from impression.modeling import Loft, Loop, Region, Section, Station, SurfaceBody
+from impression.modeling import Loft, Loop, Region, Section, Station, SurfaceBody, TopologyPath
 from impression.modeling.loft import LoftPlanningBlockedError, loft_plan_sections
 
 
@@ -120,3 +120,97 @@ def test_anonymous_ambiguity_still_obeys_branch_limit() -> None:
 
     with pytest.raises(LoftPlanningBlockedError, match="candidate_enumeration_limit"):
         loft_plan_sections((source, target), samples=3, ambiguity_max_branches=2)
+
+
+def _named_rectangle(identity: str, center_x: float) -> TopologyPath:
+    return TopologyPath.from_points(
+        (
+            (center_x - 0.5, -0.5),
+            (center_x + 0.5, -0.5),
+            (center_x + 0.5, 0.5),
+            (center_x - 0.5, 0.5),
+        ),
+        id=identity,
+    )
+
+
+def _section_with_named_holes(paths: tuple[TopologyPath, ...]) -> Section:
+    outer = TopologyPath.from_points(((-5.0, -4.0), (5.0, -4.0), (5.0, 4.0), (-5.0, 4.0)), id="outer")
+    return Section(
+        regions=(
+            Region(
+                outer=outer.to_section_loop(),
+                holes=tuple(path.to_section_loop() for path in paths),
+            ),
+        ),
+        metadata={"topology_paths": (outer, *paths)},
+    )
+
+
+def _hole_stations(source: Section, target: Section) -> tuple[Station, Station]:
+    frame = {
+        "u": (1.0, 0.0, 0.0),
+        "v": (0.0, 1.0, 0.0),
+        "n": (0.0, 0.0, 1.0),
+    }
+    return (
+        Station(t=0.0, section=source, origin=(0.0, 0.0, 0.0), **frame),
+        Station(t=1.0, section=target, origin=(0.0, 0.0, 2.0), **frame),
+    )
+
+
+def test_named_holes_that_exchange_positions_pair_by_identity() -> None:
+    source = _section_with_named_holes((_named_rectangle("hole-a", -2.0), _named_rectangle("hole-b", 2.0)))
+    target = _section_with_named_holes((_named_rectangle("hole-a", 2.0), _named_rectangle("hole-b", -2.0)))
+
+    plan = loft_plan_sections(_hole_stations(source, target), samples=16, fairness_mode="off")
+    hole_pairs = plan.transitions[0].region_pairs[0].loop_pairs[1:]
+
+    assert tuple(pair.prev_loop_ref.identity for pair in hole_pairs) == ("hole-a", "hole-b")
+    assert tuple(pair.curr_loop_ref.identity for pair in hole_pairs) == ("hole-a", "hole-b")
+    assert tuple(float(pair.curr_loop[:, 0].mean()) for pair in hole_pairs) == pytest.approx((2.0, -2.0))
+    assert plan.metadata["hole_identity_resolved_pair_count"] == 2
+
+    body = Loft(
+        (0.0, 1.0),
+        _hole_stations(source, target),
+        (source, target),
+        samples=16,
+        fairness_mode="off",
+        cap_ends=True,
+    )
+    assert body.kernel_metadata()["hole_identity_resolved_pair_count"] == 2
+
+
+def test_duplicate_and_missing_named_hole_identities_fail_before_geometry() -> None:
+    source = _section_with_named_holes((_named_rectangle("hole-a", -2.0), _named_rectangle("hole-a", 2.0)))
+    target = _section_with_named_holes((_named_rectangle("hole-a", -2.0), _named_rectangle("hole-b", 2.0)))
+    with pytest.raises(ValueError, match="invalid_hole_identity duplicate source id 'hole-a'"):
+        loft_plan_sections(_hole_stations(source, target), samples=16)
+
+    source = _section_with_named_holes((_named_rectangle("hole-a", -2.0), _named_rectangle("hole-b", 2.0)))
+    target = _section_with_named_holes((_named_rectangle("hole-a", -2.0), _named_rectangle("hole-c", 2.0)))
+    with pytest.raises(ValueError, match="invalid_hole_identity contradictory exact id sets"):
+        loft_plan_sections(_hole_stations(source, target), samples=16)
+
+
+def test_named_pairing_leaves_anonymous_residue_to_geometric_fallback() -> None:
+    source_named = _named_rectangle("named", -2.0)
+    target_named = _named_rectangle("named", 2.0)
+    anonymous_source = _named_rectangle("unused-source", 0.0).to_section_loop()
+    anonymous_target = _named_rectangle("unused-target", 0.0).to_section_loop()
+    outer = TopologyPath.from_points(((-5.0, -4.0), (5.0, -4.0), (5.0, 4.0), (-5.0, 4.0)), id="outer")
+    source = Section(
+        regions=(Region(outer=outer.to_section_loop(), holes=(source_named.to_section_loop(), anonymous_source)),),
+        metadata={"topology_paths": (outer, source_named)},
+    )
+    target = Section(
+        regions=(Region(outer=outer.to_section_loop(), holes=(target_named.to_section_loop(), anonymous_target)),),
+        metadata={"topology_paths": (outer, target_named)},
+    )
+
+    plan = loft_plan_sections(_hole_stations(source, target), samples=16, fairness_mode="off")
+    hole_pairs = plan.transitions[0].region_pairs[0].loop_pairs[1:]
+
+    assert tuple(pair.prev_loop_ref.identity for pair in hole_pairs) == ("named", None)
+    assert tuple(float(pair.curr_loop[:, 0].mean()) for pair in hole_pairs) == pytest.approx((2.0, 0.0))


### PR DESCRIPTION
## Summary
- extend PlannedLoopRef with stable topology-path identity
- index named holes against canonical section loops before geometric assignment
- resolve exact names first and limit minimum-cost matching to anonymous residue
- emit stable duplicate and contradictory identity diagnostics
- prove public planner and Loft executor agreement for crossed named holes
- finalize Fix 03 specs, progression, ACD progress, and canonical architecture

## Verification
- `12 passed` focused identity-first tests
- `171 passed` loft planner/executor suite
- `1736 passed` full repository suite
- `22 passed` documentation/spec/focused closeout suite
- focused XML/HTML coverage refreshed under `project/coverage/loft-fix03/`

Closes #244