### PR TITLE
Propagate loft planner configuration through expansion

### DIFF
--- a/project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md
+++ b/project/release-0.1.0a/architecture/loft-topology-point-correspondence-architecture.md
@@ -2931,8 +2931,25 @@ Split decision:
 - Cohesion reason: helper methods should be specified together as one public
   authoring surface over the same topology path record family.
 
+## Planner Configuration Propagation
+
+Public loft planning constructs one immutable `LoftPlannerOptions` value after
+boundary validation. Direct transition pairing, split/merge station expansion,
+synthetic region/loop pairing, and ambiguity-report pairing all consume that
+same value; nested helpers do not define planner-policy defaults. In particular,
+`ambiguity_max_branches` remains a hard caller-owned candidate bound throughout
+the call graph.
+
+The plan stores the effective options as canonical metadata. Candidate-limit
+refusals report the effective cap and transition location, including whether the
+limit was reached during original-station expansion or a later expanded-plan
+interval. This makes configuration drift observable without changing existing
+public argument names or defaults.
+
 ## Change History
 
+- 2026-08-04: Added the implemented immutable planner-options boundary and
+  direct/nested/synthetic propagation contract.
 - 2026-08-04: Added the implemented identity-first named-hole planner boundary
   and executor handoff contract.
 - 2026-05-27: Critically reviewed active manifest candidates beyond score

--- a/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
+++ b/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
@@ -116,6 +116,7 @@ internal resets.
 
 - [ ] Implementation conforms to the target architecture.
 - [x] Fix 03 named-hole identity resolution conforms through public planning and execution routes.
+- [x] Fix 06 immutable planner configuration propagates through direct, expanded, and nested pairing routes.
 - [x] Final leaves are independently reviewed and canonicalized.
 - [x] Paired test specs point to canonical leaves.
 - [x] Final progression preserves prerequisite order.
@@ -135,6 +136,10 @@ through public routes with closed-valid surface output.
 
 ## Change History
 
+- 2026-08-04 - Completed Fix 06 and reconciled canonical loft correspondence
+  architecture. Reason: public planner settings now become one immutable options
+  value consumed by direct, expanded, and synthetic transition pairing; branch
+  limit failures identify the effective cap and planning location.
 - 2026-08-04 - Completed Fix 03 and reconciled canonical loft correspondence
   architecture. Reason: named holes now resolve before anonymous geometric
   residue and execution consumes the resolved plan.

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -82,13 +82,13 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 06: Expanded Planner Configuration Propagation
 
-- [ ] Implement immutable propagation of public planner configuration through every expanded planning route.
+- [x] Implement immutable propagation of public planner configuration through every expanded planning route.
   - Specification: [Fix 06](../specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md)
   - Prerequisites: none
-- [ ] Wire options through direct, nested-expansion, and ambiguity-enumeration library routes.
-- [ ] Validate below-, at-, and above-limit public planner behavior.
+- [x] Wire options through direct, nested-expansion, and ambiguity-enumeration library routes.
+- [x] Validate below-, at-, and above-limit public planner behavior.
   - Test specification: [Fix 06 Test](../test-specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md)
-- [ ] Update progression and loft ACD status after route validation.
+- [x] Update progression and loft ACD status after route validation.
 
 ### Fix 08A: Loft Difference Trim-Fragment Construction
 

--- a/project/release-1.0.0a4/specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 06: Expanded Planner Configuration Propagation
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Source artifact: [GitHub issue #246](https://github.com/kellyjanderson/Impression/issues/246)

--- a/project/release-1.0.0a4/test-specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 06 Test: Expanded Planner Configuration Propagation
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 06: Expanded Planner Configuration Propagation](../specifications/fix-06-expanded-planner-configuration-propagation-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
@@ -57,8 +57,8 @@ This canonical paired contract verifies the complete retained feature boundary f
 ## Acceptance
 
 - [x] Feature spec is canonical.
-- [ ] Route-level proof exists for the declared app type.
-- [ ] Helper-only tests cannot satisfy this contract.
-- [ ] Every observable result and feature acceptance criterion is asserted through the intended route.
-- [ ] Failure, stale-result, refusal, or no-cut behavior is covered where applicable.
-- [ ] Focused and full configured suites pass without mesh modeling fallback or test-model workaround geometry.
+- [x] Route-level proof exists for the declared app type.
+- [x] Helper-only tests cannot satisfy this contract.
+- [x] Every observable result and feature acceptance criterion is asserted through the intended route.
+- [x] Failure, stale-result, refusal, or no-cut behavior is covered where applicable.
+- [x] Focused and full configured suites pass without mesh modeling fallback or test-model workaround geometry.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -62,6 +62,7 @@ from .drawing2d import (
 )
 from .loft import (
     Loft,
+    LoftPlannerOptions,
     Station,
     PlannedStation,
     PlannedLoopRef,
@@ -1279,6 +1280,7 @@ __all__ = [
     "RailConflictDiagnostic",
     "RailResolutionResult",
     "RailSource",
+    "LoftPlannerOptions",
     "PointLifecycleEvent",
     "PointLifecycleState",
     "LoftFamilyIntentEvidence",

--- a/src/impression/modeling/loft.py
+++ b/src/impression/modeling/loft.py
@@ -63,6 +63,36 @@ class RailSource(str, Enum):
 
 
 @dataclass(frozen=True)
+class LoftPlannerOptions:
+    """Validated planner configuration shared by every transition-planning call."""
+
+    split_merge_mode: str
+    split_merge_steps: int
+    split_merge_bias: float
+    ambiguity_mode: str
+    ambiguity_cost_profile: str
+    ambiguity_max_branches: int
+    fairness_mode: str
+    fairness_weight: float
+    skeleton_mode: str
+    fairness_iterations: int
+
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "split_merge_mode": self.split_merge_mode,
+            "split_merge_steps": int(self.split_merge_steps),
+            "split_merge_bias": float(self.split_merge_bias),
+            "ambiguity_mode": self.ambiguity_mode,
+            "ambiguity_cost_profile": self.ambiguity_cost_profile,
+            "ambiguity_max_branches": int(self.ambiguity_max_branches),
+            "fairness_mode": self.fairness_mode,
+            "fairness_weight": float(self.fairness_weight),
+            "skeleton_mode": self.skeleton_mode,
+            "fairness_iterations": int(self.fairness_iterations),
+        }
+
+
+@dataclass(frozen=True)
 class RailConflictDiagnostic:
     reason: str
     source_ref: str
@@ -3225,14 +3255,25 @@ def loft_plan_sections(
         if disambiguation_seed is None
         else int(disambiguation_seed)
     )
+    planner_options = LoftPlannerOptions(
+        split_merge_mode=split_merge_mode,
+        split_merge_steps=int(split_merge_steps),
+        split_merge_bias=float(split_merge_bias),
+        ambiguity_mode=resolved_ambiguity_mode,
+        ambiguity_cost_profile=ambiguity_cost_profile,
+        ambiguity_max_branches=int(ambiguity_max_branches),
+        fairness_mode=fairness_mode,
+        fairness_weight=float(fairness_weight),
+        skeleton_mode=skeleton_mode,
+        fairness_iterations=int(fairness_iterations),
+    )
 
     effective_stations = list(stations)
     if split_merge_mode == "resolve":
         effective_stations = _expand_split_merge_stations(
             stations=effective_stations,
             samples=samples,
-            split_merge_steps=split_merge_steps,
-            split_merge_bias=split_merge_bias,
+            options=planner_options,
         )
         _validate_section_stations(effective_stations)
 
@@ -3425,16 +3466,7 @@ def loft_plan_sections(
             transitions = _pair_sections_for_transition(
                 prev_regions,
                 curr_regions,
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=resolved_ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=int(ambiguity_max_branches),
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=planner_options,
                 region_order_override=region_order_override,
                 many_to_many_assignment_override=selected_region_assignment,
                 hole_assignment_overrides=selected_hole_assignments,
@@ -3475,16 +3507,7 @@ def loft_plan_sections(
             transitions = _pair_sections_for_transition(
                 prev_regions,
                 curr_regions,
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=resolved_ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=int(ambiguity_max_branches),
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=planner_options,
                 region_order_override=region_order_override,
                 many_to_many_assignment_override=selected_region_assignment,
                 hole_assignment_overrides=selected_hole_assignments,
@@ -3561,16 +3584,7 @@ def loft_plan_sections(
                     transitions = _pair_sections_for_transition(
                         prev_regions,
                         curr_regions,
-                        split_merge_mode=split_merge_mode,
-                        split_merge_steps=split_merge_steps,
-                        split_merge_bias=split_merge_bias,
-                        ambiguity_mode=resolved_ambiguity_mode,
-                        ambiguity_cost_profile=ambiguity_cost_profile,
-                        ambiguity_max_branches=int(ambiguity_max_branches),
-                        fairness_mode=fairness_mode,
-                        fairness_weight=fairness_weight,
-                        skeleton_mode=skeleton_mode,
-                        fairness_iterations=fairness_iterations,
+                        options=planner_options,
                         region_order_override=region_order_override,
                         many_to_many_assignment_override=selected_region_assignment,
                         hole_assignment_overrides=selected_hole_assignments,
@@ -3658,6 +3672,7 @@ def loft_plan_sections(
             "ambiguity_selection_policy": ambiguity_selection_policy,
             "ambiguity_cost_profile": ambiguity_cost_profile,
             "ambiguity_max_branches": int(ambiguity_max_branches),
+            "planner_options": planner_options.canonical_payload(),
             "disambiguation_mode": disambiguation_mode,
             "disambiguation_seed": int(resolved_disambiguation_seed),
             "probabilistic_trials": int(probabilistic_trials),
@@ -3719,14 +3734,25 @@ def loft_plan_ambiguities(
     _validate_ambiguity_max_branches(ambiguity_max_branches)
     _validate_section_stations(stations)
     _validate_station_hole_topology(stations)
+    planner_options = LoftPlannerOptions(
+        split_merge_mode=split_merge_mode,
+        split_merge_steps=int(split_merge_steps),
+        split_merge_bias=float(split_merge_bias),
+        ambiguity_mode="auto",
+        ambiguity_cost_profile=ambiguity_cost_profile,
+        ambiguity_max_branches=int(ambiguity_max_branches),
+        fairness_mode="local",
+        fairness_weight=0.2,
+        skeleton_mode="auto",
+        fairness_iterations=12,
+    )
 
     effective_stations = list(stations)
     if split_merge_mode == "resolve":
         effective_stations = _expand_split_merge_stations(
             stations=effective_stations,
             samples=samples,
-            split_merge_steps=split_merge_steps,
-            split_merge_bias=split_merge_bias,
+            options=planner_options,
         )
         _validate_section_stations(effective_stations)
 
@@ -3773,12 +3799,7 @@ def loft_plan_ambiguities(
             transitions = _pair_sections_for_transition(
                 prev_regions,
                 curr_regions,
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode="auto",
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=int(ambiguity_max_branches),
+                options=planner_options,
             )
         except ValueError:
             continue
@@ -6021,9 +6042,10 @@ def _expand_split_merge_stations(
     *,
     stations: list[Station],
     samples: int,
-    split_merge_steps: int,
-    split_merge_bias: float,
+    options: LoftPlannerOptions,
 ) -> list[Station]:
+    split_merge_steps = options.split_merge_steps
+    split_merge_bias = options.split_merge_bias
     if len(stations) < 2 or split_merge_steps <= 1:
         return stations
 
@@ -6040,13 +6062,31 @@ def _expand_split_merge_stations(
             expanded.append(curr)
             continue
 
-        transitions = _pair_sections_for_transition(
-            prev_regions,
-            curr_regions,
-            split_merge_mode="resolve",
-            split_merge_steps=split_merge_steps,
-            split_merge_bias=split_merge_bias,
-        )
+        try:
+            transitions = _pair_sections_for_transition(
+                prev_regions,
+                curr_regions,
+                options=options,
+            )
+        except ValueError as exc:
+            detail = str(exc)
+            if "unsupported_topology_ambiguity" not in detail:
+                raise
+            ambiguity_class = _classify_region_transition_ambiguity(
+                prev_regions=[region[0] for region in prev_regions],
+                curr_regions=[region[0] for region in curr_regions],
+                ambiguity_max_branches=options.ambiguity_max_branches,
+                ambiguity_cost_profile=options.ambiguity_cost_profile,
+            )
+            raise ValueError(
+                "Unsupported topology transition: unsupported_topology_ambiguity "
+                f"(interval {idx}->{idx + 1}; ambiguity_class={ambiguity_class}; "
+                f"tie_break_stage={_ambiguity_failure_stage(detail)}; "
+                f"candidate_count_after_pruning={_ambiguity_failure_candidate_count(detail)}; "
+                f"ambiguity_max_branches={options.ambiguity_max_branches}; "
+                f"planner_location=split_merge_expansion:{idx}->{idx + 1}; "
+                f"effective_options={options.canonical_payload()}; detail={detail})"
+            ) from exc
         u0 = float(np.clip(split_merge_bias - 0.2, 0.0, 1.0))
         u1 = float(np.clip(split_merge_bias + 0.2, 0.0, 1.0))
         if u1 <= u0:
@@ -6339,20 +6379,19 @@ def _pair_sections_for_transition(
     prev_regions: list[list[np.ndarray]],
     curr_regions: list[list[np.ndarray]],
     *,
-    split_merge_mode: str,
-    split_merge_steps: int,
-    split_merge_bias: float,
-    ambiguity_mode: str = "auto",
-    ambiguity_cost_profile: str = "balanced",
-    ambiguity_max_branches: int = 64,
-    fairness_mode: str = "local",
-    fairness_weight: float = 0.2,
-    skeleton_mode: str = "auto",
-    fairness_iterations: int = 12,
+    options: LoftPlannerOptions,
     region_order_override: tuple[int, ...] | None = None,
     many_to_many_assignment_override: tuple[int, ...] | None = None,
     hole_assignment_overrides: dict[tuple[str, int, str, int], tuple[int, ...]] | None = None,
 ) -> list[_PairedSectionTransition]:
+    split_merge_mode = options.split_merge_mode
+    split_merge_steps = options.split_merge_steps
+    split_merge_bias = options.split_merge_bias
+    ambiguity_cost_profile = options.ambiguity_cost_profile
+    ambiguity_max_branches = options.ambiguity_max_branches
+    fairness_mode = options.fairness_mode
+    fairness_weight = options.fairness_weight
+    fairness_iterations = options.fairness_iterations
     prev_count = len(prev_regions)
     curr_count = len(curr_regions)
     transitions: list[_PairedSectionTransition] = []
@@ -6391,16 +6430,7 @@ def _pair_sections_for_transition(
             paired = _pair_region_loops_for_transition(
                 prev_regions[prev_idx],
                 curr_regions[curr_idx],
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=ambiguity_max_branches,
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=options,
                 hole_assignment_override=hole_assignment_overrides.get(
                     ("actual", prev_idx, "actual", curr_idx)
                 ),
@@ -6453,16 +6483,7 @@ def _pair_sections_for_transition(
             paired = _pair_region_loops_for_transition(
                 prev_regions[prev_idx],
                 curr_regions[curr_idx],
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=ambiguity_max_branches,
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=options,
                 hole_assignment_override=hole_assignment_overrides.get(
                     ("actual", prev_idx, "actual", curr_idx)
                 ),
@@ -6484,16 +6505,7 @@ def _pair_sections_for_transition(
             paired = _pair_region_loops_for_transition(
                 synthetic_prev,
                 curr_regions[curr_idx],
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=ambiguity_max_branches,
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=options,
                 hole_assignment_override=None,
             )
             transitions.append(
@@ -6546,16 +6558,7 @@ def _pair_sections_for_transition(
             paired = _pair_region_loops_for_transition(
                 prev_regions[prev_idx],
                 curr_regions[curr_idx],
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=ambiguity_max_branches,
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=options,
                 hole_assignment_override=hole_assignment_overrides.get(
                     ("actual", prev_idx, "actual", curr_idx)
                 ),
@@ -6577,16 +6580,7 @@ def _pair_sections_for_transition(
             paired = _pair_region_loops_for_transition(
                 prev_regions[prev_idx],
                 synthetic_curr,
-                split_merge_mode=split_merge_mode,
-                split_merge_steps=split_merge_steps,
-                split_merge_bias=split_merge_bias,
-                ambiguity_mode=ambiguity_mode,
-                ambiguity_cost_profile=ambiguity_cost_profile,
-                ambiguity_max_branches=ambiguity_max_branches,
-                fairness_mode=fairness_mode,
-                fairness_weight=fairness_weight,
-                skeleton_mode=skeleton_mode,
-                fairness_iterations=fairness_iterations,
+                options=options,
                 hole_assignment_override=None,
             )
             transitions.append(
@@ -6607,21 +6601,20 @@ def _pair_region_loops_for_transition(
     prev_region_loops: list[np.ndarray],
     curr_region_loops: list[np.ndarray],
     *,
-    split_merge_mode: str,
-    split_merge_steps: int,
-    split_merge_bias: float,
-    ambiguity_mode: str = "auto",
-    ambiguity_cost_profile: str = "balanced",
-    ambiguity_max_branches: int = 64,
-    fairness_mode: str = "local",
-    fairness_weight: float = 0.2,
-    skeleton_mode: str = "auto",
-    fairness_iterations: int = 12,
+    options: LoftPlannerOptions,
     hole_assignment_override: tuple[int, ...] | None = None,
 ) -> _PairedRegionLoops:
+    split_merge_mode = options.split_merge_mode
+    split_merge_steps = options.split_merge_steps
+    split_merge_bias = options.split_merge_bias
+    ambiguity_cost_profile = options.ambiguity_cost_profile
+    ambiguity_max_branches = options.ambiguity_max_branches
+    fairness_mode = options.fairness_mode
+    fairness_weight = options.fairness_weight
+    fairness_iterations = options.fairness_iterations
     # Step 1 (Spec 19): fairness/skeleton controls are surfaced and propagated.
     # Optimization behavior is introduced in follow-up steps.
-    _ = (fairness_mode, fairness_weight, skeleton_mode, fairness_iterations)
+    _ = options.skeleton_mode
 
     prev_outer = prev_region_loops[0]
     curr_outer = curr_region_loops[0]

--- a/tests/test_loft.py
+++ b/tests/test_loft.py
@@ -1491,7 +1491,66 @@ def test_loft_plan_sections_records_explicit_ambiguity_controls_in_metadata():
     assert plan.metadata["ambiguity_mode"] == "fail"
     assert plan.metadata["ambiguity_cost_profile"] == "distance_first"
     assert plan.metadata["ambiguity_max_branches"] == 17
+    assert plan.metadata["planner_options"]["ambiguity_max_branches"] == 17
     assert "ambiguity_class_counts" in plan.metadata
+
+
+def test_staged_one_to_four_to_seven_propagates_exact_branch_cap() -> None:
+    def multi_region_section(center_xs: tuple[float, ...]) -> Section:
+        return Section(
+            tuple(
+                as_section(make_rect(size=(0.5, 0.5), center=(center_x, 0.0))).regions[0]
+                for center_x in center_xs
+            )
+        )
+
+    stations = tuple(
+        Station(
+            t=t,
+            section=multi_region_section(center_xs),
+            origin=(0.0, 0.0, t),
+            u=(1.0, 0.0, 0.0),
+            v=(0.0, 1.0, 0.0),
+            n=(0.0, 0.0, 1.0),
+        )
+        for t, center_xs in (
+            (0.0, (0.0,)),
+            (0.5, (-3.0, -1.0, 1.0, 3.0)),
+            (1.0, (-4.0, -2.7, -1.3, 0.0, 1.3, 2.7, 4.0)),
+        )
+    )
+
+    with pytest.raises(ValueError) as small_exc:
+        loft_plan_sections(
+            stations,
+            samples=8,
+            split_merge_mode="resolve",
+            ambiguity_max_branches=3,
+        )
+    assert "ambiguity_max_branches=3" in str(small_exc.value)
+    assert "planner_location=split_merge_expansion:0->1" in str(small_exc.value)
+    assert "'ambiguity_max_branches': 3" in str(small_exc.value)
+
+    with pytest.raises(LoftPlanningBlockedError) as large_exc:
+        loft_plan_sections(
+            stations,
+            samples=8,
+            split_merge_mode="resolve",
+            ambiguity_max_branches=4096,
+        )
+    assert "interval 10->11" in str(large_exc.value)
+    assert "ambiguity_max_branches=4096" in str(large_exc.value)
+    assert "ambiguity_max_branches=64" not in str(large_exc.value)
+
+    for sufficient_cap in (5040, 6000):
+        plan = loft_plan_sections(
+            stations,
+            samples=8,
+            split_merge_mode="resolve",
+            ambiguity_max_branches=sufficient_cap,
+        )
+        assert len(plan.stations) == 19
+        assert plan.metadata["planner_options"]["ambiguity_max_branches"] == sufficient_cap
 
 
 def test_loft_plan_sections_records_explicit_fairness_controls_in_metadata():

--- a/tests/test_loft_identity_first_pairing.py
+++ b/tests/test_loft_identity_first_pairing.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import numpy as np
 import pytest
 
-from impression.modeling import Loft, Loop, Region, Section, Station, SurfaceBody, TopologyPath
+from impression.modeling import Loft, LoftPlannerOptions, Loop, Region, Section, Station, SurfaceBody, TopologyPath
 from impression.modeling.loft import LoftPlanningBlockedError, loft_plan_sections
 
 
@@ -120,6 +122,27 @@ def test_anonymous_ambiguity_still_obeys_branch_limit() -> None:
 
     with pytest.raises(LoftPlanningBlockedError, match="candidate_enumeration_limit"):
         loft_plan_sections((source, target), samples=3, ambiguity_max_branches=2)
+
+
+def test_loft_planner_options_are_immutable_and_have_a_canonical_diagnostic_payload() -> None:
+    options = LoftPlannerOptions(
+        split_merge_mode="resolve",
+        split_merge_steps=6,
+        split_merge_bias=0.4,
+        ambiguity_mode="auto",
+        ambiguity_cost_profile="balanced",
+        ambiguity_max_branches=17,
+        fairness_mode="global",
+        fairness_weight=0.35,
+        skeleton_mode="auto",
+        fairness_iterations=9,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        options.ambiguity_max_branches = 64  # type: ignore[misc]
+
+    assert options.canonical_payload()["ambiguity_max_branches"] == 17
+    assert options.canonical_payload()["fairness_mode"] == "global"
 
 
 def _named_rectangle(identity: str, center_x: float) -> TopologyPath:


### PR DESCRIPTION
## Summary
- introduce immutable `LoftPlannerOptions` at public planning boundaries
- propagate the effective options through direct, expanded, synthetic, and ambiguity-report pairing routes
- report the exact caller branch cap and transition location on nested exhaustion
- cover 1-to-4-to-7 planning below, at, and above the required branch budget
- finalize Fix 06 specs, progression, ACD conformance, and canonical architecture

## Validation
- 149 focused planner tests passed
- 169 broader loft tests passed under coverage
- 1,738 full repository tests passed
- staged 1-to-4-to-7 boundary regression passed after the full run

Issue: #246 (configuration-propagation leaf; Fix 05 retains identity/lineage scope)