### PR TITLE
Fix hole junction surface execution

### DIFF
--- a/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
+++ b/project/release-1.0.0a4/architecture/acd-loft-identity-and-junction-correctness.md
@@ -151,6 +151,7 @@ payloads, and incomplete or duplicate derived lineage fails before execution.
 - [x] Fix 05A exact region identities resolve before anonymous residue and publish explicit count-changing births/deaths.
 - [x] Fix 05B synthetic stations preserve deterministic region/loop lineage through public planning and execution.
 - [x] Fix 04A count-changing holes publish validated interior-junction direction, lineage, and boundary inputs through planning and execution.
+- [x] Fix 04B count-changing holes execute as interior-junction patches with exact terminal-cap counting and closed-valid surface output.
 - [x] Fix 06 immutable planner configuration propagates through direct, expanded, and nested pairing routes.
 - [x] Final leaves are independently reviewed and canonicalized.
 - [x] Paired test specs point to canonical leaves.
@@ -174,6 +175,10 @@ through public routes with closed-valid surface output.
 - 2026-08-04 - Completed Fix 04A. Reason: hole births and deaths now publish
   immutable identity-bearing interior-junction events, deterministic boundary
   rings, and exact pre-execution lineage validation through the surface executor.
+- 2026-08-05 - Completed Fix 04B. Reason: split/merge hole closures now publish
+  interior-junction surface patches instead of terminal closure caps, preserve
+  junction-event linkage through execution, and restore exact two-cap
+  closed-valid surface output on the published split/merge route.
 - 2026-08-04 - Completed Fix 05B. Reason: identity-aware expansion now carries
   deterministic region and loop lineage through every synthetic station,
   preserves topology paths in both directions, and reaches the public surface

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -210,13 +210,13 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 04B: Hole Junction Surface Execution
 
-- [ ] Implement junction patches, seam/orientation handling, exact terminal cap count, and closure validation.
+- [x] Implement junction patches, seam/orientation handling, exact terminal cap count, and closure validation.
   - Specification: [Fix 04B](../specifications/fix-04b-hole-junction-surface-execution-v1_0.md)
   - Prerequisite: [Fix 04A](../specifications/fix-04a-hole-junction-plan-records-v1_0.md)
-- [ ] Wire junction execution into `Loft(...)` and the published split/merge example route.
-- [ ] Validate closed `SurfaceBody` output, cap count, and showcase behavior.
+- [x] Wire junction execution into `Loft(...)` and the published split/merge example route.
+- [x] Validate closed `SurfaceBody` output, cap count, and showcase behavior.
   - Test specification: [Fix 04B Test](../test-specifications/fix-04b-hole-junction-surface-execution-v1_0.md)
-- [ ] Update loft docs, progression, and ACD status after route validation.
+- [x] Update loft docs, progression, and ACD status after route validation.
 
 ### Fix 08C: Loft Difference Result-Shell Reconstruction
 

--- a/project/release-1.0.0a4/specifications/fix-04b-hole-junction-surface-execution-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-04b-hole-junction-surface-execution-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 04B: Hole Junction Surface Execution
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
 Source artifact: [Split parent](./fix-04-hole-split-merge-junction-surfaces-v1_0.md)
@@ -112,13 +112,14 @@ Pass 4 split decision: retained. Cohesion reason: one executor outcome assembles
 - Architecture feedback status:
   - tracked in active ACD
 - Already implemented prerequisites:
+  - Fix 04a junction plan records
   - existing records/routes named under Dependencies And Routes
 - Missing prerequisite architecture:
   - none
 - Missing prerequisite specifications:
   - none
 - Unimplemented prerequisite specifications:
-  - Fix 04a junction plan records
+  - none; Fix 04a junction plan records is implemented
 - Progression handling:
   - prerequisites listed above run first; otherwise this child may proceed after canonical review
 

--- a/project/release-1.0.0a4/test-specifications/fix-04b-hole-junction-surface-execution-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-04b-hole-junction-surface-execution-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 04B Test: Hole Junction Surface Execution
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 04B: Hole Junction Surface Execution](../specifications/fix-04b-hole-junction-surface-execution-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-loft-identity-and-junction-correctness.md)
@@ -59,6 +59,6 @@ This canonical paired contract verifies the complete retained split-child bounda
 ## Acceptance
 
 - [x] Feature child is canonical.
-- [ ] Route-level proof exists for library-only.
-- [ ] Helper-only tests cannot satisfy the contract.
-- [ ] Observable results and failure behavior are asserted.
+- [x] Route-level proof exists for library-only.
+- [x] Helper-only tests cannot satisfy the contract.
+- [x] Observable results and failure behavior are asserted.

--- a/src/impression/modeling/loft.py
+++ b/src/impression/modeling/loft.py
@@ -2821,7 +2821,7 @@ def _loft_kernel_metadata_from_body(body: SurfaceBody) -> dict[str, object]:
 def _loft_expected_patch_boundary_refs(patch: object, patch_index: int) -> tuple[SurfaceBoundaryRef, ...]:
     kernel = dict(getattr(patch, "metadata", {}).get("kernel", {}))
     surface_role = kernel.get("surface_role")
-    if surface_role in {"closure-cap", "start-cap", "end-cap"}:
+    if surface_role in {"closure-cap", "start-cap", "end-cap", "interior_junction"}:
         trim_loops = tuple(getattr(patch, "trim_loops", ()) or ())
         if not trim_loops:
             return (SurfaceBoundaryRef(patch_index, "trim:outer"),)
@@ -2891,7 +2891,7 @@ def _loft_cap_patch_indices(patches: Sequence[object]) -> tuple[int, ...]:
         patch_index
         for patch_index, patch in enumerate(patches)
         if dict(getattr(patch, "metadata", {}).get("kernel", {})).get("surface_role")
-        in {"closure-cap", "start-cap", "end-cap"}
+        in {"start-cap", "end-cap"}
     )
 
 
@@ -4470,6 +4470,12 @@ def _loft_execute_plan_surface(
         prev_station = plan.stations[prev_idx]
         curr_station = plan.stations[curr_idx]
         region_pairs_by_branch = {pair.branch_id: pair for pair in transition.region_pairs}
+        junction_event_ids_by_branch = {
+            branch_id: tuple(
+                event.id for event in transition.junction_events if event.branch_id == branch_id
+            )
+            for branch_id in transition.branch_order
+        }
         family_selection = family_selection_by_interval.get(
             transition.interval,
             classify_loft_patch_family(transition).canonical_payload(),
@@ -4570,6 +4576,11 @@ def _loft_execute_plan_surface(
                     loop_ref = loop_pair.prev_loop_ref if closure.side == "prev" else loop_pair.curr_loop_ref
                     region_ref = region_pair.prev_region_ref if closure.side == "prev" else region_pair.curr_region_ref
                     patch_index = len(patches)
+                    closure_surface_role = (
+                        "interior_junction"
+                        if loop_pair.role in {"synthetic_birth", "synthetic_death"}
+                        else "closure-cap"
+                    )
                     patches.append(
                         _loft_planar_patch_from_station_loops(
                             station,
@@ -4578,11 +4589,12 @@ def _loft_execute_plan_surface(
                                 "kernel": {
                                     "operation": "loft",
                                     "executor": "surface",
-                                    "surface_role": "closure-cap",
+                                    "surface_role": closure_surface_role,
                                     "closure_scope": "loop",
                                     "closure_side": closure.side,
                                     "branch_id": branch_id,
                                     "loop_index": closure.loop_index,
+                                    "junction_event_ids": junction_event_ids_by_branch.get(branch_id, ()),
                                 }
                             },
                         )
@@ -4605,6 +4617,11 @@ def _loft_execute_plan_surface(
                         for loop_pair in region_pair.loop_pairs
                     )
                     patch_index = len(patches)
+                    closure_surface_role = (
+                        "interior_junction"
+                        if region_pair.action in {"split_birth", "merge_death"}
+                        else "closure-cap"
+                    )
                     patches.append(
                         _loft_planar_patch_from_station_loops(
                             station,
@@ -4613,10 +4630,11 @@ def _loft_execute_plan_surface(
                                 "kernel": {
                                     "operation": "loft",
                                     "executor": "surface",
-                                    "surface_role": "closure-cap",
+                                    "surface_role": closure_surface_role,
                                     "closure_scope": "region",
                                     "closure_side": closure.side,
                                     "branch_id": branch_id,
+                                    "junction_event_ids": junction_event_ids_by_branch.get(branch_id, ()),
                                 }
                             },
                         )

--- a/tests/test_loft.py
+++ b/tests/test_loft.py
@@ -948,7 +948,7 @@ def test_private_surface_loft_executor_reuses_station_seams_across_adjacent_inte
     assert {(1, "bottom"), (1, "top")} in seam_pairs
 
 
-def test_private_surface_loft_executor_emits_loop_closure_cap_for_synthetic_hole_birth() -> None:
+def test_private_surface_loft_executor_emits_interior_junction_patch_for_synthetic_hole_birth() -> None:
     outer = make_rect(size=(1.2, 1.2)).outer
     hole = make_rect(size=(0.4, 0.4)).outer
     start = PlanarShape2D(outer=outer, holes=[])
@@ -968,10 +968,16 @@ def test_private_surface_loft_executor_emits_loop_closure_cap_for_synthetic_hole
         for patch in body.iter_patches(world=False)
         if patch.family == "planar"
     ]
-    assert planar_roles == ["closure-cap"]
+    assert planar_roles == ["interior_junction"]
+    planar_kernel = next(
+        patch.metadata.get("kernel", {})
+        for patch in body.iter_patches(world=False)
+        if patch.family == "planar"
+    )
+    assert planar_kernel.get("junction_event_ids")
 
 
-def test_private_surface_loft_executor_emits_region_closure_cap_for_region_death() -> None:
+def test_private_surface_loft_executor_emits_interior_junction_patch_for_region_death() -> None:
     base = as_section(make_rect(size=(1.0, 1.0)))
     extra = as_section(make_rect(size=(0.5, 0.5), center=(2.0, 0.0)))
     s0 = Section((base.regions[0], extra.regions[0]))
@@ -988,7 +994,7 @@ def test_private_surface_loft_executor_emits_region_closure_cap_for_region_death
     planar_patches = [patch for patch in body.iter_patches(world=False) if patch.family == "planar"]
     assert planar_patches
     assert any(
-        patch.metadata.get("kernel", {}).get("surface_role") == "closure-cap"
+        patch.metadata.get("kernel", {}).get("surface_role") == "interior_junction"
         and patch.metadata.get("kernel", {}).get("closure_scope") == "region"
         for patch in planar_patches
     )

--- a/tests/test_loft_showcase.py
+++ b/tests/test_loft_showcase.py
@@ -63,6 +63,7 @@ def test_perforated_vessel_showcase_handles_hole_birth_split_merge_and_death() -
         split_merge_steps=10,
         cap_ends=True,
     )
+    kernel = body.kernel_metadata()
     mesh = tessellate_surface_body(body, export_tessellation_request()).mesh
     assert mesh.n_vertices > 0
     assert mesh.n_faces > 0
@@ -70,6 +71,15 @@ def test_perforated_vessel_showcase_handles_hole_birth_split_merge_and_death() -
     assert (x_max - x_min) > 1.5
     assert (y_max - y_min) > 1.5
     assert (z_max - z_min) > 3.0
+    assert kernel["loft_cap_validity"]["valid"] is True
+    assert kernel["loft_cap_validity"]["cap_count"] == 2
+    assert kernel["loft_closure_evidence"]["closed_valid"] is True
+    junction_roles = {
+        patch.kernel_metadata().get("surface_role")
+        for patch in body.iter_patches(world=True)
+        if patch.kernel_metadata().get("surface_role")
+    }
+    assert {"interior_junction", "start-cap", "end-cap"} <= junction_roles
     _assert_mesh_quality(mesh)
 
 


### PR DESCRIPTION
## Summary
- publish split/merge closure patches as interior junction surfaces instead of terminal closure caps
- keep junction trim-boundary seam coverage while counting only true start/end caps in loft cap validity
- attach junction event IDs to executed junction patches and restore closed-valid two-cap metadata on split/merge loft output
- mark Fix04B spec, paired test spec, progression, and loft ACD status complete

## Validation
- PYTHONPATH=/Users/k/Documents/Projects/Impression-a4-fix04b/src /Users/k/Documents/Projects/Impression/.venv/bin/python -m pytest -q tests/test_loft.py tests/test_loft_showcase.py tests/test_loft_point_lifecycle_records.py -k 'junction or perforated or cap_validity or closure or synthetic_hole_birth or region_death'
- PYTHONPATH=/Users/k/Documents/Projects/Impression-a4-fix04b/src /Users/k/Documents/Projects/Impression/.venv/bin/python -m pytest -q tests/test_loft.py tests/test_loft_showcase.py tests/test_loft_surface_executor_correspondence.py tests/test_loft_point_lifecycle_records.py
- PYTHONPATH=/Users/k/Documents/Projects/Impression-a4-fix04b/src /Users/k/Documents/Projects/Impression/.venv/bin/python -m pytest -q tests/test_spec_docs.py tests/test_progression.py tests/test_release_metadata.py -k '04B or hole_junction or loft or release_metadata'
- PYTHONPATH=/Users/k/Documents/Projects/Impression-a4-fix04b/src /Users/k/Documents/Projects/Impression/.venv/bin/python -m pytest -q
- /Users/k/Documents/Projects/Impression/.venv/bin/python -m compileall src tests
- git diff --check