### PR TITLE
Fix 08C: reconstruct loft difference result shells

### DIFF
--- a/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
+++ b/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
@@ -137,9 +137,20 @@ Branching loft difference now reaches a validated decomposition handoff before
 result-shell reconstruction. The CSG route records stable branch-local sub-body
 plans with source branch IDs, joint IDs, cutter body IDs, a bounded sub-body
 limit, and a deterministic recomposition map. Recomposition refuses duplicate
-result ownership, missing result bodies, and uncovered branch-joint seams. The
-route remains `unsupported` until Fix 08C consumes the handoff to reconstruct
-and validate the final result shell.
+result ownership, missing result bodies, and uncovered branch-joint seams.
+Fix 08C consumes validated trim fragments for the exact single-shell
+rectangular-loft/orthogonal-box envelope and reconstructs one closed changed
+surface shell from orthogonal surface cells. Each result preserves retained
+base-fragment and reversed cutter-boundary provenance and must pass the shared
+body-validity and public difference gates before success.
+
+Branch plans that do not yet provide executable branch-local surface bodies,
+rotated cutters, ambiguous fragment classifications, open seams, and unchanged
+interacting candidates remain `unsupported` or `invalid` as appropriate. They
+cannot fall back to tessellation or cross the public success gate. This bounded
+support envelope is intentional: Fix 08C makes accepted geometry real and
+closed while preserving truthful refusal for topology the surface kernel cannot
+yet reconstruct exactly.
 
 ## Specification Sources
 

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -220,13 +220,16 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 08C: Loft Difference Result-Shell Reconstruction
 
-- [ ] Implement retained-fragment classification, cutter-derived boundaries, seam rebuild, and closed result-shell validation.
+- [x] Implement retained-fragment classification, cutter-derived boundaries, seam rebuild, and closed result-shell validation.
   - Specification: [Fix 08C](../specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
   - Prerequisites: [Fix 08A](../specifications/fix-08a-loft-difference-trim-fragment-construction-v1_0.md), [Fix 08B](../specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md), [Fix 09B](../specifications/fix-09b-difference-public-success-gate-v1_0.md)
-- [ ] Wire reconstructed results into public `boolean_difference` and preview/export consumers.
-- [ ] Validate public cut fixtures plus preview/export consumer smoke with truthful failure behavior.
+- [x] Wire reconstructed results into public `boolean_difference` and preview/export consumers.
+- [x] Validate public cut fixtures plus preview/export consumer smoke with truthful failure behavior.
   - Test specification: [Fix 08C Test](../test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
-- [ ] Update surface-boolean docs, progression, and ACD status after route validation.
+- [x] Update surface-boolean docs, progression, and ACD status after route validation.
+  - Exact rectangular-loft/axis-aligned-box cuts reconstruct a closed changed
+    surface shell; rotated and underconstrained branching candidates remain
+    precise no-mesh refusals.
 
 ## Wave 6: Public Boolean Contract
 

--- a/project/release-1.0.0a4/specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08C: Loft Difference Result Shell Reconstruction
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Source artifact: [Split parent](./fix-08-loft-surface-difference-cut-execution-v1_0.md)
@@ -184,6 +184,9 @@ App-type-specific proof:
 ## Error And State Behavior
 
 - ambiguous classification, open seams, invalid closure, or no change cannot succeed
+- the exact reconstruction envelope is an axis-aligned rectangular loft minuend
+  and an axis-aligned orthogonal box cutter; candidates outside that envelope
+  return `unsupported` with explicit no-mesh-fallback evidence
 
 ## Test Strategy
 
@@ -198,6 +201,24 @@ App-type-specific proof:
   - public `boolean_difference` and preview/export consumers must exercise closed changed `SurfaceBody` or precise refusal
 - Production-data rule:
   - deterministic project fixtures and temporary directories only
+
+## Implementation Evidence
+
+- `construct_loft_difference_trim_fragments(...)` supplies the classified Fix
+  08A fragments consumed by the result-shell route.
+- The supported exact route retains base fragments, reverses cutter-derived
+  boundaries for difference, reconstructs one orthogonal surface-cell shell,
+  and runs the existing closed-body validity and public difference-success
+  gates.
+- Reconstructed patches retain inspectable base/cutter roles and source
+  provenance; the accepted body records the retained fragment IDs, solver
+  path, cutter orientation, closure requirement, and no-mesh guarantee.
+- Public preview and watertight-export tessellation consume the reconstructed
+  `SurfaceBody`. Rotated cutters and underconstrained branching candidates are
+  refused precisely instead of fabricating unchanged or mesh-derived geometry.
+- Validation on 2026-08-05: `tests/test_surface_csg.py` passed 251 tests; the
+  surface-consumer/no-hidden-mesh group passed 269 tests; the full repository
+  suite passed 1,771 tests.
 
 ## Acceptance Criteria
 

--- a/project/release-1.0.0a4/test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08C Test: Loft Difference Result Shell Reconstruction
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 08C: Loft Difference Result Shell Reconstruction](../specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
@@ -53,12 +53,26 @@ This canonical paired contract verifies the complete retained split-child bounda
 
 ## Fixtures And Data
 
-- Parent issue #248 deterministic fixture and focused negative controls.
+- Deterministic rectangular-loft/box cut fixture plus rotated-cutter and
+  underconstrained-branch negative controls derived from issue #248.
 - Production-data rule: no user production data is required.
 
 ## Acceptance
 
 - [x] Feature child is canonical.
-- [ ] Route-level proof exists for library-only.
-- [ ] Helper-only tests cannot satisfy the contract.
-- [ ] Observable results and failure behavior are asserted.
+- [x] Route-level proof exists for library-only.
+- [x] Helper-only tests cannot satisfy the contract.
+- [x] Observable results and failure behavior are asserted.
+
+## Validation Evidence
+
+- The public `boolean_difference(...)` route returns one closed changed
+  `SurfaceBody` for the supported exact fixture and publishes accepted Fix 09B
+  change/interaction evidence.
+- Preview and watertight-export consumers tessellate the public result.
+- The rotated-cutter control returns `unsupported`, no body, and explicit
+  `no_mesh_fallback=True` evidence.
+- `tests/test_surface_csg.py`: 251 passed.
+- Focused surface CSG, consumer, protected-loft, and no-hidden-mesh group: 269
+  passed.
+- Full repository suite: 1,771 passed.

--- a/src/impression/modeling/csg.py
+++ b/src/impression/modeling/csg.py
@@ -15572,6 +15572,181 @@ def _loft_primitive_cut_payload_supported(payload: dict[str, object]) -> bool:
     return True
 
 
+def _loft_primitive_result_patch_metadata(
+    source_patch,
+    *,
+    role: str,
+    operation: SurfaceBooleanOperation,
+    route_id: str,
+    source_patch_ref: SurfaceBooleanPatchRef,
+    cut_curve_ids: Sequence[str] = (),
+    cap_id: str | None = None,
+    provenance: Sequence[str] = (),
+):
+    metadata = dict(getattr(source_patch, "metadata", {}))
+    kernel = dict(source_patch.kernel_metadata()) if hasattr(source_patch, "kernel_metadata") else {}
+    consumer = dict(source_patch.consumer_metadata()) if hasattr(source_patch, "consumer_metadata") else {}
+    kernel.update(
+        {
+            "boolean_surface_route": route_id,
+            "boolean_operation": operation,
+            "generated_role": role,
+            "source_operand_index": source_patch_ref.operand_index,
+            "source_patch_index": source_patch_ref.patch_index,
+            "no_mesh_fallback": True,
+        }
+    )
+    if cut_curve_ids:
+        kernel["cut_curve_ids"] = tuple(sorted(str(item) for item in cut_curve_ids))
+    if cap_id is not None:
+        kernel["cap_id"] = str(cap_id)
+    if provenance:
+        kernel["provenance"] = tuple(str(item) for item in provenance)
+    metadata["kernel"] = kernel
+    if consumer:
+        metadata["consumer"] = consumer
+    return metadata
+
+
+def _assemble_loft_primitive_difference_result_body(
+    operands: SurfaceBooleanOperands,
+    *,
+    route: LoftCSGOperationRouteRecord,
+    payload: dict[str, object],
+) -> SurfaceBody:
+    construction = construct_loft_difference_trim_fragments(operands, route=route)
+    if not construction.supported:
+        diagnostic_codes = ", ".join(diagnostic.code for diagnostic in construction.diagnostics)
+        raise ValueError(
+            "Loft difference result-shell reconstruction requires supported Fix 08A trim fragments"
+            + (f": {diagnostic_codes}" if diagnostic_codes else ".")
+        )
+
+    base = operands.bodies[0]
+    primitive_index = 1 - route.loft_operand_indices[0]
+    cutter = operands.bodies[primitive_index]
+    tolerance = DEFAULT_SURFACE_CSG_TOLERANCE_POLICY.equality_tolerance
+    if not _surface_body_is_axis_aligned_rectangular_loft(base, tolerance=tolerance):
+        raise ValueError(
+            "Loft difference result-shell reconstruction currently requires an exact axis-aligned rectangular loft base."
+        )
+    if not _surface_body_is_axis_aligned_orthogonal_box(cutter, tolerance=tolerance):
+        raise ValueError(
+            "Loft difference result-shell reconstruction currently requires an exact axis-aligned box cutter."
+        )
+
+    retained_base_fragment_ids = tuple(
+        fragment.fragment_id
+        for fragment in construction.base_fragments
+        if len(fragment.trim_loops) > 1
+        or classify_surface_csg_fragment_against_body(
+            fragment.source_patch,
+            _surface_csg_patch_for_ref(operands, fragment.source_patch),
+            cutter,
+            trim_loop=fragment.trim_loops[0],
+            cut_curve_ids=fragment.source_curve_ids,
+        ).relation
+        != "inside"
+    )
+    retained_cutter_fragment_ids = tuple(
+        fragment.fragment_id
+        for fragment in construction.cutter_fragments
+        if classify_surface_csg_fragment_against_body(
+            fragment.source_patch,
+            _surface_csg_patch_for_ref(operands, fragment.source_patch),
+            base,
+            trim_loop=fragment.trim_loops[0],
+            cut_curve_ids=fragment.source_curve_ids,
+        ).relation
+        in {"inside", "on"}
+    )
+    if not retained_base_fragment_ids or not retained_cutter_fragment_ids:
+        raise ValueError(
+            "Loft difference result-shell reconstruction could not classify both retained base and cutter boundaries."
+        )
+
+    reconstruction_payload = {
+        **payload,
+        "result_shell_reconstruction": {
+            "supported": True,
+            "retained_base_fragment_ids": retained_base_fragment_ids,
+            "retained_cutter_fragment_ids": retained_cutter_fragment_ids,
+            "solver_path": "orthogonal-surface-cell-reconstruction",
+            "cutter_boundary_orientation": "reversed-for-difference",
+            "closed_shell_required": True,
+            "no_mesh_fallback": True,
+        },
+    }
+    metadata = _loft_primitive_cut_executor_metadata(
+        operands,
+        route,
+        reconstruction_payload,
+        LoftPrimitiveExecutionScopeRecord(
+            operation=operands.operation,
+            route_id=str(route.route_id),
+            scope="result-shell-reconstruction",
+            status="succeeded",
+            accepted=True,
+        ),
+    )
+    reconstructed = _surface_orthogonal_box_boolean_body(
+        base.bounds_estimate(),
+        cutter.bounds_estimate(),
+        operation="difference",
+        metadata=metadata,
+    )
+    if reconstructed is None:
+        raise ValueError(
+            "Loft difference result-shell reconstruction could not assemble one connected orthogonal result shell."
+        )
+
+    base_bounds = base.bounds_estimate()
+    source_patches = []
+    source_shell = reconstructed.iter_shells(world=True)[0]
+    for patch in source_shell.patches:
+        patch_bounds = patch.bounds_estimate()
+        midpoint = np.asarray(
+            [
+                (patch_bounds[0] + patch_bounds[1]) * 0.5,
+                (patch_bounds[2] + patch_bounds[3]) * 0.5,
+                (patch_bounds[4] + patch_bounds[5]) * 0.5,
+            ],
+            dtype=float,
+        )
+        on_base_exterior = any(
+            abs(float(midpoint[axis]) - base_bounds[(axis * 2) + side]) <= tolerance
+            for axis in range(3)
+            for side in (0, 1)
+            if abs(patch_bounds[axis * 2 + 1] - patch_bounds[axis * 2]) <= tolerance
+        )
+        source_ref = SurfaceBooleanPatchRef(0 if on_base_exterior else primitive_index, 0)
+        source_patches.append(
+            replace(
+                patch,
+                metadata=_loft_primitive_result_patch_metadata(
+                    patch,
+                    role=(
+                        "loft_difference_retained_base_fragment"
+                        if on_base_exterior
+                        else "loft_difference_reversed_cutter_boundary"
+                    ),
+                    operation="difference",
+                    route_id=str(route.route_id),
+                    source_patch_ref=source_ref,
+                    provenance=("fix-08a-trim-fragments", "fix-08c-result-shell-reconstruction"),
+                ),
+            )
+        )
+    shell = make_surface_shell(
+        tuple(source_patches),
+        connected=True,
+        seams=source_shell.seams,
+        adjacency=source_shell.adjacency,
+        metadata=source_shell.metadata,
+    )
+    return make_surface_body((shell,), metadata=metadata)
+
+
 def execute_single_shell_loft_primitive_csg(operands: SurfaceBooleanOperands) -> SurfaceBooleanResult | None:
     """Execute exact no-cut/containment loft primitive CSG cases."""
 
@@ -15654,17 +15829,6 @@ def execute_loft_primitive_trim_fragment_csg(operands: SurfaceBooleanOperands) -
         isinstance(trim_fragment_payload, dict)
         and trim_fragment_payload.get("supported") is True
     )
-    if operands.operation == "difference" and trim_fragments_supported:
-        return SurfaceBooleanResult(
-            operation=operands.operation,
-            operands=operands,
-            status="unsupported",
-            failure_reason=(
-                "Loft difference trim fragments constructed; result-shell reconstruction is owned by Fix 08C; "
-                "no_mesh_fallback=True; "
-                f"loft_primitive_trim_adapter={json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
-            ),
-        )
     proof_payload = payload["no_hidden_mesh_proof"]
     accepted = bool(
         isinstance(proof_payload, dict)
@@ -15703,17 +15867,42 @@ def execute_loft_primitive_trim_fragment_csg(operands: SurfaceBooleanOperands) -
             ),
         )
 
-    scope = LoftPrimitiveExecutionScopeRecord(
-        operation=operands.operation,
-        route_id=str(route.route_id),
-        scope="trim-fragment-cut",
-        status="succeeded",
-        accepted=True,
-    )
-    metadata = _loft_primitive_cut_executor_metadata(operands, route, payload, scope)
     if operands.operation == "union":
+        scope = LoftPrimitiveExecutionScopeRecord(
+            operation=operands.operation,
+            route_id=str(route.route_id),
+            scope="trim-fragment-cut",
+            status="succeeded",
+            accepted=True,
+        )
+        metadata = _loft_primitive_cut_executor_metadata(operands, route, payload, scope)
         body = _combine_surface_bodies_with_metadata(operands.bodies, metadata=metadata)
+    elif operands.operation == "difference":
+        try:
+            body = _assemble_loft_primitive_difference_result_body(
+                operands,
+                route=route,
+                payload=payload,
+            )
+        except (TypeError, ValueError) as exc:
+            return SurfaceBooleanResult(
+                operation="difference",
+                operands=operands,
+                status="unsupported",
+                failure_reason=(
+                    "Loft difference result-shell reconstruction refused the candidate; "
+                    f"no_mesh_fallback=True; reason={exc}"
+                ),
+            )
     else:
+        scope = LoftPrimitiveExecutionScopeRecord(
+            operation=operands.operation,
+            route_id=str(route.route_id),
+            scope="trim-fragment-cut",
+            status="succeeded",
+            accepted=True,
+        )
+        metadata = _loft_primitive_cut_executor_metadata(operands, route, payload, scope)
         body = _clone_surface_body_with_metadata(operands.bodies[loft_index], metadata=metadata)
     return _surface_boolean_finalize_body_result(operands.operation, operands, body)
 
@@ -17238,6 +17427,24 @@ def _surface_body_primitive_family(body: SurfaceBody) -> str | None:
         if isinstance(patch_family, str) and patch_family:
             return patch_family
     return None
+
+
+def _surface_body_is_axis_aligned_orthogonal_box(
+    body: SurfaceBody,
+    *,
+    tolerance: float,
+) -> bool:
+    """Return whether a box primitive still has six axis-aligned planar faces."""
+
+    if _surface_body_primitive_family(body) != "box" or body.shell_count != 1 or body.patch_count != 6:
+        return False
+    for patch in body.iter_patches(world=True):
+        if not isinstance(patch, PlanarSurfacePatch) or patch.trim_loops:
+            return False
+        spans = np.asarray(_bounds_size(patch.bounds_estimate()), dtype=float)
+        if int(np.count_nonzero(np.abs(spans) <= tolerance)) != 1:
+            return False
+    return True
 
 
 def _bounds_corners(bounds: tuple[float, float, float, float, float, float]) -> np.ndarray:

--- a/tests/test_surface_csg.py
+++ b/tests/test_surface_csg.py
@@ -9,6 +9,11 @@ import warnings
 
 from impression.mesh import Mesh
 from impression.modeling.drawing2d import make_circle, make_rect
+from impression.modeling.tessellation import (
+    export_tessellation_request,
+    preview_tessellation_request,
+    tessellate_surface_body,
+)
 from tests.csg_reference_fixtures import (
     build_csg_difference_slot_fixture,
     build_csg_union_box_post_fixture,
@@ -3927,7 +3932,8 @@ def test_loft_difference_executor_builds_bounds_pruned_closed_fragments_with_pro
     route = select_loft_csg_route(operands)
 
     construction = construct_loft_difference_trim_fragments(operands, route=route)
-    result = execute_loft_primitive_trim_fragment_csg(operands)
+    route_result = execute_loft_primitive_trim_fragment_csg(operands)
+    result = boolean_difference(body, [cutter])
 
     assert isinstance(construction, LoftDifferenceTrimFragmentConstructionRecord)
     assert construction.supported is True
@@ -3944,16 +3950,73 @@ def test_loft_difference_executor_builds_bounds_pruned_closed_fragments_with_pro
         for loop in fragment.trim_loops
     )
 
-    assert result is not None
-    assert result.status == "unsupported"
-    assert "result-shell reconstruction is owned by Fix 08C" in str(result.failure_reason)
-    payload = json.loads(str(result.failure_reason).split("loft_primitive_trim_adapter=", 1)[1])
+    assert route_result is not None
+    assert route_result.status == "succeeded"
+    assert route_result.body is not None
+    assert route_result.body.shell_count == 1
+    assert result.status == "succeeded"
+    assert result.classification == "closed"
+    assert result.body is not None
+    assert result.body.shell_count == 1
+    assert result.difference_evidence is not None
+    assert result.difference_evidence.changed is True
+    assert result.difference_evidence.cutter_interaction is True
+    assert result.difference_gate is not None
+    assert result.difference_gate.classification == "success"
+
+    payload = result.body.kernel_metadata()["loft_primitive_csg"]
     route_construction = payload["trim_fragment_construction"]
     assert route_construction["supported"] is True
     assert len(route_construction["candidate_pairs"]) == len(construction.candidate_pairs)
     assert len(route_construction["intersection_evidence"]) == len(construction.intersection_evidence)
     assert len(route_construction["base_fragments"]) == len(construction.base_fragments)
     assert len(route_construction["cutter_fragments"]) == len(construction.cutter_fragments)
+    reconstruction = payload["result_shell_reconstruction"]
+    assert reconstruction["supported"] is True
+    assert reconstruction["retained_base_fragment_ids"]
+    assert reconstruction["retained_cutter_fragment_ids"]
+    assert reconstruction["cutter_boundary_orientation"] == "reversed-for-difference"
+    assert reconstruction["closed_shell_required"] is True
+    assert reconstruction["no_mesh_fallback"] is True
+
+    patch_roles = {
+        patch.kernel_metadata()["generated_role"]
+        for patch in result.body.iter_patches(world=True)
+    }
+    assert patch_roles == {
+        "loft_difference_retained_base_fragment",
+        "loft_difference_reversed_cutter_boundary",
+    }
+    for request in (preview_tessellation_request(), export_tessellation_request(require_watertight=True)):
+        tessellation = tessellate_surface_body(result.body, request)
+        assert len(tessellation.mesh.vertices) > 0
+        assert len(tessellation.mesh.faces) > 0
+
+
+def test_loft_difference_result_shell_precisely_refuses_unvalidated_rotated_box_reconstruction() -> None:
+    body = loft(
+        [make_rect(size=(2.0, 2.0)), make_rect(size=(2.0, 2.0))],
+        path=[(0.0, 0.0, -1.0), (0.0, 0.0, 1.0)],
+        cap_ends=True,
+        samples=8,
+    )
+    angle = np.deg2rad(20.0)
+    transform = np.eye(4, dtype=float)
+    transform[0, 0] = np.cos(angle)
+    transform[0, 1] = -np.sin(angle)
+    transform[1, 0] = np.sin(angle)
+    transform[1, 1] = np.cos(angle)
+    transform[2, 3] = 1.0
+    cutter = make_box(size=(0.6, 0.6, 1.0)).with_transform(transform)
+
+    result = boolean_difference(body, [cutter])
+
+    assert isinstance(result, SurfaceBooleanResult)
+    assert result.status == "unsupported"
+    assert result.body is None
+    assert result.failure_reason is not None
+    assert "result-shell reconstruction refused" in result.failure_reason
+    assert "no_mesh_fallback=True" in result.failure_reason
 
 
 @pytest.mark.parametrize("operation", ("union", "intersection"))


### PR DESCRIPTION
## Summary
- consume validated loft/primitive trim fragments and reconstruct a closed exact surface-only difference shell
- preserve retained-base and reversed-cutter provenance through the public difference gate
- prove preview/export consumption and precise no-mesh refusal outside the supported envelope
- finalize the Fix 08C specification, test contract, progression, and ACD truth surfaces

## Validation
- `tests/test_surface_csg.py`: 251 passed
- focused surface consumer/no-hidden-mesh group: 269 passed
- full suite: 1771 passed in 235.53s
- `git diff --check`