### PR TITLE
Fix 07A: enforce the surface-only boolean runtime API

### DIFF
--- a/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
+++ b/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
@@ -82,6 +82,21 @@ mesh operands receive `TypeError` at the public boundary. Standalone mesh
 analysis/export functions remain unchanged. The API migration lands after
 surface union/difference correction so callers have a complete surfaced route.
 
+## Surface-Only Runtime API Boundary
+
+The public `impression.modeling` boolean functions now accept only
+`SurfaceBody` operands, use body/surface terminology, and return
+`SurfaceBooleanResult` consistently. A shared public-boundary validator rejects
+`Mesh`, `MeshGroup`, mixed collections, and other representations before family
+selection or kernel dispatch. Its error identifies the offending parameter or
+collection index and points callers to the explicit mesh-tool boundary.
+
+`union_meshes` is no longer a top-level `impression.modeling` export. It remains
+available through `impression.modeling.mesh_tools` beside retained mesh
+analysis and repair operations. Runtime and export separation is complete under
+Fix 07A; docs, examples, inventory guards, and clean installed-package proof
+remain owned by Fix 07B.
+
 ## Application Integration Contract
 
 - App type: library-only with console preview/export consumers.

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -235,13 +235,15 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 07A: Surface-Only Boolean Runtime API
 
-- [ ] Implement surface-only public signatures, runtime guards, exports, and result types while separating mesh utilities.
+- [x] Implement surface-only public signatures, runtime guards, exports, and result types while separating mesh utilities.
   - Specification: [Fix 07A](../specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md)
   - Prerequisites: [Fix 02](../specifications/fix-02-coplanar-loft-face-touch-union-v1_0.md), [Fix 08C](../specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md), [Fix 09B](../specifications/fix-09b-difference-public-success-gate-v1_0.md)
-- [ ] Wire the runtime contract through public `impression.modeling` exports and boolean functions.
-- [ ] Validate the public signature/runtime matrix and actionable mesh-operand errors.
+- [x] Wire the runtime contract through public `impression.modeling` exports and boolean functions.
+- [x] Validate the public signature/runtime matrix and actionable mesh-operand errors.
   - Test specification: [Fix 07A Test](../test-specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md)
-- [ ] Update progression and surface-boolean ACD status after route validation.
+- [x] Update progression and surface-boolean ACD status after route validation.
+  - Documentation, examples, inventory guards, and installed-wheel conformance
+    remain owned by the following Fix 07B leaf.
 
 ### Fix 07B: Surface Boolean Docs And Package Contract
 

--- a/project/release-1.0.0a4/specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 07A: Surface-Only Boolean Runtime API
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Source artifact: [Split parent](./fix-07-surface-only-public-boolean-api-v1_0.md)
@@ -111,15 +111,15 @@ Pass 4 split decision: retained. Cohesion reason: one installed runtime represen
 - Architecture feedback status:
   - tracked in active ACD
 - Already implemented prerequisites:
-  - existing records/routes named under Dependencies And Routes
+  - Fix 02 surfaced union
+  - Fix 08c surfaced difference reconstruction
+  - Fix 09b public difference gate
 - Missing prerequisite architecture:
   - none
 - Missing prerequisite specifications:
   - none
 - Unimplemented prerequisite specifications:
-  - Fix 02 surfaced union
-  - Fix 08c surfaced difference reconstruction
-  - Fix 09b public difference gate
+  - none
 - Progression handling:
   - prerequisites listed above run first; otherwise this child may proceed after canonical review
 
@@ -179,6 +179,8 @@ App-type-specific proof:
 ## Error And State Behavior
 
 - mesh/mixed inputs identify the separate non-modeling utility
+- invalid representations raise `TypeError` before family-gate or kernel
+  dispatch and identify the offending public parameter/index
 
 ## Test Strategy
 
@@ -192,6 +194,22 @@ App-type-specific proof:
   - public `impression.modeling` boolean functions must exercise surfaced result or actionable representation error
 - Production-data rule:
   - deterministic project fixtures and temporary directories only
+
+## Implementation Evidence
+
+- `boolean_union(bodies, tolerance)`, `boolean_difference(base, cutters,
+  tolerance)`, and `boolean_intersection(bodies, tolerance)` now annotate only
+  `SurfaceBody` operands and consistently return `SurfaceBooleanResult`.
+- One shared public-boundary validator rejects `Mesh`, `MeshGroup`, mixed, and
+  other non-surface operands before the family gate, identifying the offending
+  parameter or collection index and directing callers to
+  `impression.modeling.mesh_tools`.
+- `union_meshes` is absent from the top-level `impression.modeling` export table
+  and is explicitly exported from `impression.modeling.mesh_tools` as the
+  retained standalone mesh-union utility.
+- Validation on 2026-08-05: the focused signature/runtime/export matrix passed
+  8 tests; the surface CSG plus retained mesh-tool group passed 262 tests; the
+  full repository suite passed 1,778 tests.
 
 ## Acceptance Criteria
 

--- a/project/release-1.0.0a4/test-specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 07A Test: Surface-Only Boolean Runtime API
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 07A: Surface-Only Boolean Runtime API](../specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
@@ -59,6 +59,21 @@ This canonical paired contract verifies the complete retained split-child bounda
 ## Acceptance
 
 - [x] Feature child is canonical.
-- [ ] Route-level proof exists for library-only.
-- [ ] Helper-only tests cannot satisfy the contract.
-- [ ] Observable results and failure behavior are asserted.
+- [x] Route-level proof exists for library-only.
+- [x] Helper-only tests cannot satisfy the contract.
+- [x] Observable results and failure behavior are asserted.
+
+## Validation Evidence
+
+- Runtime introspection asserts all three public parameter names, surfaced
+  operand annotations, tolerance annotations, and the uniform
+  `SurfaceBooleanResult` return annotation.
+- Calls imported through `impression.modeling` prove valid surfaced operands
+  still reach the real boolean routes and return structured results.
+- Mesh, `MeshGroup`, base, cutter, and mixed-collection controls prove
+  actionable `TypeError` occurs before family-gate dispatch.
+- Export inspection proves `union_meshes` is absent from top-level modeling and
+  available through `impression.modeling.mesh_tools`.
+- Focused runtime/signature/export matrix: 8 passed.
+- Surface CSG and retained mesh-tool group: 262 passed.
+- Full repository suite: 1,778 passed.

--- a/src/impression/modeling/__init__.py
+++ b/src/impression/modeling/__init__.py
@@ -696,7 +696,6 @@ from .csg import (
     surface_csg_selection_is_empty,
     validate_surface_csg_curve,
     validate_surface_csg_patch_local_curve_domain,
-    union_meshes,
 )
 from .paths import Path
 from .group import (
@@ -1768,7 +1767,6 @@ __all__ = [
     "surface_csg_selection_is_empty",
     "validate_surface_csg_curve",
     "validate_surface_csg_patch_local_curve_domain",
-    "union_meshes",
     "Path",
     "MESH_GROUP_COMPATIBILITY_BOUNDARY",
     "MESH_GROUP_COMPATIBILITY_CLASSIFICATION",

--- a/src/impression/modeling/csg.py
+++ b/src/impression/modeling/csg.py
@@ -20498,17 +20498,44 @@ def _validate_public_surface_union_result(
     )
 
 
+def _require_public_surface_boolean_body(
+    function_name: str,
+    parameter_name: str,
+    operand: object,
+) -> SurfaceBody:
+    if isinstance(operand, SurfaceBody):
+        return operand
+    raise TypeError(
+        f"{function_name}() accepts only SurfaceBody operands; "
+        f"{parameter_name} received {type(operand).__name__}. "
+        "Mesh and MeshGroup are terminal/tool representations, not modeling operands. "
+        "Use impression.modeling.mesh_tools for explicit mesh analysis and repair; "
+        "union_meshes(...) there is the separate standalone mesh-union utility."
+    )
+
+
+def _require_public_surface_boolean_bodies(
+    function_name: str,
+    parameter_name: str,
+    operands: Iterable[object],
+) -> tuple[SurfaceBody, ...]:
+    return tuple(
+        _require_public_surface_boolean_body(function_name, f"{parameter_name}[{index}]", operand)
+        for index, operand in enumerate(operands)
+    )
+
+
 def boolean_union(
-    meshes: Iterable[Mesh | MeshGroup | SurfaceBody],
+    bodies: Iterable[SurfaceBody],
     tolerance: float = 1e-4,
-) -> Mesh | SurfaceBooleanResult:
+) -> SurfaceBooleanResult:
     if tolerance <= 0:
         raise ValueError("tolerance must be positive.")
-    bodies = tuple(meshes)
-    gated = _surface_boolean_result_after_family_gate("union", bodies, caller_id="csg.boolean_union")  # type: ignore[arg-type]
+    body_tuple = _require_public_surface_boolean_bodies("boolean_union", "bodies", bodies)
+    gated = _surface_boolean_result_after_family_gate("union", body_tuple, caller_id="csg.boolean_union")
     if gated is not None:
         return _validate_public_surface_union_result(gated, tolerance=tolerance)
-    operands = prepare_surface_boolean_operands("union", bodies)  # type: ignore[arg-type]
+    operands = prepare_surface_boolean_operands("union", body_tuple)
     raw_result = assert_no_hidden_surface_csg_mesh_fallback(
         "csg.boolean_union",
         surface_boolean_result("union", operands),
@@ -20519,21 +20546,22 @@ def boolean_union(
 
 
 def boolean_difference(
-    base: Mesh | MeshGroup | SurfaceBody,
-    cutters: Iterable[Mesh | MeshGroup | SurfaceBody],
+    base: SurfaceBody,
+    cutters: Iterable[SurfaceBody],
     tolerance: float = 1e-4,
-) -> Mesh | SurfaceBooleanResult:
+) -> SurfaceBooleanResult:
     if tolerance <= 0:
         raise ValueError("tolerance must be positive.")
-    cutter_tuple = tuple(cutters)
+    surface_base = _require_public_surface_boolean_body("boolean_difference", "base", base)
+    cutter_tuple = _require_public_surface_boolean_bodies("boolean_difference", "cutters", cutters)
     gated = _surface_boolean_result_after_family_gate(
         "difference",
-        (base, *cutter_tuple),
+        (surface_base, *cutter_tuple),
         caller_id="csg.boolean_difference",
-    )  # type: ignore[arg-type]
+    )
     if gated is not None:
         return assert_surface_difference_success_gate(gated)
-    operands = prepare_surface_boolean_difference_operands(base, cutter_tuple)  # type: ignore[arg-type]
+    operands = prepare_surface_boolean_difference_operands(surface_base, cutter_tuple)
     difference_policy = {
         "equality_tolerance": tolerance,
         "domain_tolerance": min(tolerance, DEFAULT_SURFACE_CSG_TOLERANCE_POLICY.domain_tolerance),
@@ -20563,20 +20591,20 @@ def boolean_difference(
 
 
 def boolean_intersection(
-    meshes: Iterable[Mesh | MeshGroup | SurfaceBody],
+    bodies: Iterable[SurfaceBody],
     tolerance: float = 1e-4,
-) -> Mesh | SurfaceBooleanResult:
+) -> SurfaceBooleanResult:
     if tolerance <= 0:
         raise ValueError("tolerance must be positive.")
-    bodies = tuple(meshes)
+    body_tuple = _require_public_surface_boolean_bodies("boolean_intersection", "bodies", bodies)
     gated = _surface_boolean_result_after_family_gate(
         "intersection",
-        bodies,
+        body_tuple,
         caller_id="csg.boolean_intersection",
-    )  # type: ignore[arg-type]
+    )
     if gated is not None:
         return gated
-    operands = prepare_surface_boolean_operands("intersection", bodies)  # type: ignore[arg-type]
+    operands = prepare_surface_boolean_operands("intersection", body_tuple)
     return assert_no_hidden_surface_csg_mesh_fallback(
         "csg.boolean_intersection",
         surface_boolean_result("intersection", operands),

--- a/src/impression/modeling/mesh_tools/__init__.py
+++ b/src/impression/modeling/mesh_tools/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from impression.mesh import Mesh, MeshAnalysis, analyze_mesh, repair_mesh, section_mesh_with_plane
+from impression.modeling.csg import union_meshes
 from impression.modeling._ops_mesh import hull_mesh, manifold_from_mesh_group, mesh_from_manifold
 
 MESH_TOOL_BOUNDARY = "explicit-mesh-tool"
@@ -46,4 +47,5 @@ __all__ = [
     "mesh_from_manifold",
     "repair_mesh",
     "section_mesh_with_plane",
+    "union_meshes",
 ]

--- a/tests/test_surface_csg.py
+++ b/tests/test_surface_csg.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError, replace
+import inspect
 import json
+from typing import Iterable, get_type_hints
+import warnings
+
+import impression.modeling as modeling_module
 import impression.modeling.csg as csg_module
 import numpy as np
 import pytest
-import warnings
 
 from impression.mesh import Mesh
 from impression.modeling.drawing2d import make_circle, make_rect
@@ -5095,6 +5099,84 @@ def test_public_surface_boolean_returns_structured_result_without_deprecation() 
     assert intersection_result.body is not None
     assert len(union_result.operands.body_ids) == 2
     assert not [item for item in caught if issubclass(item.category, DeprecationWarning)]
+
+
+def test_public_surface_boolean_signature_matrix_is_surface_only() -> None:
+    expected = {
+        boolean_union: (("bodies", "tolerance"), Iterable[SurfaceBody]),
+        boolean_difference: (("base", "cutters", "tolerance"), SurfaceBody),
+        boolean_intersection: (("bodies", "tolerance"), Iterable[SurfaceBody]),
+    }
+
+    for function, (parameter_names, first_parameter_type) in expected.items():
+        signature = inspect.signature(function)
+        hints = get_type_hints(function)
+        assert tuple(signature.parameters) == parameter_names
+        assert hints[parameter_names[0]] == first_parameter_type
+        assert hints["tolerance"] is float
+        assert hints["return"] is SurfaceBooleanResult
+
+    difference_hints = get_type_hints(boolean_difference)
+    assert difference_hints["cutters"] == Iterable[SurfaceBody]
+
+
+@pytest.mark.parametrize(
+    ("function_name", "invoke", "parameter_label", "received_type"),
+    (
+        ("boolean_union", lambda mesh: boolean_union([mesh]), "bodies[0]", "Mesh"),
+        (
+            "boolean_union",
+            lambda mesh: boolean_union([csg_module.MeshGroup([mesh])]),
+            "bodies[0]",
+            "MeshGroup",
+        ),
+        ("boolean_difference", lambda mesh: boolean_difference(mesh, [make_box()]), "base", "Mesh"),
+        (
+            "boolean_difference",
+            lambda mesh: boolean_difference(make_box(), [mesh]),
+            "cutters[0]",
+            "Mesh",
+        ),
+        (
+            "boolean_intersection",
+            lambda mesh: boolean_intersection([make_box(), mesh]),
+            "bodies[1]",
+            "Mesh",
+        ),
+    ),
+)
+def test_public_surface_boolean_rejects_mesh_operands_before_kernel_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    function_name: str,
+    invoke,
+    parameter_label: str,
+    received_type: str,
+) -> None:
+    mesh = make_box_mesh(size=(1.0, 1.0, 1.0))
+
+    def unexpected_dispatch(*_args, **_kwargs):
+        pytest.fail("mesh operands reached surface CSG family dispatch")
+
+    monkeypatch.setattr(csg_module, "_surface_boolean_result_after_family_gate", unexpected_dispatch)
+
+    with pytest.raises(TypeError) as exc_info:
+        invoke(mesh)
+
+    message = str(exc_info.value)
+    assert f"{function_name}() accepts only SurfaceBody operands" in message
+    assert parameter_label in message
+    assert f"received {received_type}" in message
+    assert "impression.modeling.mesh_tools" in message
+    assert "union_meshes" in message
+
+
+def test_mesh_union_is_exported_only_from_explicit_mesh_tool_boundary() -> None:
+    from impression.modeling import mesh_tools
+
+    assert "union_meshes" not in modeling_module.__all__
+    assert not hasattr(modeling_module, "union_meshes")
+    assert callable(mesh_tools.union_meshes)
+    assert mesh_tools.union_meshes is csg_module.union_meshes
 
 
 def test_surface_boolean_result_contract_supports_partial_box_sphere_union() -> None:


### PR DESCRIPTION
## Summary
- restrict public boolean annotations, names, and return types to SurfaceBody and SurfaceBooleanResult
- reject Mesh, MeshGroup, and mixed inputs before surface CSG dispatch with actionable migration guidance
- move the retained union_meshes export behind impression.modeling.mesh_tools
- finalize the Fix 07A specification, test contract, progression, and ACD runtime boundary

## Validation
- focused public signature/runtime/export matrix: 8 passed
- surface CSG and retained mesh-tool group: 262 passed
- full suite: 1778 passed in 231.51s
- clean-process import/signature smoke passed
- git diff --check