### PR TITLE
Fix 07B: complete the surface boolean package contract

### DIFF
--- a/docs/examples/csg/difference_example.py
+++ b/docs/examples/csg/difference_example.py
@@ -1,23 +1,30 @@
-"""CSG difference example."""
+"""Surface CSG difference example."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from impression.io import write_stl
-
-from impression.modeling import boolean_difference, make_box_mesh, make_cylinder_mesh
+from impression.modeling import (
+    boolean_difference,
+    export_tessellation_request,
+    make_box,
+    tessellate_surface_body,
+)
 
 
 def build():
-    base = make_box_mesh(size=(2, 2, 2), color="#5A7BFF")
-    cutter = make_cylinder_mesh(radius=0.4, height=2.5, color="#FF7A18")
-    return boolean_difference(base, [cutter])
+    base = make_box(size=(3, 2, 2), color="#5A7BFF")
+    cutter = make_box(size=(1.5, 1, 3), center=(1, 0, 0), color="#FF7A18")
+    result = boolean_difference(base, [cutter])
+    if result.status not in {"succeeded", "no-cut"} or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface difference did not produce a body.")
+    return result.body
 
 
 if __name__ == "__main__":
     OUTPUT = Path("dist")
     OUTPUT.mkdir(exist_ok=True)
-    mesh = build()
+    mesh = tessellate_surface_body(build(), export_tessellation_request()).mesh
     write_stl(mesh, OUTPUT / "difference_example.stl")
     print("Saved difference_example.stl with", mesh.n_faces, "faces")

--- a/docs/examples/csg/intersection_example.py
+++ b/docs/examples/csg/intersection_example.py
@@ -1,23 +1,30 @@
-"""CSG intersection example."""
+"""Surface CSG intersection example."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from impression.io import write_stl
-
-from impression.modeling import boolean_intersection, make_box_mesh, make_sphere_mesh
+from impression.modeling import (
+    boolean_intersection,
+    export_tessellation_request,
+    make_box,
+    tessellate_surface_body,
+)
 
 
 def build():
-    box = make_box_mesh(size=(2, 2, 2), color=(0.35, 0.55, 0.95))
-    sphere = make_sphere_mesh(radius=1.2, color=(1.0, 0.55, 0.2))
-    return boolean_intersection([box, sphere])
+    left = make_box(size=(2, 2, 2), center=(-0.5, 0, 0), color=(0.35, 0.55, 0.95))
+    right = make_box(size=(2, 2, 2), center=(0.5, 0, 0), color=(1.0, 0.55, 0.2))
+    result = boolean_intersection([left, right])
+    if result.status != "succeeded" or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface intersection did not produce a body.")
+    return result.body
 
 
 if __name__ == "__main__":
     OUTPUT = Path("dist")
     OUTPUT.mkdir(exist_ok=True)
-    mesh = build()
+    mesh = tessellate_surface_body(build(), export_tessellation_request()).mesh
     write_stl(mesh, OUTPUT / "intersection_example.stl")
     print("Saved intersection_example.stl with", mesh.n_faces, "faces")

--- a/docs/examples/csg/teeth_union_example.py
+++ b/docs/examples/csg/teeth_union_example.py
@@ -11,7 +11,8 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import make_cylinder_mesh, union_meshes
+from impression.modeling import make_cylinder_mesh
+from impression.modeling.mesh_tools import union_meshes
 
 
 def build():

--- a/docs/examples/csg/tooth_example.py
+++ b/docs/examples/csg/tooth_example.py
@@ -1,4 +1,4 @@
-"""Solid tombstone: box + rounded top, fused via boolean_union.
+"""Tombstone surface parts shown without a boolean operation.
 
 Run with:
   impression preview docs/examples/csg/tooth_example.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_union, rotate, make_box_mesh, make_cylinder_mesh
+from impression.modeling import rotate, make_box_mesh, make_cylinder_mesh
 
 
 def build():
@@ -20,9 +20,6 @@ def build():
     cap_height = 2.0
     cap = make_cylinder_mesh(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
     rotate(cap, axis=(1.0, 0.0, 0.0), angle_deg=90)
-    # Fuse into a single solid; tolerance kept small to avoid masking geometry issues.
-    # mesh = boolean_union([body, cap], tolerance=1e-4)
-
     return [cap, body]
 
 

--- a/docs/examples/csg/tooth_union_example.py
+++ b/docs/examples/csg/tooth_union_example.py
@@ -1,7 +1,7 @@
-"""Solid tombstone: box + rounded top, fused via boolean_union.
+"""Solid tombstone mesh tool: box + rounded top fused via union_meshes.
 
 Run with:
-  impression preview docs/examples/csg/tooth_example.py
+  impression preview docs/examples/csg/tooth_union_example.py
 """
 
 from __future__ import annotations
@@ -10,7 +10,8 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import boolean_union, rotate, make_box_mesh, make_cylinder_mesh
+from impression.modeling import rotate, make_box_mesh, make_cylinder_mesh
+from impression.modeling.mesh_tools import union_meshes
 
 
 def build():
@@ -21,7 +22,7 @@ def build():
     cap = make_cylinder_mesh(radius=2.5, height=cap_height, center=(0.0, 0.0, 0.0), color=(0.5,0.5,0.5,1.0))
     rotate(cap, axis=(1.0, 0.0, 0.0), angle_deg=90)
     # Fuse into a single solid; tolerance kept small to avoid masking geometry issues.
-    mesh = boolean_union([body, cap], tolerance=1e-4)
+    mesh = union_meshes([body, cap], tolerance=1e-4)
 
     return mesh
 

--- a/docs/examples/csg/union_example.py
+++ b/docs/examples/csg/union_example.py
@@ -1,23 +1,30 @@
-"""CSG union example."""
+"""Surface CSG union example."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from impression.io import write_stl
-
-from impression.modeling import boolean_union, make_box_mesh, make_cylinder_mesh
+from impression.modeling import (
+    boolean_union,
+    export_tessellation_request,
+    make_box,
+    tessellate_surface_body,
+)
 
 
 def build():
-    box = make_box_mesh(size=(2, 2, 1), color=(0.35, 0.55, 0.95))
-    cyl = make_cylinder_mesh(radius=0.6, height=1.5, color=(1.0, 0.6, 0.2))
-    return boolean_union([box, cyl])
+    left = make_box(size=(2, 2, 1), center=(-0.5, 0, 0), color=(0.35, 0.55, 0.95))
+    right = make_box(size=(2, 2, 1), center=(0.5, 0, 0), color=(1.0, 0.6, 0.2))
+    result = boolean_union([left, right])
+    if result.status != "succeeded" or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface union did not produce a body.")
+    return result.body
 
 
 if __name__ == "__main__":
     OUTPUT = Path("dist")
     OUTPUT.mkdir(exist_ok=True)
-    mesh = build()
+    mesh = tessellate_surface_body(build(), export_tessellation_request()).mesh
     write_stl(mesh, OUTPUT / "union_example.stl")
     print("Saved union_example.stl with", mesh.n_faces, "faces")

--- a/docs/examples/csg/union_meshes_example.py
+++ b/docs/examples/csg/union_meshes_example.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 from impression.io import write_stl
 
-from impression.modeling import make_box_mesh, make_cylinder_mesh, union_meshes
+from impression.modeling import make_box_mesh, make_cylinder_mesh
+from impression.modeling.mesh_tools import union_meshes
 
 
 def build():

--- a/docs/modeling/csg.md
+++ b/docs/modeling/csg.md
@@ -1,216 +1,204 @@
-# Modeling — CSG Helpers
+# Modeling — Surface Booleans
 
-Mesh compatibility helpers are imported from `impression.modeling`:
+Impression's public modeling booleans operate on `SurfaceBody` geometry. They
+never accept triangle meshes as modeling operands and never convert meshes back
+into surface truth.
 
 ```python
 from impression.modeling import (
-    boolean_union,
+    SurfaceBooleanResult,
     boolean_difference,
     boolean_intersection,
-    make_box_mesh,
-    make_cylinder_mesh,
-    union_meshes,
-)
-```
-
-Booleans propagate per-object colors onto result faces. Union/intersection faces keep the originating mesh color; difference assigns new cut faces to the cutter’s color.
-If no input colors are provided, the result uses the default preview color.
-
-The mesh-lane helpers operate on internal triangle meshes and use `manifold3d`
-for robust, watertight-aware booleans. Feed them mesh-specific inputs such as
-`make_*_mesh(...)` or a mesh produced by an explicit tessellation boundary. Do
-not treat public `make_*` primitives as mesh constructors; those return
-`SurfaceBody` by default.
-Install requirement: `pip install manifold3d`.
-
-## Surface-First Status
-
-Surface-body booleans are still in migration, so the public boolean execution helpers remain mesh-primary for now. The surfaced work that is ready today is the canonical input-preparation layer:
-
-```python
-from impression.modeling import (
+    boolean_union,
     make_box,
-    prepare_surface_boolean_difference_operands,
-    prepare_surface_boolean_operands,
-    surface_boolean_overlap_fragments,
-    surface_boolean_intersection_stage,
-)
-
-left = make_box(size=(1.0, 1.0, 1.0))
-right = make_box(size=(1.0, 1.0, 1.0), center=(0.25, 0.0, 0.0))
-
-prepared_union = prepare_surface_boolean_operands("union", [left, right])
-prepared_difference = prepare_surface_boolean_difference_operands(left, [right])
-intersection_stage = surface_boolean_intersection_stage(prepared_union)
-overlap_fragments = surface_boolean_overlap_fragments(
-    prepare_surface_boolean_operands("intersection", [left, right])
 )
 ```
 
-Current surfaced boolean eligibility rules are explicit and deterministic:
-
-- operands must be `SurfaceBody` instances
-- each operand must contain exactly one shell
-- each shell must be connected
-- each operand must be closed-valid under shell seam and boundary truth
-- canonical preparation bakes attached transforms into patch geometry before later execution
-
-This preparation layer exists so surfaced boolean execution can land on top of a stable input contract instead of silently falling back to mesh truth.
-
-The first bounded execution helper is also available now:
-
-- `surface_boolean_intersection_stage(...)`
-- `surface_boolean_overlap_fragments(...)` for the current overlap-intersection box slice
-
-That helper currently computes deterministic surfaced cut-curve and patch
-classification records, including bounded split-selection records, for the
-intentionally small initial scope:
-
-- exactly two operands
-- simple single-shell axis-aligned planar box-style operands without trims
-
-More general surfaced boolean execution is still tracked by the remaining open
-surface boolean execution leaves.
-
-The public boolean helpers are surfacebody-result APIs. Today that surfacebody route:
-
-- validates and canonicalizes `SurfaceBody` operands
-- can return a structured `SurfaceBooleanResult`
-- runs supported reconstructed outputs through a deterministic surfaced validity gate with bounded cleanup
-- never emits a legacy mesh deprecation warning
-- succeeds for a very small bounded initial scope:
-  - exact no-cut disjoint, touching, equal, and exact-containment cases in the current supported primitive families
-  - `intersection` of simple overlapping axis-aligned box-style operands
-  - `union` of simple overlapping axis-aligned box-style operands when the result stays a single connected orthogonal surfaced shell
-  - `difference` of simple overlapping axis-aligned box-style operands when the result stays a single connected orthogonal surfaced shell
-  - `union` of simple disjoint surfaced operands as a multi-shell surfaced result
-  - `union` when one bounded supported surfaced operand exactly contains the other or both are equal
-  - `difference` when the cutter is disjoint from the base, or fully removes it through an exact no-cut relation
-- remains explicitly unsupported for broader surfaced boolean cases
-
-That means callers can start moving onto the surfaced contract now without pretending the general surface boolean kernel is already finished.
-
-Within that surfaced lane, result posture is now explicit across three caller-facing outcomes:
-
-- `status="succeeded"` for accepted surfaced results
-- `status="invalid"` when bounded cleanup cannot make a reconstructed surfaced result pass the validity gate
-- `status="unsupported"` when the current surfaced execution slice does not implement the requested case yet
-
-## Migration Posture
-
-The public boolean APIs now separate surfacebody modeling from explicit mesh compatibility:
-
-- surfacebody-result APIs: public boolean helpers validate `SurfaceBody` operands and return `SurfaceBooleanResult`
-- explicit mesh compatibility: `union_meshes(...)` and `make_*_mesh(...)` stay behind mesh-named helpers
-
-The surfaced lane is the migration contract for downstream callers that want to stop depending on mesh-primary boolean truth. It is intentionally honest:
-
-- surfaced inputs are validated and canonicalized
-- surfaced results are explicit and structured
-- supported reconstructed results get only bounded deterministic cleanup such as duplicate seam-use removal and canonical ordering
-- invalid surfaced reconstruction remains explicit instead of silently falling back to mesh
-- unsupported execution stays surfaced and does not fall back to mesh
-- legacy mesh deprecation posture remains in place for the executable mesh lane
-
-If you need triangle output, tessellate accepted `SurfaceBody` results or use explicit mesh compatibility helpers at mesh-consumer boundaries.
-
-## Reference Readiness
-
-The surfaced CSG reference program has two representative overlap-evidence
-fixtures active today:
-
-- `surfacebody/csg_union_box_post`
-- `surfacebody/csg_difference_slot`
-
-Those active overlap fixtures carry:
-
-- dirty and clean reference images
-- dirty and clean reference STL files
-- triptych-style operand/result presentation so operand A, result, and operand
-  B stay visible in one deterministic render
-- canonical slice artifacts with an asymmetric edge-protrusion cue so rotated
-  section truth fails clearly
-
-The still-open initial matrix also includes:
-
-- `surfacebody/csg_intersection_box_sphere`
-
-That named intersection entry remains part of the required surfaced CSG
-promotion matrix, but it is still open because the bounded surfaced execution
-lane does not yet own a meaningful partial-overlap box/sphere result.
-
-Orientation-sensitive fixtures may carry canonical slice artifacts:
-
-- expected section bitmap
-- recovered section bitmap
-- visual diff bitmap
-
-Those slice checks classify whether the recovered section is the same shape with
-the same orientation, the same shape but rotated, or a different shape.
-
-## boolean_union(meshes, tolerance=1e-4)
-- Combine two or more meshes into a single body.
-- `meshes`: iterable of internal meshes (`Mesh`/`MeshGroup`).
-- `tolerance`: reserved for future mesh hygiene tuning.
-- Example: `docs/examples/csg/union_example.py` (blue box + orange cylinder)
-- Preview: `impression preview docs/examples/csg/union_example.py`
+All three functions return `SurfaceBooleanResult`. Inspect the result before
+passing its body to preview, export, or another modeling operation:
 
 ```python
-from impression.modeling import boolean_union, make_box_mesh, make_cylinder_mesh
+result = boolean_union(
+    [
+        make_box(size=(2, 2, 1), center=(-0.5, 0, 0)),
+        make_box(size=(2, 2, 1), center=(0.5, 0, 0)),
+    ]
+)
+
+if result.status != "succeeded" or result.body is None:
+    raise RuntimeError(result.failure_reason or "Surface union did not produce a body.")
+
+body = result.body
+```
+
+This explicit envelope keeps unsupported geometry, invalid reconstruction, and
+valid no-cut outcomes distinct from successful changed geometry.
+
+## Public Contract
+
+```text
+boolean_union(bodies: Iterable[SurfaceBody], tolerance: float = 1e-4) -> SurfaceBooleanResult
+boolean_difference(base: SurfaceBody, cutters: Iterable[SurfaceBody], tolerance: float = 1e-4) -> SurfaceBooleanResult
+boolean_intersection(bodies: Iterable[SurfaceBody], tolerance: float = 1e-4) -> SurfaceBooleanResult
+```
+
+The operand collection is named `bodies`, not `meshes`. Runtime validation
+happens before CSG family selection or kernel dispatch. Passing `Mesh`,
+`MeshGroup`, or a mixed collection raises `TypeError` and points to the separate
+mesh-tool namespace.
+
+Every surfaced operand must be closed-valid. Preparation bakes attached
+transforms into patch geometry and preserves the structured evidence used by
+the execution and validity gates.
+
+## Result Statuses
+
+- `succeeded`: the operation produced an accepted surfaced result.
+- `no-cut`: a difference was proven disjoint and retains the unchanged closed
+  base honestly.
+- `invalid`: the candidate contradicted the public result contract or failed
+  closure, seam, operand-witness, or change validation.
+- `unsupported`: the exact surface kernel does not implement the requested
+  geometry family or topology.
+
+Successful results provide `result.body`. Invalid and unsupported results do
+not expose partial geometry. Surface difference additionally publishes
+normalized geometry-change evidence and a public success-gate decision so an
+unchanged interacting result cannot be mislabeled as success.
+
+## `boolean_union(bodies, tolerance=1e-4)`
+
+Combine two or more closed surface bodies. Supported coincident-contact routes
+remove interior faces and validate the reconstructed shell before returning
+success.
+
+```python
+from impression.modeling import boolean_union, make_box
+
 
 def build():
-    box = make_box_mesh(size=(2, 2, 1))
-    cyl = make_cylinder_mesh(radius=0.6, height=1.5)
-    return boolean_union([box, cyl])
+    left = make_box(size=(2, 2, 1), center=(-0.5, 0, 0))
+    right = make_box(size=(2, 2, 1), center=(0.5, 0, 0))
+    result = boolean_union([left, right])
+    if result.status != "succeeded" or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface union failed.")
+    return result.body
 ```
+
+Example: `docs/examples/csg/union_example.py`
 
 ![Union CSG](../assets/previews/csg-union.png)
 
-You can also union a collection directly with `union_meshes`, which accepts either an iterable or a mapping (e.g., dict) of meshes:
+## `boolean_difference(base, cutters, tolerance=1e-4)`
+
+Subtract one or more closed surface cutters from a closed surface base.
+Successful interacting results must contain a real reconstructed cut and pass
+the shared difference success gate.
 
 ```python
-from impression.modeling import make_box_mesh, make_cylinder_mesh, union_meshes
+from impression.modeling import boolean_difference, make_box
+
 
 def build():
-    a = make_box_mesh(size=(2, 2, 1), color="#5A7BFF")
-    b = make_cylinder_mesh(radius=0.8, height=1.5, color="#FF7A18")
-    return union_meshes({"box": a, "cyl": b})
+    base = make_box(size=(3, 2, 2))
+    cutter = make_box(size=(1.5, 1, 3), center=(1, 0, 0))
+    result = boolean_difference(base, [cutter])
+    if result.status not in {"succeeded", "no-cut"} or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface difference failed.")
+    return result.body
 ```
 
-Example: `docs/examples/csg/union_meshes_example.py`
-
-`union_meshes(...)` is retained as an explicit standalone mesh tool. It is
-useful for analysis, repair, and debugging workflows, but it should not be read
-as canonical surfaced modeling truth.
-
-## boolean_difference(base, cutters, tolerance=1e-4)
-- Subtract one or more cutter meshes from `base`.
-- Example: `docs/examples/csg/difference_example.py`
-- Preview: `impression preview docs/examples/csg/difference_example.py`
-
-```python
-from impression.modeling import boolean_difference, make_box_mesh, make_cylinder_mesh
-
-def build():
-    base = make_box_mesh(size=(2, 2, 2))
-    cutter = make_cylinder_mesh(radius=0.4, height=2.5)
-    return boolean_difference(base, [cutter])
-```
+Example: `docs/examples/csg/difference_example.py`
 
 ![Difference CSG](../assets/previews/csg-difference.png)
 
-## boolean_intersection(meshes, tolerance=1e-4)
-- Keep only overlapping volume among provided meshes.
-- Example: `docs/examples/csg/intersection_example.py`
-- Preview: `impression preview docs/examples/csg/intersection_example.py`
+## `boolean_intersection(bodies, tolerance=1e-4)`
+
+Keep only the shared volume of two or more closed surface bodies.
 
 ```python
-from impression.modeling import boolean_intersection, make_box_mesh, make_sphere_mesh
+from impression.modeling import boolean_intersection, make_box
+
 
 def build():
-    box = make_box_mesh(size=(2, 2, 2))
-    sphere = make_sphere_mesh(radius=1.2)
-    return boolean_intersection([box, sphere])
+    left = make_box(size=(2, 2, 2), center=(-0.5, 0, 0))
+    right = make_box(size=(2, 2, 2), center=(0.5, 0, 0))
+    result = boolean_intersection([left, right])
+    if result.status != "succeeded" or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface intersection failed.")
+    return result.body
 ```
 
+Example: `docs/examples/csg/intersection_example.py`
+
 ![Intersection CSG](../assets/previews/csg-intersection.png)
+
+## Preview And Export
+
+Model modules should return the accepted `SurfaceBody`, not the result envelope.
+The preview and export commands tessellate that surface only at their consumer
+boundary:
+
+```bash
+impression preview docs/examples/csg/union_example.py
+impression export docs/examples/csg/union_example.py --output dist/union.stl --overwrite
+```
+
+Code that needs a mesh directly can use
+`tessellate_surface_body(body, export_tessellation_request())` after the boolean
+result has succeeded.
+
+## Explicit Mesh Tools
+
+Meshes remain useful for downstream analysis, repair, debugging, and terminal
+interchange. Those operations live in `impression.modeling.mesh_tools`, outside
+the public modeling boolean API:
+
+```python
+from impression.modeling import make_box_mesh, make_cylinder_mesh
+from impression.modeling.mesh_tools import union_meshes
+
+
+mesh = union_meshes(
+    {
+        "box": make_box_mesh(size=(2, 2, 1)),
+        "cylinder": make_cylinder_mesh(radius=0.8, height=1.5),
+    }
+)
+```
+
+`union_meshes(...)` is retained as an explicit standalone mesh tool. It is not
+canonical surfaced modeling truth and is intentionally absent from the
+top-level `impression.modeling` export table.
+
+Example: `docs/examples/csg/union_meshes_example.py`
+
+## Current Exact Scope
+
+The surface kernel supports bounded exact routes, including:
+
+- disjoint, touching, equal, and containment classifications for supported
+  primitive families;
+- overlapping axis-aligned box union, difference, and intersection;
+- coplanar loft-body contact union with interior-patch removal;
+- exact rectangular-loft/orthogonal-box difference reconstruction;
+- explicit structured refusal for unsupported higher-order or underconstrained
+  topology.
+
+Unsupported execution remains surfaced and does not fall back to mesh. Accepted
+reconstructed bodies pass deterministic seam, adjacency, closure, provenance,
+and operand-witness validation.
+
+## Reference Readiness
+
+The surfaced CSG reference program includes:
+
+- `surfacebody/csg_union_box_post`
+- `surfacebody/csg_difference_slot`
+- `surfacebody/csg_intersection_box_sphere`
+
+Reference cases carry dirty and clean reference images, dirty and clean
+reference STL files, and triptych-style operand/result presentation. Canonical
+slice artifacts use an asymmetric edge-protrusion cue and compare the expected
+section bitmap, recovered section bitmap, and visual diff bitmap, distinguishing
+the same shape from the same shape but rotated.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,8 +1,8 @@
 # Tutorial - Getting Started
 
 This tutorial walks through the basics: creating your first model, previewing it, and
-exporting a watertight STL. Every step uses Impression primitives and helpers (internal
-meshes), with PyVista acting only as the viewer.
+exporting a watertight STL. Every modeling step uses surfaced Impression
+primitives; tessellation occurs only in preview and export consumers.
 
 ## 1) Create a Simple Model
 
@@ -15,16 +15,18 @@ from impression.modeling import make_box, make_cylinder, boolean_union
 def build():
     base = make_box(size=(40, 30, 6))
     post = make_cylinder(radius=5, height=18).translate((12, 8, 6))
-    return boolean_union([base, post])
+    result = boolean_union([base, post])
+    if result.status != "succeeded" or result.body is None:
+        raise RuntimeError(result.failure_reason or "Surface union failed.")
+    return result.body
 ```
 
 Key ideas:
 
-- `build()` returns internal meshes, not PyVista objects.
+- `build()` returns a `SurfaceBody`, not a mesh or PyVista object.
 - All dimensions use your configured units (default: millimeters).
-- Public CSG is still executable on the mesh lane today. The surfaced CSG lane
-  exists as a migration contract and returns structured surfaced results rather
-  than renderable boolean geometry.
+- Public CSG accepts only `SurfaceBody` operands and returns a structured
+  `SurfaceBooleanResult`; preview and export consume the accepted `result.body`.
 
 ## 2) Preview
 
@@ -45,8 +47,8 @@ impression export examples/hello_impression.py --output dist/hello_impression.st
 
 ## 4) Add Color
 
-Color is applied at the mesh level and used in the viewer. This does not affect STL
-export, but it helps visualize assemblies and CSG behavior.
+Color metadata is retained on surfaced geometry and used in the viewer. This
+does not affect STL export, but it helps visualize assemblies and CSG behavior.
 
 ```python
 from impression.modeling import make_box

--- a/docs/tutorials/serious-modeling.md
+++ b/docs/tutorials/serious-modeling.md
@@ -9,8 +9,9 @@ Use these lanes instead:
 
 - loft for profile-to-profile transitions
 - surface-first primitives for bounded solid construction
-- CSG documentation for the current executable mesh boolean lane and the
-  surfaced migration slices
+- surface-only public booleans for supported exact CSG routes
+- explicit `impression.modeling.mesh_tools` utilities only for downstream mesh
+  analysis, repair, and debugging
 
 This page remains in place only so existing links fail honestly instead of
 silently teaching a workflow the project is removing.

--- a/project/release-1.0.0a4/README.md
+++ b/project/release-1.0.0a4/README.md
@@ -1,7 +1,7 @@
 # Impression v1.0.0a4 Corrective Release Definition
 
 Date: 2026-08-04
-Status: Proposed
+Status: Implementation Complete; Release Qualification Pending
 Issue set: [#242](https://github.com/kellyjanderson/Impression/issues/242) through [#248](https://github.com/kellyjanderson/Impression/issues/248)
 Base release: `v1.0.0a3`
 
@@ -91,4 +91,13 @@ The release candidate may be tagged only after:
 This release has 19 cohesive canonical leaves with 100% issue responsibility
 coverage and a [dependency-ordered implementation progression](planning/progression.md).
 
-Exact next workflow action: implement the progression from Wave 1 prerequisites.
+All 19 canonical implementation leaves and their paired test contracts are
+complete on the a4 integration branch. The source/docs/export inventory, primary
+surface CSG examples, and an isolated clean-wheel runtime smoke agree on the
+surface-only boolean contract. The full local repository suite passed 1,781
+tests on macOS on 2026-08-05.
+
+Exact next workflow action: perform release-candidate qualification against the
+remaining version-level gates, including the complete test-model reproduction,
+supported Linux lane, one-time wheel/sdist/docs artifact build, clean-install
+qualification of those exact artifacts, and prerelease publication approval.

--- a/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
+++ b/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
@@ -1,7 +1,7 @@
 # Surface Boolean Correctness And API Boundary Architectural Change Document
 
 Date: 2026-08-04
-Status: In Progress
+Status: Implementation Complete; Canonical Reconciliation Pending
 Canonical architecture targets:
 
 - `project/release-0.1.0a/architecture/csg-coincident-contact-architecture.md`
@@ -197,7 +197,8 @@ yet reconstruct exactly.
 
 ## Conformance Checklist
 
-- [ ] Implementation conforms to the target architecture.
+- [x] Implementation conforms to the target architecture within the declared
+  bounded exact-support and truthful-refusal envelope.
 - [x] Fix 02 rectangular-loft face-touch/overlap merger conforms and passes the public preview/export route.
 - [x] Fix 08A bounds-pruned loft difference intersections produce closed provenance-bearing trim fragments or precise refusal.
 - [x] Fix 09A normalizes every surfaced difference result into validated changed, unchanged, or ambiguous evidence.
@@ -205,6 +206,9 @@ yet reconstruct exactly.
 - [x] Final leaves are independently reviewed and canonicalized.
 - [x] Paired test specs point to canonical leaves.
 - [x] Final progression preserves no-op gate and API migration prerequisites.
+- [x] Fix 07A and Fix 07B align runtime signatures, top-level exports,
+  documentation, tutorials, executable examples, preview/export consumption,
+  and the isolated clean-wheel contract.
 - [ ] Canonical CSG/API architecture is reconciled after implementation.
 
 ## Closure Criteria
@@ -221,6 +225,12 @@ architecture records the conformed solver and compatibility boundaries.
 
 ## Change History
 
+- 2026-08-05 - Completed Fix 07A and Fix 07B. Reason: the public modeling
+  boolean boundary now accepts only `SurfaceBody`, returns
+  `SurfaceBooleanResult`, rejects mesh representations before dispatch, keeps
+  mesh union under `impression.modeling.mesh_tools`, and is consistent across
+  source, reference docs, tutorials, executable examples, preview/export
+  consumers, and an isolated installed wheel.
 - 2026-08-04 - Completed Fix 09B. Reason: the shared public difference gate now
   requires changed interacting evidence for success, reports proven disjoint
   clones as explicit no-cut, and rejects unchanged overlap, tangent, ambiguous,

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -247,13 +247,16 @@ prerequisites are complete; the whole preceding wave need not finish first.
 
 ### Fix 07B: Surface Boolean Docs And Package Contract
 
-- [ ] Implement documentation, example, inventory-guard, and clean-package conformance for the surface-only API.
+- [x] Implement documentation, example, inventory-guard, and clean-package conformance for the surface-only API.
   - Specification: [Fix 07B](../specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md)
   - Prerequisite: [Fix 07A](../specifications/fix-07a-surface-only-boolean-runtime-api-v1_0.md)
-- [ ] Wire the public contract through installed-package docs, tutorials, and examples.
-- [ ] Validate documentation assertions and clean-wheel smoke against the runtime API.
+- [x] Wire the public contract through installed-package docs, tutorials, and examples.
+- [x] Validate documentation assertions and clean-wheel smoke against the runtime API.
   - Test specification: [Fix 07B Test](../test-specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md)
-- [ ] Update release docs, progression, and surface-boolean ACD status after route validation.
+- [x] Update release docs, progression, and surface-boolean ACD status after route validation.
+  - All 19 canonical implementation leaves and their paired test contracts are
+    now complete; release-candidate qualification remains a separate release
+    gate.
 
 ## Specification Canonicalization
 

--- a/project/release-1.0.0a4/specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 07B: Surface Boolean Docs And Package Contract
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Primary ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Source artifact: [Split parent](./fix-07-surface-only-public-boolean-api-v1_0.md)
@@ -111,13 +111,13 @@ Pass 4 split decision: retained. Cohesion reason: one source/docs/wheel conforma
 - Architecture feedback status:
   - tracked in active ACD
 - Already implemented prerequisites:
-  - existing records/routes named under Dependencies And Routes
+  - Fix 07a runtime API
 - Missing prerequisite architecture:
   - none
 - Missing prerequisite specifications:
   - none
 - Unimplemented prerequisite specifications:
-  - Fix 07a runtime API
+  - none
 - Progression handling:
   - prerequisites listed above run first; otherwise this child may proceed after canonical review
 
@@ -178,6 +178,9 @@ App-type-specific proof:
 ## Error And State Behavior
 
 - stale mesh signature/example or package mismatch fails validation
+- clean-wheel validation asserts the imported module originates inside the
+  isolated installation target, preventing an editable source checkout from
+  satisfying package acceptance accidentally
 
 ## Test Strategy
 
@@ -192,6 +195,29 @@ App-type-specific proof:
   - installed package, API documentation, tutorials, and examples must exercise consistent source/docs/wheel contract and migration guidance
 - Production-data rule:
   - deterministic project fixtures and temporary directories only
+
+## Implementation Evidence
+
+- `docs/modeling/csg.md` now defines only `SurfaceBody` operands and
+  `SurfaceBooleanResult` returns for public modeling booleans, including result
+  statuses, migration errors, supported exact scope, and preview/export
+  consumption.
+- The getting-started and serious-modeling tutorials now return accepted
+  surfaced bodies and route retained mesh operations through
+  `impression.modeling.mesh_tools`.
+- The primary union, difference, and intersection examples execute the public
+  surfaced API and produce bodies consumable by preview and export
+  tessellation. Retained mesh-union examples import the separate tool boundary.
+- The source/docs/export inventory guard rejects stale parameter names,
+  mesh-primary prose, top-level mesh-union exports, and mesh operands in the
+  primary public boolean examples.
+- The clean-wheel smoke builds the wheel, installs it into an isolated target,
+  proves imports originate there, and validates signatures, exports, surfaced
+  execution, and actionable mesh rejection.
+- Validation on 2026-08-05: the paired Fix 07B contract passed 7 tests; the
+  focused release-contract group passed 284 tests; the full repository suite
+  passed 1,781 tests. The published union example also produced a non-empty
+  offscreen preview PNG and a non-empty binary STL through the real CLI.
 
 ## Acceptance Criteria
 

--- a/project/release-1.0.0a4/test-specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 07B Test: Surface Boolean Docs And Package Contract
 
 Date: 2026-08-04
-Status: Proposed
+Status: Final
 Feature spec: [Fix 07B: Surface Boolean Docs And Package Contract](../specifications/fix-07b-surface-boolean-docs-package-contract-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
@@ -59,6 +59,25 @@ This canonical paired contract verifies the complete retained split-child bounda
 ## Acceptance
 
 - [x] Feature child is canonical.
-- [ ] Route-level proof exists for library-only.
-- [ ] Helper-only tests cannot satisfy the contract.
-- [ ] Observable results and failure behavior are asserted.
+- [x] Route-level proof exists for library-only.
+- [x] Helper-only tests cannot satisfy the contract.
+- [x] Observable results and failure behavior are asserted.
+
+## Validation Evidence
+
+- Documentation assertions cover all public signatures, statuses, result-body
+  consumption, early `TypeError`, exact support posture, and the explicit mesh
+  tool namespace.
+- The three primary examples execute through `impression.modeling` and their
+  accepted bodies tessellate for both preview and export consumers.
+- The real CLI rendered the union example to a non-empty offscreen preview PNG
+  and exported it to a non-empty binary STL.
+- AST and inventory guards prevent `union_meshes` from returning to the
+  top-level modeling export and prevent mesh constructors from entering the
+  surfaced boolean examples.
+- The wheel is built and installed into an isolated target; its module origin,
+  annotations, exports, successful surfaced call, and mesh refusal are checked
+  in a fresh subprocess outside the source checkout.
+- Paired Fix 07B contract: 7 passed.
+- Focused docs, CSG, mesh-tool, and preview group: 284 passed.
+- Full repository suite: 1,781 passed.

--- a/tests/test_surface_csg_docs.py
+++ b/tests/test_surface_csg_docs.py
@@ -1,67 +1,267 @@
 from __future__ import annotations
 
+import ast
+import inspect
+import os
 from pathlib import Path
+import runpy
+import subprocess
+import sys
+import textwrap
+from typing import Iterable, get_type_hints
 
-from impression.modeling import inventory_legacy_primitive_mesh_assumptions
+import impression.modeling as modeling
+from impression.modeling import (
+    SurfaceBody,
+    SurfaceBooleanResult,
+    boolean_difference,
+    boolean_intersection,
+    boolean_union,
+    export_tessellation_request,
+    inventory_legacy_primitive_mesh_assumptions,
+    preview_tessellation_request,
+    tessellate_surface_body,
+)
+from impression.modeling import mesh_tools
 
 
-def test_csg_docs_explain_surface_migration_posture(project_root: Path) -> None:
-    doc = (project_root / "docs" / "modeling" / "csg.md").read_text()
-    assert "surfacebody-result APIs" in doc
-    assert "SurfaceBooleanResult" in doc
-    assert 'status="unsupported"' not in doc or "remains explicitly unsupported" in doc
-    assert "succeeds for a very small bounded initial scope" in doc
-    assert "exact no-cut disjoint, touching, equal, and exact-containment cases" in doc
-    assert "split-selection records" in doc
-    assert "surface_boolean_overlap_fragments" in doc
-    assert 'status="invalid"' in doc
-    assert "bounded deterministic cleanup" in doc
+SURFACE_CSG_EXAMPLES = (
+    Path("docs/examples/csg/union_example.py"),
+    Path("docs/examples/csg/difference_example.py"),
+    Path("docs/examples/csg/intersection_example.py"),
+)
+
+EXPLICIT_MESH_CSG_EXAMPLES = (
+    Path("docs/examples/csg/union_meshes_example.py"),
+    Path("docs/examples/csg/teeth_union_example.py"),
+    Path("docs/examples/csg/tooth_union_example.py"),
+)
+
+
+def test_csg_reference_documents_the_surface_only_runtime_contract(project_root: Path) -> None:
+    doc = (project_root / "docs/modeling/csg.md").read_text(encoding="utf-8")
+
+    assert "boolean_union(bodies: Iterable[SurfaceBody]" in doc
+    assert "boolean_difference(base: SurfaceBody, cutters: Iterable[SurfaceBody]" in doc
+    assert "boolean_intersection(bodies: Iterable[SurfaceBody]" in doc
+    assert doc.count("-> SurfaceBooleanResult") >= 3
+    assert "Passing `Mesh`" in doc
+    assert "`MeshGroup`, or a mixed collection raises `TypeError`" in doc
+    assert "before CSG family selection or kernel dispatch" in doc
+    assert "result.body" in doc
+    assert '`no-cut`' in doc
+    assert '`invalid`' in doc
+    assert '`unsupported`' in doc
     assert "does not fall back to mesh" in doc
+    assert "impression.modeling.mesh_tools" in doc
+    assert "intentionally absent from the\ntop-level `impression.modeling` export table" in doc
+
+    forbidden = (
+        "boolean_union(meshes",
+        "boolean_intersection(meshes",
+        "public boolean execution helpers remain mesh-primary",
+        "Surface-body booleans are still in migration",
+    )
+    assert not any(token in doc for token in forbidden)
 
 
-def test_csg_docs_define_required_reference_fixtures(project_root: Path) -> None:
-    doc = (project_root / "docs" / "modeling" / "csg.md").read_text()
+def test_csg_reference_keeps_surface_reference_evidence_explicit(project_root: Path) -> None:
+    doc = (project_root / "docs/modeling/csg.md").read_text(encoding="utf-8")
+
     assert "surfacebody/csg_union_box_post" in doc
     assert "surfacebody/csg_difference_slot" in doc
     assert "surfacebody/csg_intersection_box_sphere" in doc
     assert "dirty and clean reference images" in doc
-    assert "dirty and clean reference STL files" in doc
+    assert "dirty and clean\nreference STL files" in doc
     assert "triptych-style operand/result presentation" in doc
     assert "edge-protrusion cue" in doc
-    assert "does not yet own a meaningful partial-overlap box/sphere result" in doc
-    assert "expected section bitmap" in doc
+    assert "expected\nsection bitmap" in doc
     assert "same shape but rotated" in doc
 
 
-def test_tutorials_keep_mesh_boolean_lane_explicit_while_surface_lane_migrates(project_root: Path) -> None:
-    getting_started = (project_root / "docs" / "tutorials" / "getting-started.md").read_text()
-    serious_modeling = (project_root / "docs" / "tutorials" / "serious-modeling.md").read_text()
-    assert "surfaced CSG lane" in getting_started
-    assert "executable mesh boolean lane" in serious_modeling
+def test_tutorials_use_surface_results_and_explicit_mesh_tool_guidance(project_root: Path) -> None:
+    getting_started = (project_root / "docs/tutorials/getting-started.md").read_text(encoding="utf-8")
+    serious_modeling = (project_root / "docs/tutorials/serious-modeling.md").read_text(encoding="utf-8")
+
+    assert "result = boolean_union([base, post])" in getting_started
+    assert "return result.body" in getting_started
+    assert "returns a `SurfaceBody`, not a mesh" in getting_started
+    assert "Public CSG accepts only `SurfaceBody` operands" in getting_started
+    assert "executable mesh boolean lane" not in serious_modeling
+    assert "surface-only public booleans" in serious_modeling
+    assert "impression.modeling.mesh_tools" in serious_modeling
 
 
-def test_mesh_compatibility_docs_and_examples_use_explicit_mesh_inputs(project_root: Path) -> None:
-    paths = (
-        project_root / "README.md",
-        project_root / "docs" / "modeling" / "csg.md",
-        project_root / "docs" / "examples" / "csg" / "union_example.py",
-        project_root / "docs" / "examples" / "csg" / "difference_example.py",
-        project_root / "docs" / "examples" / "csg" / "intersection_example.py",
-        project_root / "docs" / "examples" / "csg" / "union_meshes_example.py",
-        project_root / "docs" / "examples" / "csg" / "teeth_union_example.py",
-        project_root / "docs" / "examples" / "csg" / "tooth_union_example.py",
-        project_root / "docs" / "examples" / "csg" / "tooth_example.py",
-        project_root / "docs" / "examples" / "csg" / "tooth_parts_example.py",
+def test_surface_csg_examples_execute_through_public_modeling_api(project_root: Path) -> None:
+    for relative_path in SURFACE_CSG_EXAMPLES:
+        source = (project_root / relative_path).read_text(encoding="utf-8")
+        namespace = runpy.run_path(str(project_root / relative_path))
+        body = namespace["build"]()
+
+        assert isinstance(body, SurfaceBody), relative_path
+        assert body.shell_count == 1, relative_path
+        assert "make_box_mesh" not in source, relative_path
+        assert "make_cylinder_mesh" not in source, relative_path
+        assert "make_sphere_mesh" not in source, relative_path
+        assert "result.body" in source, relative_path
+        for request in (preview_tessellation_request(), export_tessellation_request()):
+            mesh = tessellate_surface_body(body, request).mesh
+            assert mesh.n_faces > 0, (relative_path, request.consumer)
+
+
+def test_mesh_csg_examples_import_union_only_from_explicit_tool_boundary(project_root: Path) -> None:
+    for relative_path in EXPLICIT_MESH_CSG_EXAMPLES:
+        source = (project_root / relative_path).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(relative_path))
+        imports = [node for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)]
+
+        assert any(
+            node.module == "impression.modeling.mesh_tools"
+            and any(alias.name == "union_meshes" for alias in node.names)
+            for node in imports
+        ), relative_path
+        assert not any(
+            node.module == "impression.modeling"
+            and any(alias.name == "union_meshes" for alias in node.names)
+            for node in imports
+        ), relative_path
+
+
+def test_source_docs_and_exports_share_one_surface_boolean_inventory(project_root: Path) -> None:
+    expected = {
+        boolean_union: (("bodies", "tolerance"), Iterable[SurfaceBody]),
+        boolean_difference: (("base", "cutters", "tolerance"), SurfaceBody),
+        boolean_intersection: (("bodies", "tolerance"), Iterable[SurfaceBody]),
+    }
+    for function, (parameter_names, first_type) in expected.items():
+        signature = inspect.signature(function)
+        hints = get_type_hints(function)
+        assert tuple(signature.parameters) == parameter_names
+        assert hints[parameter_names[0]] == first_type
+        assert hints["return"] is SurfaceBooleanResult
+
+    assert get_type_hints(boolean_difference)["cutters"] == Iterable[SurfaceBody]
+    assert "union_meshes" not in modeling.__all__
+    assert not hasattr(modeling, "union_meshes")
+    assert "union_meshes" in mesh_tools.__all__
+    assert callable(mesh_tools.union_meshes)
+
+    inventory_paths = (
+        Path("README.md"),
+        Path("docs/modeling/csg.md"),
+        Path("docs/tutorials/getting-started.md"),
+        *SURFACE_CSG_EXAMPLES,
+        *EXPLICIT_MESH_CSG_EXAMPLES,
+        Path("docs/examples/csg/tooth_example.py"),
+        Path("docs/examples/csg/tooth_parts_example.py"),
     )
     report = inventory_legacy_primitive_mesh_assumptions(
-        {str(path.relative_to(project_root)): path.read_text(encoding="utf-8") for path in paths}
+        {
+            str(path): (project_root / path).read_text(encoding="utf-8")
+            for path in inventory_paths
+        }
     )
-    csg_doc = (project_root / "docs" / "modeling" / "csg.md").read_text(encoding="utf-8")
-    union_meshes_example = (project_root / "docs" / "examples" / "csg" / "union_meshes_example.py").read_text(
-        encoding="utf-8"
+    assert report.stale_findings == ()
+
+
+def _run_checked(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout
+
+
+def test_clean_wheel_exposes_the_same_surface_boolean_contract(project_root: Path, tmp_path: Path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    install_root = tmp_path / "installed"
+    wheelhouse.mkdir()
+
+    _run_checked(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(wheelhouse),
+            str(project_root),
+        ],
+        cwd=tmp_path,
+    )
+    wheels = tuple(wheelhouse.glob("impression-*.whl"))
+    assert len(wheels) == 1
+    _run_checked(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--target",
+            str(install_root),
+            str(wheels[0]),
+        ],
+        cwd=tmp_path,
     )
 
-    assert report.stale_findings == ()
-    assert "not treat public `make_*` primitives as mesh constructors" in csg_doc
-    assert "make_box_mesh" in union_meshes_example
-    assert "make_cylinder_mesh" in union_meshes_example
+    smoke = textwrap.dedent(
+        """
+        import inspect
+        import os
+        from pathlib import Path
+        from typing import Iterable, get_type_hints
+
+        import impression.modeling as modeling
+        from impression.modeling.mesh_tools import union_meshes
+
+        install_root = Path(os.environ["IMPRESSION_CLEAN_INSTALL_ROOT"]).resolve()
+        module_path = Path(modeling.__file__).resolve()
+        assert install_root in module_path.parents, (install_root, module_path)
+
+        expected = {
+            modeling.boolean_union: (("bodies", "tolerance"), Iterable[modeling.SurfaceBody]),
+            modeling.boolean_difference: (("base", "cutters", "tolerance"), modeling.SurfaceBody),
+            modeling.boolean_intersection: (("bodies", "tolerance"), Iterable[modeling.SurfaceBody]),
+        }
+        for function, (parameter_names, first_type) in expected.items():
+            signature = inspect.signature(function)
+            hints = get_type_hints(function)
+            assert tuple(signature.parameters) == parameter_names
+            assert hints[parameter_names[0]] == first_type
+            assert hints["return"] is modeling.SurfaceBooleanResult
+
+        assert get_type_hints(modeling.boolean_difference)["cutters"] == Iterable[modeling.SurfaceBody]
+        assert "union_meshes" not in modeling.__all__
+        assert not hasattr(modeling, "union_meshes")
+        assert callable(union_meshes)
+
+        outer = modeling.make_box(size=(2, 2, 2))
+        inner = modeling.make_box(size=(1, 1, 1))
+        result = modeling.boolean_union([outer, inner])
+        assert isinstance(result, modeling.SurfaceBooleanResult)
+        assert result.status == "succeeded"
+        assert result.body is not None
+
+        try:
+            modeling.boolean_union([modeling.make_box_mesh(size=(1, 1, 1))])
+        except TypeError as exc:
+            message = str(exc)
+            assert "accepts only SurfaceBody operands" in message
+            assert "impression.modeling.mesh_tools" in message
+        else:
+            raise AssertionError("clean wheel accepted a mesh modeling operand")
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(install_root)
+    env["IMPRESSION_CLEAN_INSTALL_ROOT"] = str(install_root)
+    env.pop("PYTHONHOME", None)
+    _run_checked([sys.executable, "-c", smoke], cwd=tmp_path, env=env)


### PR DESCRIPTION
## Summary
- migrate the CSG reference and tutorials to the surface-only runtime contract
- make the primary union, difference, and intersection examples execute public SurfaceBody booleans and return accepted bodies
- quarantine retained mesh-union examples behind impression.modeling.mesh_tools
- add source/docs/export inventory guards and an isolated clean-wheel signature/import/runtime smoke
- close every remaining a4 progression item while keeping release-candidate publication qualification explicit

## Validation
- Fix 07B paired contract: 7 passed
- focused docs/CSG/mesh-tool/preview group: 284 passed
- full suite: 1781 passed in 231.65s
- real CLI offscreen preview PNG smoke passed
- real CLI binary STL export smoke passed
- git diff --check