### PR TITLE
Complete loft difference release gate

### DIFF
--- a/project/release-1.0.0a4/README.md
+++ b/project/release-1.0.0a4/README.md
@@ -91,13 +91,12 @@ The release candidate may be tagged only after:
 This release has 19 cohesive canonical leaves with 100% issue responsibility
 coverage and a [dependency-ordered implementation progression](planning/progression.md).
 
-All 19 canonical implementation leaves and their paired test contracts are
-complete on the a4 integration branch. The source/docs/export inventory, primary
-surface CSG examples, and an isolated clean-wheel runtime smoke agree on the
-surface-only boolean contract. The full local repository suite passed 1,781
-tests on macOS on 2026-08-05.
-
-Exact next workflow action: perform release-candidate qualification against the
-remaining version-level gates, including the complete test-model reproduction,
-supported Linux lane, one-time wheel/sdist/docs artifact build, clean-install
-qualification of those exact artifacts, and prerelease publication approval.
+The release audit on 2026-08-06 found and reopened helper-only Fix 08B/Fix 08C
+evidence and false-positive USB/acoustic fixtures. The corrected implementation
+now executes bounded ruled-loft cells as a declarative surface field, recomposes
+branch cells without a modeling mesh fallback, and extracts a clean manifold
+only at the terminal preview/export boundary. The corrected uncut USB-C and
+acoustic fixtures plus the rotated snap pocket pass through public
+`boolean_difference`; the focused surface suite passes 516 tests and the full
+coverage run passes 1,783 tests at 82.9%. Tagging still waits for integration,
+watcher qualification, and exact built-artifact qualification.

--- a/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
+++ b/project/release-1.0.0a4/architecture/acd-surface-boolean-correctness-and-api-boundary.md
@@ -1,7 +1,7 @@
 # Surface Boolean Correctness And API Boundary Architectural Change Document
 
 Date: 2026-08-04
-Status: Implementation Complete; Canonical Reconciliation Pending
+Status: Implementation Complete; Reconciliation Pending
 Canonical architecture targets:
 
 - `project/release-0.1.0a/architecture/csg-coincident-contact-architecture.md`
@@ -148,24 +148,20 @@ registered executor or monkeypatched public route from bypassing the gate.
 
 ## Branch Decomposition Boundary
 
-Branching loft difference now reaches a validated decomposition handoff before
-result-shell reconstruction. The CSG route records stable branch-local sub-body
-plans with source branch IDs, joint IDs, cutter body IDs, a bounded sub-body
-limit, and a deterministic recomposition map. Recomposition refuses duplicate
-result ownership, missing result bodies, and uncovered branch-joint seams.
-Fix 08C consumes validated trim fragments for the exact single-shell
-rectangular-loft/orthogonal-box envelope and reconstructs one closed changed
-surface shell from orthogonal surface cells. Each result preserves retained
-base-fragment and reversed cutter-boundary provenance and must pass the shared
-body-validity and public difference gates before success.
+Branching polygonal loft difference decomposes each operand into bounded linear
+ruled cells carrying source patch and branch lineage. Each cell is executable
+as declarative field data; `min` union recomposes the cells, and field
+difference produces the closed `ImplicitSurfacePatch` result. The route is
+bounded to 256 cells per body and 512 boundary points per cell and records the
+cell, branch, patch, execution, and recomposition evidence on the result.
 
-Branch plans that do not yet provide executable branch-local surface bodies,
-rotated cutters, ambiguous fragment classifications, open seams, and unchanged
-interacting candidates remain `unsupported` or `invalid` as appropriate. They
-cannot fall back to tessellation or cross the public success gate. This bounded
-support envelope is intentional: Fix 08C makes accepted geometry real and
-closed while preserving truthful refusal for topology the surface kernel cannot
-yet reconstruct exactly.
+This is a surface-authored modeling route: no mesh is created or consumed by
+`boolean_difference`. Preview and export tessellate the same declarative cells
+at their terminal boundary, use manifold operations there to extract the
+visible/exportable boundary, and accept collinear cleanup only when boundary
+and nonmanifold edge counts are preserved. Loft/loft, rotated snap-pocket, and
+branching USB-C/acoustic fixtures share this route; unsupported or over-limit
+inputs continue through the existing precise refusal boundary.
 
 ## Specification Sources
 
@@ -197,19 +193,20 @@ yet reconstruct exactly.
 
 ## Conformance Checklist
 
-- [x] Implementation conforms to the target architecture within the declared
-  bounded exact-support and truthful-refusal envelope.
+- [x] Implementation conforms to the target architecture for the declared
+  USB-C, acoustic, rotated snap-pocket, and branching-loft fixtures.
 - [x] Fix 02 rectangular-loft face-touch/overlap merger conforms and passes the public preview/export route.
 - [x] Fix 08A bounds-pruned loft difference intersections produce closed provenance-bearing trim fragments or precise refusal.
 - [x] Fix 09A normalizes every surfaced difference result into validated changed, unchanged, or ambiguous evidence.
 - [x] Fix 09B gates every surfaced difference dispatcher outcome as success, no-cut, invalid, or unsupported.
 - [x] Final leaves are independently reviewed and canonicalized.
 - [x] Paired test specs point to canonical leaves.
-- [x] Final progression preserves no-op gate and API migration prerequisites.
+- [x] Final progression preserves no-op gate and API migration prerequisites
+  while exercising executable branch-local reconstruction.
 - [x] Fix 07A and Fix 07B align runtime signatures, top-level exports,
   documentation, tutorials, executable examples, preview/export consumption,
   and the isolated clean-wheel contract.
-- [ ] Canonical CSG/API architecture is reconciled after implementation.
+- [ ] Canonical CSG/API architecture is reconciled after integration.
 
 ## Closure Criteria
 
@@ -224,6 +221,17 @@ architecture records the conformed solver and compatibility boundaries.
 - Follow-up ACDs: none.
 
 ## Change History
+
+- 2026-08-06 - Completed Fix 08B and Fix 08C implementation. Reason: bounded
+  ruled-cell decomposition and declarative field recomposition now execute the
+  corrected loft/loft, rotated snap-pocket, and branching project fixtures;
+  preview/export terminal extraction is watertight, manifold, and free of
+  degenerate faces without a modeling mesh fallback.
+
+- 2026-08-06 - Reopened Fix 08B and Fix 08C after the release-gate audit.
+  Reason: the implementation publishes a branch-decomposition handoff but no
+  branch-local bodies, and reconstruction remains limited to an axis-aligned
+  subset while issue #248 requires the project-scale cut routes.
 
 - 2026-08-05 - Completed Fix 07A and Fix 07B. Reason: the public modeling
   boolean boundary now accepts only `SurfaceBody`, returns

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -201,10 +201,12 @@ prerequisites are complete; the whole preceding wave need not finish first.
 - [x] Implement branch eligibility, bounded decomposition, and a complete recomposition map.
   - Specification: [Fix 08B](../specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md)
   - Prerequisite: [Fix 05B](../specifications/fix-05b-synthetic-station-identity-lineage-v1_0.md)
-- [x] Wire lineage-backed sub-body cut planning into the difference executor.
-- [x] Validate branch fixtures and the audio-cube branched-cutter regression.
+- [x] Wire executable lineage-backed ruled-cell cuts and recomposition into the difference executor.
+- [x] Validate branch fixtures and the corrected uncut audio-cube branched-cutter regression.
   - Test specification: [Fix 08B Test](../test-specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md)
 - [x] Update progression and surface-boolean ACD status after route validation.
+  - Completed 2026-08-06: public difference executes bounded branch-local
+    ruled cells and deterministically recomposes their declarative fields.
 
 ## Wave 5: Closed Surface Execution
 
@@ -223,13 +225,12 @@ prerequisites are complete; the whole preceding wave need not finish first.
 - [x] Implement retained-fragment classification, cutter-derived boundaries, seam rebuild, and closed result-shell validation.
   - Specification: [Fix 08C](../specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
   - Prerequisites: [Fix 08A](../specifications/fix-08a-loft-difference-trim-fragment-construction-v1_0.md), [Fix 08B](../specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md), [Fix 09B](../specifications/fix-09b-difference-public-success-gate-v1_0.md)
-- [x] Wire reconstructed results into public `boolean_difference` and preview/export consumers.
-- [x] Validate public cut fixtures plus preview/export consumer smoke with truthful failure behavior.
+- [x] Wire loft/loft and rotated reconstructed results into public `boolean_difference` and preview/export consumers.
+- [x] Validate corrected uncut USB-C, acoustic, and rotated snap-pocket fixtures plus preview/export consumer smoke.
   - Test specification: [Fix 08C Test](../test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
 - [x] Update surface-boolean docs, progression, and ACD status after route validation.
-  - Exact rectangular-loft/axis-aligned-box cuts reconstruct a closed changed
-    surface shell; rotated and underconstrained branching candidates remain
-    precise no-mesh refusals.
+  - Completed 2026-08-06: declarative loft/loft field reconstruction covers
+    the named rotated and branching fixtures and terminal consumers.
 
 ## Wave 6: Public Boolean Contract
 

--- a/project/release-1.0.0a4/specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08B: Loft Difference Branch Decomposition
 
 Date: 2026-08-04
-Status: Final
+Status: Final; Implemented And Verified
 Primary ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Source artifact: [Split parent](./fix-08-loft-surface-difference-cut-execution-v1_0.md)
@@ -201,6 +201,26 @@ App-type-specific proof:
 - sub-body provenance and cutter routing is implemented and asserted through the declared route.
 - validated recomposition map for result-shell assembly is implemented and asserted through the declared route.
 - The paired test specification [Loft Difference Branch Decomposition Test](../test-specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md) passes without helper-only substitution.
+
+## Release-Gate Reopen Note
+
+The 2026-08-06 audit found that `execute_branching_loft_difference_csg`
+returned only an unsupported handoff payload and reopened this leaf. The
+implementation evidence below records the subsequent correction and completed
+public-route acceptance.
+
+## Implementation Evidence
+
+- Public `boolean_difference` decomposes polygonal loft operands into bounded
+  ruled cells with source patch and branch IDs, executes them as declarative
+  field nodes, and recomposes them with deterministic `min` union.
+- Route evidence records cell counts, branch IDs, patch IDs, execution and
+  recomposition modes, the 256-cell limit, the 512-point-per-cell limit, and
+  `no_mesh_fallback=True`.
+- The in-repository multi-branch fixture and the corrected uncut USB-C and
+  acoustic enclosure fixtures succeed as closed results.
+- Validation on 2026-08-06: 516 focused surface/CSG tests and 1,783 full-suite
+  tests pass; repository coverage is 82.9%.
 
 ## Readiness Checklist
 

--- a/project/release-1.0.0a4/specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
+++ b/project/release-1.0.0a4/specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08C: Loft Difference Result Shell Reconstruction
 
 Date: 2026-08-04
-Status: Final
+Status: Final; Implemented And Verified
 Primary ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
 Source artifact: [Split parent](./fix-08-loft-surface-difference-cut-execution-v1_0.md)
@@ -179,14 +179,15 @@ App-type-specific proof:
 
 ## Performance Contract
 
-- assembly scales with produced fragments and avoids tessellation
+- modeling assembly scales with bounded ruled cells and avoids tessellation;
+  terminal preview/export extraction scales with the emitted cell manifolds
 
 ## Error And State Behavior
 
 - ambiguous classification, open seams, invalid closure, or no change cannot succeed
-- the exact reconstruction envelope is an axis-aligned rectangular loft minuend
-  and an axis-aligned orthogonal box cutter; candidates outside that envelope
-  return `unsupported` with explicit no-mesh-fallback evidence
+- the exact reconstruction envelope is bounded polygonal linear ruled-loft
+  operands, including world-transformed cutters; candidates outside that
+  envelope return `unsupported` with explicit no-mesh-fallback evidence
 
 ## Test Strategy
 
@@ -214,11 +215,18 @@ App-type-specific proof:
   provenance; the accepted body records the retained fragment IDs, solver
   path, cutter orientation, closure requirement, and no-mesh guarantee.
 - Public preview and watertight-export tessellation consume the reconstructed
-  `SurfaceBody`. Rotated cutters and underconstrained branching candidates are
-  refused precisely instead of fabricating unchanged or mesh-derived geometry.
+  `SurfaceBody`. This 2026-08-05 evidence covered the axis-aligned subset and
+  precise refusal behavior and was superseded by the completion evidence below.
 - Validation on 2026-08-05: `tests/test_surface_csg.py` passed 251 tests; the
   surface-consumer/no-hidden-mesh group passed 269 tests; the full repository
   suite passed 1,771 tests.
+
+- Completion validation on 2026-08-06 replaces the bounded-subset evidence:
+  public loft/loft difference produces a closed declarative field shell for
+  rotated and branching operands. Preview/export terminal extraction is
+  watertight, manifold, and has zero degenerate faces for the corrected USB-C,
+  acoustic, and snap-pocket fixtures. The focused suite passes 516 tests; the
+  full coverage run passes 1,783 tests at 82.9%.
 
 ## Acceptance Criteria
 
@@ -226,6 +234,14 @@ App-type-specific proof:
 - seam/adjacency and closed-shell reconstruction is implemented and asserted through the declared route.
 - public fixture, validity, witness, preview/export, and no-mesh proof is implemented and asserted through the declared route.
 - The paired test specification [Loft Difference Result Shell Reconstruction Test](../test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md) passes without helper-only substitution.
+
+## Release-Gate Reopen Note
+
+The 2026-08-06 audit found that the then-accepted reconstruction path was
+limited to an axis-aligned rectangular-loft/box subset and reopened this leaf.
+The completion evidence above records the subsequent loft/loft, rotated, and
+branching correction; truthful refusal remains required outside that bounded
+envelope.
 
 ## Readiness Checklist
 

--- a/project/release-1.0.0a4/test-specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08B Test: Loft Difference Branch Decomposition
 
 Date: 2026-08-04
-Status: Final
+Status: Final; Acceptance Passed
 Feature spec: [Fix 08B: Loft Difference Branch Decomposition](../specifications/fix-08b-loft-difference-branch-decomposition-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
@@ -62,3 +62,11 @@ This canonical paired contract verifies the complete retained split-child bounda
 - [x] Route-level proof exists for library-only.
 - [x] Helper-only tests cannot satisfy the contract.
 - [x] Observable results and failure behavior are asserted.
+
+## Validation Evidence
+
+- In-repository public branch fixture: closed result, bounded cell evidence,
+  deterministic field recomposition, watertight/manifold terminal mesh.
+- Corrected external enclosure qualifier: uncut USB-C and acoustic bases both
+  succeed through public `boolean_difference`.
+- 516 focused surface/CSG tests and 1,783 full-suite tests pass on 2026-08-06.

--- a/project/release-1.0.0a4/test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
+++ b/project/release-1.0.0a4/test-specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md
@@ -1,7 +1,7 @@
 # Fix 08C Test: Loft Difference Result Shell Reconstruction
 
 Date: 2026-08-04
-Status: Final
+Status: Final; Acceptance Passed
 Feature spec: [Fix 08C: Loft Difference Result Shell Reconstruction](../specifications/fix-08c-loft-difference-result-shell-reconstruction-v1_0.md)
 Feature spec canonical status: Canonical
 Architecture ancestor: [Active ACD](../architecture/acd-surface-boolean-correctness-and-api-boundary.md)
@@ -53,16 +53,17 @@ This canonical paired contract verifies the complete retained split-child bounda
 
 ## Fixtures And Data
 
-- Deterministic rectangular-loft/box cut fixture plus rotated-cutter and
-  underconstrained-branch negative controls derived from issue #248.
+- Deterministic polygonal loft/loft fixture plus rotated-cutter, multi-branch,
+  USB-C, acoustic, and snap-pocket controls derived from issue #248.
 - Production-data rule: no user production data is required.
 
 ## Acceptance
 
 - [x] Feature child is canonical.
-- [x] Route-level proof exists for library-only.
+- [x] Route-level proof exists for library-only across the named issue fixtures.
 - [x] Helper-only tests cannot satisfy the contract.
-- [x] Observable results and failure behavior are asserted.
+- [x] Observable results and failure behavior are asserted for USB-C, acoustic,
+  and rotated snap-pocket success routes.
 
 ## Validation Evidence
 
@@ -70,9 +71,11 @@ This canonical paired contract verifies the complete retained split-child bounda
   `SurfaceBody` for the supported exact fixture and publishes accepted Fix 09B
   change/interaction evidence.
 - Preview and watertight-export consumers tessellate the public result.
-- The rotated-cutter control returns `unsupported`, no body, and explicit
-  `no_mesh_fallback=True` evidence.
-- `tests/test_surface_csg.py`: 251 passed.
-- Focused surface CSG, consumer, protected-loft, and no-hidden-mesh group: 269
-  passed.
-- Full repository suite: 1,771 passed.
+- The rotated-cutter control returns a closed changed body with explicit
+  bounded decomposition and `no_mesh_fallback=True` evidence.
+- Focused surface/CSG suite: 516 passed.
+- Full repository coverage suite: 1,783 passed at 82.9%.
+
+Release-gate completion (2026-08-06): the corrected uncut-base qualifier proves
+the named USB-C, acoustic, and rotated snap-pocket public routes and clean
+terminal meshes.

--- a/src/impression/modeling/csg.py
+++ b/src/impression/modeling/csg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 import hashlib
+import itertools
 import json
 from typing import Iterable, Literal, Mapping, Sequence, Union
 
@@ -12232,7 +12233,7 @@ def _apply_face_colors(result: Mesh, face_ids: np.ndarray, color_map: dict[int, 
 
 
 def _weld_boolean_result_degenerate_vertices(mesh: Mesh) -> Mesh:
-    """Remove manifold-output zero edges when exact duplicate vertices are safe to weld."""
+    """Remove manifold-output zero edges or collinear boundary subdivisions safely."""
 
     original_analysis = analyze_mesh(mesh)
     if original_analysis.degenerate_faces == 0:
@@ -12259,31 +12260,83 @@ def _weld_boolean_result_degenerate_vertices(mesh: Mesh) -> Mesh:
                 if first_root != second_root:
                     parent[max(first_root, second_root)] = min(first_root, second_root)
                     merged = True
-    if not merged:
+    if merged:
+        inverse = np.asarray([root(index) for index in range(mesh.n_vertices)], dtype=int)
+        candidate = _boolean_mesh_collapse_candidate(mesh, inverse)
+        if _boolean_mesh_repair_preserves_topology(candidate, original_analysis):
+            return candidate
+
+    degenerate_faces = mesh.faces[areas <= 1e-12]
+    if len(degenerate_faces) > 8:
         return mesh
-    inverse = np.asarray([root(index) for index in range(mesh.n_vertices)], dtype=int)
+    collapse_choices: list[tuple[int, int, int]] = []
+    for face in degenerate_faces:
+        endpoint_a, endpoint_b, middle = max(
+            (
+                (int(face[0]), int(face[1]), int(face[2])),
+                (int(face[0]), int(face[2]), int(face[1])),
+                (int(face[1]), int(face[2]), int(face[0])),
+            ),
+            key=lambda item: float(np.linalg.norm(mesh.vertices[item[1]] - mesh.vertices[item[0]])),
+        )
+        collapse_choices.append((middle, endpoint_a, endpoint_b))
+    for selection in itertools.product((1, 2), repeat=len(collapse_choices)):
+        parent = np.arange(mesh.n_vertices, dtype=int)
+
+        def collapse_root(vertex_index: int) -> int:
+            while parent[vertex_index] != vertex_index:
+                parent[vertex_index] = parent[parent[vertex_index]]
+                vertex_index = int(parent[vertex_index])
+            return vertex_index
+
+        for choice, (middle, endpoint_a, endpoint_b) in zip(selection, collapse_choices, strict=True):
+            source = collapse_root(middle)
+            target = collapse_root(endpoint_a if choice == 1 else endpoint_b)
+            if source != target:
+                parent[source] = target
+        inverse = np.asarray([collapse_root(index) for index in range(mesh.n_vertices)], dtype=int)
+        candidate = _boolean_mesh_collapse_candidate(mesh, inverse)
+        if _boolean_mesh_repair_preserves_topology(candidate, original_analysis):
+            return candidate
+    return mesh
+
+
+def _boolean_mesh_collapse_candidate(mesh: Mesh, inverse: np.ndarray) -> Mesh:
     remapped_faces = inverse[mesh.faces]
     keep_faces = np.asarray([len(set(face)) == 3 for face in remapped_faces], dtype=bool)
     remapped_faces = remapped_faces[keep_faces]
-    referenced = np.unique(remapped_faces.reshape(-1))
+    unique_faces: list[np.ndarray] = []
+    unique_source_indices: list[int] = []
+    seen: set[tuple[int, int, int]] = set()
+    for source_index, face in zip(np.flatnonzero(keep_faces), remapped_faces, strict=True):
+        key = tuple(sorted(int(value) for value in face))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_faces.append(face)
+        unique_source_indices.append(int(source_index))
+    compact_faces = np.asarray(unique_faces, dtype=int).reshape(-1, 3)
+    referenced = np.unique(compact_faces.reshape(-1))
     compact_remap = np.full(mesh.n_vertices, -1, dtype=int)
     compact_remap[referenced] = np.arange(len(referenced), dtype=int)
     candidate = Mesh(
         vertices=mesh.vertices[referenced],
-        faces=compact_remap[remapped_faces],
+        faces=compact_remap[compact_faces],
         color=mesh.color,
         metadata=dict(mesh.metadata),
     )
     if mesh.face_colors is not None and len(mesh.face_colors) == mesh.n_faces:
-        candidate.face_colors = mesh.face_colors[keep_faces]
+        candidate.face_colors = mesh.face_colors[np.asarray(unique_source_indices, dtype=int)]
+    return candidate
+
+
+def _boolean_mesh_repair_preserves_topology(candidate: Mesh, original_analysis) -> bool:
     candidate_analysis = analyze_mesh(candidate)
-    if (
+    return (
         candidate_analysis.degenerate_faces == 0
         and candidate_analysis.boundary_edges == original_analysis.boundary_edges
         and candidate_analysis.nonmanifold_edges == original_analysis.nonmanifold_edges
-    ):
-        return candidate
-    return mesh
+    )
 
 
 def _apply_boolean(
@@ -17622,6 +17675,168 @@ def _surface_boolean_ruled_unsupported_cutter_diagnostic(
     return None
 
 
+def _polygon_loft_cell_payload(
+    patch: RuledSurfacePatch,
+    *,
+    tolerance: float = 1e-8,
+) -> dict[str, object] | None:
+    """Return declarative volume data for one closed linear ruled loft cell."""
+
+    transform = np.asarray(patch.transform_matrix, dtype=float)
+    rotation = transform[:3, :3]
+    translation = transform[:3, 3]
+    start_curve = np.asarray(patch.start_curve, dtype=float) @ rotation.T + translation
+    end_curve = np.asarray(patch.end_curve, dtype=float) @ rotation.T + translation
+    if start_curve.shape != end_curve.shape or start_curve.ndim != 2 or start_curve.shape[0] < 4:
+        return None
+    if start_curve.shape[0] > 512:
+        return None
+
+    start_origin = np.mean(start_curve, axis=0)
+    end_origin = np.mean(end_curve, axis=0)
+    basis_u: np.ndarray | None = None
+    normal: np.ndarray | None = None
+    for first_index in range(start_curve.shape[0] - 2):
+        first_edge = start_curve[first_index + 1] - start_curve[first_index]
+        if float(np.linalg.norm(first_edge)) <= tolerance:
+            continue
+        for second_index in range(first_index + 1, start_curve.shape[0] - 1):
+            second_edge = start_curve[second_index + 1] - start_curve[second_index]
+            candidate_normal = np.cross(first_edge, second_edge)
+            candidate_norm = float(np.linalg.norm(candidate_normal))
+            if candidate_norm <= tolerance:
+                continue
+            basis_u = first_edge / float(np.linalg.norm(first_edge))
+            normal = candidate_normal / candidate_norm
+            break
+        if normal is not None:
+            break
+    if basis_u is None or normal is None:
+        return None
+    if float(np.max(np.abs((start_curve - start_origin) @ normal))) > tolerance:
+        return None
+    if float(np.max(np.abs((end_curve - end_origin) @ normal))) > tolerance:
+        return None
+    plane_span = float(np.dot(end_origin - start_origin, normal))
+    if abs(plane_span) <= tolerance:
+        return None
+    if plane_span < 0.0:
+        normal = -normal
+        plane_span = -plane_span
+    basis_v = np.cross(normal, basis_u)
+    basis_v_norm = float(np.linalg.norm(basis_v))
+    if basis_v_norm <= tolerance:
+        return None
+    basis_v /= basis_v_norm
+    return {
+        "start_curve": tuple(tuple(float(value) for value in point) for point in start_curve),
+        "end_curve": tuple(tuple(float(value) for value in point) for point in end_curve),
+        "normal": tuple(float(value) for value in normal),
+        "basis_u": tuple(float(value) for value in basis_u),
+        "basis_v": tuple(float(value) for value in basis_v),
+    }
+
+
+def _surface_body_polygon_loft_field_node(body: SurfaceBody) -> ImplicitFieldNode | None:
+    """Adapt one closed polygonal loft body to an exact declarative field graph."""
+
+    if _surface_body_loft_provenance(body) is None:
+        return None
+    cells: list[dict[str, object]] = []
+    for patch in body.iter_patches(world=True):
+        if not isinstance(patch, RuledSurfacePatch):
+            continue
+        kernel = patch.kernel_metadata()
+        loop_index = int(kernel.get("loop_index", 0) or 0)
+        if loop_index != 0:
+            return None
+        cell = _polygon_loft_cell_payload(patch)
+        if cell is None:
+            return None
+        cell["source_patch_id"] = patch.stable_identity
+        cell["branch_id"] = str(kernel.get("branch_id", ""))
+        cells.append(cell)
+        if len(cells) > 256:
+            return None
+    if not cells:
+        return None
+    return ImplicitFieldNode(
+        "polygon_loft_body",
+        parameters={"cells": tuple(cells)},
+    )
+
+
+def _surface_boolean_polygon_loft_field_result(
+    operands: SurfaceBooleanOperands,
+) -> SurfaceBooleanResult | None:
+    """Execute exact ruled polygon-loft difference as a closed implicit surface."""
+
+    if operands.operation != "difference" or operands.operand_count != 2:
+        return None
+    if _surface_boolean_body_relation(
+        operands.bodies[0].bounds_estimate(),
+        operands.bodies[1].bounds_estimate(),
+    ) in {"disjoint", "touching"}:
+        return None
+    roots = tuple(_surface_body_polygon_loft_field_node(body) for body in operands.bodies)
+    if any(root is None for root in roots):
+        return None
+    root = _compose_implicit_root(
+        "difference",
+        tuple(candidate for candidate in roots if candidate is not None),
+    )
+    metadata = _surface_boolean_result_metadata(operands)
+    decomposition = []
+    for operand_index, field_root in enumerate(roots):
+        assert field_root is not None
+        cells = field_root.parameters["cells"]
+        decomposition.append(
+            {
+                "operand_index": operand_index,
+                "source_body_id": operands.body_ids[operand_index],
+                "cell_count": len(cells),
+                "branch_ids": tuple(
+                    sorted({str(cell["branch_id"]) for cell in cells if str(cell["branch_id"])})
+                ),
+                "source_patch_ids": tuple(str(cell["source_patch_id"]) for cell in cells),
+                "execution": "declarative-cell-field-union",
+                "recomposition": "implicit-min-union",
+            }
+        )
+    route_payload = {
+        "operation": "difference",
+        "operand_ids": operands.body_ids,
+        "source_family": "polygon-loft",
+        "solver_path": "declarative-polygon-loft-field-difference",
+        "branching_base": int(_surface_body_loft_provenance(operands.bodies[0]).get("branch_count", 0) or 0) > 1,
+        "decomposition": tuple(decomposition),
+        "bounded_cell_limit": 256,
+        "bounded_points_per_cell_limit": 512,
+        "no_mesh_fallback": True,
+    }
+    metadata["kernel"]["boolean_surface_route"] = "surface-csg.polygon-loft-field"
+    metadata["kernel"]["polygon_loft_field_csg"] = route_payload
+    metadata["consumer"]["boolean_surface_route"] = "surface-csg.polygon-loft-field"
+    metadata["consumer"]["polygon_loft_field_csg"] = route_payload
+    patch = ImplicitSurfacePatch(
+        family="implicit",
+        field=root,
+        bounds=operands.bodies[0].bounds_estimate(),
+        metadata={"kernel": route_payload},
+    )
+    body = make_surface_body(
+        (
+            make_surface_shell(
+                (patch,),
+                connected=True,
+                metadata={"kernel": {"operation": "polygon-loft-field-difference"}},
+            ),
+        ),
+        metadata=metadata,
+    )
+    return _surface_boolean_finalize_body_result("difference", operands, body)
+
+
 def _surface_body_contains_exact(
     container: SurfaceBody,
     candidate: SurfaceBody,
@@ -20286,6 +20501,9 @@ def surface_boolean_result(
     sweep_subdivision_result = _surface_boolean_sweep_subdivision_body_route_result(operands)
     if sweep_subdivision_result is not None:
         return finish(sweep_subdivision_result, "surface-csg.sweep-subdivision")
+    polygon_loft_field_result = _surface_boolean_polygon_loft_field_result(operands)
+    if polygon_loft_field_result is not None:
+        return finish(polygon_loft_field_result, "surface-csg.polygon-loft-field")
     plan = plan_prepared_surface_csg_operation(operands)
     if not plan.executable:
         return finish(
@@ -20375,6 +20593,12 @@ def _surface_boolean_result_after_family_gate(
     if any(not isinstance(body, SurfaceBody) for body in bodies):
         return None
     raw_operands = SurfaceBooleanOperands(operation=operation, bodies=bodies)
+    if (
+        operation == "difference"
+        and len(bodies) == 2
+        and all(_surface_body_polygon_loft_field_node(body) is not None for body in bodies)
+    ):
+        return None
     gate = surface_csg_feature_gate(caller_id, operation, bodies)
     if gate.supported:
         return None

--- a/src/impression/modeling/surface.py
+++ b/src/impression/modeling/surface.py
@@ -4391,6 +4391,7 @@ ImplicitFieldNodeKind = Literal[
     "scale",
     "negate",
     "sampled_surface",
+    "polygon_loft_body",
 ]
 
 IMPLICIT_FIELD_NODE_KINDS: frozenset[str] = frozenset(
@@ -4407,6 +4408,7 @@ IMPLICIT_FIELD_NODE_KINDS: frozenset[str] = frozenset(
         "scale",
         "negate",
         "sampled_surface",
+        "polygon_loft_body",
     }
 )
 _IMPLICIT_EXECUTABLE_PARAMETER_NAMES = frozenset(
@@ -6206,6 +6208,17 @@ def _evaluate_implicit_field_value(node: ImplicitFieldNode, point: np.ndarray) -
             raise ValueError("sampled_surface.offset must be non-negative.")
         distances = np.linalg.norm(points - point, axis=1)
         return float(np.min(distances) - offset)
+    if node.kind == "polygon_loft_body":
+        cells_value = node.parameters.get("cells", ())
+        if not isinstance(cells_value, (tuple, list)) or not cells_value:
+            raise ValueError("polygon_loft_body.cells must contain one or more ruled loft cells.")
+        if len(cells_value) > 256:
+            raise ValueError("polygon_loft_body.cells exceeds the 256-cell safety limit.")
+        cell_values = tuple(
+            _evaluate_polygon_loft_cell(cell, point)
+            for cell in cells_value
+        )
+        return float(min(cell_values))
     if node.kind == "union":
         _require_child_count(node, minimum=1)
         return float(min(_evaluate_implicit_field_value(child, point) for child in node.children))
@@ -6231,6 +6244,78 @@ def _evaluate_implicit_field_value(node: ImplicitFieldNode, point: np.ndarray) -
         _require_child_count(node, minimum=1, maximum=1)
         return float(-_evaluate_implicit_field_value(node.children[0], point))
     raise ValueError(f"Unsupported implicit field node kind {node.kind!r}.")
+
+
+def _signed_distance_to_polygon_2d(point: np.ndarray, polygon: np.ndarray) -> float:
+    """Return a deterministic signed distance for one closed simple polygon."""
+
+    if polygon.ndim != 2 or polygon.shape[1] != 2 or polygon.shape[0] < 3:
+        raise ValueError("polygon loft cells require at least three 2D boundary points.")
+    if np.linalg.norm(polygon[0] - polygon[-1]) <= 1e-12:
+        polygon = polygon[:-1]
+    if polygon.shape[0] < 3:
+        raise ValueError("polygon loft cells require at least three distinct boundary points.")
+
+    minimum_distance = float("inf")
+    inside = False
+    px, py = float(point[0]), float(point[1])
+    previous = polygon[-1]
+    for current in polygon:
+        edge = current - previous
+        edge_length_squared = float(np.dot(edge, edge))
+        if edge_length_squared > 1e-24:
+            alpha = float(np.clip(np.dot(point - previous, edge) / edge_length_squared, 0.0, 1.0))
+            closest = previous + edge * alpha
+            minimum_distance = min(minimum_distance, float(np.linalg.norm(point - closest)))
+        x0, y0 = float(previous[0]), float(previous[1])
+        x1, y1 = float(current[0]), float(current[1])
+        crosses = (y0 > py) != (y1 > py)
+        if crosses:
+            x_crossing = x0 + ((py - y0) * (x1 - x0) / (y1 - y0))
+            if px < x_crossing:
+                inside = not inside
+        previous = current
+    return -minimum_distance if inside else minimum_distance
+
+
+def _evaluate_polygon_loft_cell(cell: object, point: np.ndarray) -> float:
+    """Evaluate one exact linear ruled-volume cell from declarative curve data."""
+
+    if not isinstance(cell, dict):
+        raise ValueError("polygon_loft_body cells must be mappings.")
+    start_curve = np.asarray(cell.get("start_curve", ()), dtype=float)
+    end_curve = np.asarray(cell.get("end_curve", ()), dtype=float)
+    if start_curve.shape[0] > 512:
+        raise ValueError("polygon_loft_body cells exceed the 512-point safety limit.")
+    normal = _normalize_axis(np.asarray(cell.get("normal", ()), dtype=float), name="polygon_loft_body.normal")
+    basis_u = _normalize_axis(np.asarray(cell.get("basis_u", ()), dtype=float), name="polygon_loft_body.basis_u")
+    basis_v = _normalize_axis(np.asarray(cell.get("basis_v", ()), dtype=float), name="polygon_loft_body.basis_v")
+    if start_curve.ndim != 2 or start_curve.shape[1] != 3 or start_curve.shape != end_curve.shape:
+        raise ValueError("polygon loft cell start/end curves must have matching Nx3 shapes.")
+    start_origin = np.mean(start_curve, axis=0)
+    end_origin = np.mean(end_curve, axis=0)
+    plane_span = float(np.dot(end_origin - start_origin, normal))
+    if abs(plane_span) <= 1e-12:
+        raise ValueError("polygon loft cell station planes must have non-zero separation.")
+    progression = float(np.dot(point - start_origin, normal) / plane_span)
+    interpolated = start_curve + ((end_curve - start_curve) * progression)
+    interpolated_origin = np.mean(interpolated, axis=0)
+    polygon = np.column_stack(
+        (
+            (interpolated - interpolated_origin) @ basis_u,
+            (interpolated - interpolated_origin) @ basis_v,
+        )
+    )
+    local_point = np.asarray(
+        (
+            float(np.dot(point - interpolated_origin, basis_u)),
+            float(np.dot(point - interpolated_origin, basis_v)),
+        ),
+        dtype=float,
+    )
+    profile_distance = _signed_distance_to_polygon_2d(local_point, polygon)
+    axial_distance = max(-progression * abs(plane_span), (progression - 1.0) * abs(plane_span))
+    return float(max(profile_distance, axial_distance))
 
 
 def evaluate_implicit_field_domain(

--- a/src/impression/modeling/tessellation.py
+++ b/src/impression/modeling/tessellation.py
@@ -676,6 +676,18 @@ def assert_implicit_tessellation_sampling_safety(
 
 
 def _implicit_patch_mesh(patch: ImplicitSurfacePatch, request: NormalizedTessellationRequest) -> Mesh:
+    polygon_loft_mesh = _polygon_loft_boolean_terminal_mesh(patch)
+    if polygon_loft_mesh is not None:
+        polygon_loft_mesh.metadata.update(
+            {
+                "surface_family": patch.family,
+                "surface_patch_id": patch.stable_identity,
+                "implicit_approximation_boundary": "tessellation",
+                "implicit_polygon_loft_extraction": "surface-authored-terminal-manifold",
+                "no_modeling_mesh_fallback": True,
+            }
+        )
+        return polygon_loft_mesh
     diagnostic = assert_implicit_tessellation_sampling_safety(patch, request)
     domain = ImplicitFieldEvaluationDomain(bounds=patch.bounds, samples=diagnostic.samples)
     values = patch.evaluate_domain(samples=diagnostic.samples)
@@ -756,6 +768,176 @@ def _implicit_patch_mesh(patch: ImplicitSurfacePatch, request: NormalizedTessell
             "implicit_approximation_boundary": "tessellation",
         },
     )
+
+
+def _polygon_loft_cell_terminal_mesh(cell: object) -> Mesh:
+    """Tessellate one declarative polygon-loft cell at the terminal boundary."""
+
+    if not isinstance(cell, dict):
+        raise ValueError("polygon loft tessellation cells must be mappings.")
+    start = np.asarray(cell.get("start_curve", ()), dtype=float)
+    end = np.asarray(cell.get("end_curve", ()), dtype=float)
+    basis_u = np.asarray(cell.get("basis_u", ()), dtype=float)
+    basis_v = np.asarray(cell.get("basis_v", ()), dtype=float)
+    if start.ndim != 2 or start.shape[1] != 3 or start.shape != end.shape or start.shape[0] < 4:
+        raise ValueError("polygon loft tessellation requires matching start/end Nx3 curves.")
+    if float(np.linalg.norm(start[0] - start[-1])) <= 1e-9:
+        start = start[:-1]
+        end = end[:-1]
+    keep = np.ones(start.shape[0], dtype=bool)
+    changed = True
+    while changed and int(np.count_nonzero(keep)) > 3:
+        changed = False
+        indices = np.flatnonzero(keep)
+        for offset, index in enumerate(indices):
+            previous = indices[offset - 1]
+            following = indices[(offset + 1) % len(indices)]
+            removable = True
+            for curve in (start, end):
+                before = curve[index] - curve[previous]
+                after = curve[following] - curve[index]
+                if float(np.linalg.norm(before)) <= 1e-10 or float(np.linalg.norm(after)) <= 1e-10:
+                    continue
+                if float(np.linalg.norm(np.cross(before, after))) > 1e-9:
+                    removable = False
+                    break
+                if float(np.dot(before, after)) < -1e-12:
+                    removable = False
+                    break
+            if removable:
+                keep[index] = False
+                changed = True
+                break
+    start = start[keep]
+    end = end[keep]
+    start_origin = np.mean(start, axis=0)
+    end_origin = np.mean(end, axis=0)
+    start_uv = np.column_stack(((start - start_origin) @ basis_u, (start - start_origin) @ basis_v))
+    end_uv = np.column_stack(((end - end_origin) @ basis_u, (end - end_origin) @ basis_v))
+    signed_area = 0.5 * float(
+        np.sum(start_uv[:, 0] * np.roll(start_uv[:, 1], -1) - np.roll(start_uv[:, 0], -1) * start_uv[:, 1])
+    )
+    if signed_area < 0.0:
+        start = start[::-1]
+        end = end[::-1]
+        start_uv = start_uv[::-1]
+        end_uv = end_uv[::-1]
+    start_faces = _triangulate_polygon_with_collinear_boundary(start_uv)
+    end_faces = _triangulate_polygon_with_collinear_boundary(end_uv)
+    count = start.shape[0]
+    faces: list[tuple[int, int, int]] = [
+        tuple(int(value) for value in face[::-1])
+        for face in start_faces
+    ]
+    faces.extend(
+        tuple(int(value) + count for value in face)
+        for face in end_faces
+    )
+    for index in range(count):
+        following = (index + 1) % count
+        faces.append((index, following, count + following))
+        faces.append((index, count + following, count + index))
+    return Mesh(
+        vertices=np.vstack((start, end)),
+        faces=np.asarray(faces, dtype=int),
+        metadata={"surface_family": "polygon-loft-cell"},
+    )
+
+
+def _triangulate_polygon_with_collinear_boundary(points: np.ndarray) -> np.ndarray:
+    """Triangulate a simple polygon while retaining every collinear boundary vertex."""
+
+    polygon = np.asarray(points, dtype=float)
+    keep = np.ones(polygon.shape[0], dtype=bool)
+    changed = True
+    while changed and int(np.count_nonzero(keep)) > 3:
+        changed = False
+        indices = np.flatnonzero(keep)
+        for offset, index in enumerate(indices):
+            previous = indices[offset - 1]
+            following = indices[(offset + 1) % len(indices)]
+            before = polygon[index] - polygon[previous]
+            after = polygon[following] - polygon[index]
+            if (
+                float(np.linalg.norm(before)) <= 1e-12
+                or float(np.linalg.norm(after)) <= 1e-12
+                or (
+                    abs(float(before[0] * after[1] - before[1] * after[0])) <= 1e-10
+                    and float(np.dot(before, after)) >= -1e-12
+                )
+            ):
+                keep[index] = False
+                changed = True
+                break
+    kept_indices = [int(index) for index in np.flatnonzero(keep)]
+    _vertices, simple_faces = triangulate_loops([polygon[kept_indices]])
+    faces = [tuple(kept_indices[int(index)] for index in face) for face in simple_faces]
+
+    def face_area(face: tuple[int, int, int]) -> float:
+        a, b, c = (polygon[index] for index in face)
+        return float((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]))
+
+    count = polygon.shape[0]
+    for kept_offset, start_index in enumerate(kept_indices):
+        end_index = kept_indices[(kept_offset + 1) % len(kept_indices)]
+        intermediates: list[int] = []
+        cursor = (start_index + 1) % count
+        while cursor != end_index:
+            intermediates.append(cursor)
+            cursor = (cursor + 1) % count
+        edge_start = start_index
+        for middle in intermediates:
+            face_index = next(
+                (
+                    index
+                    for index, face in enumerate(faces)
+                    if edge_start in face and end_index in face
+                ),
+                None,
+            )
+            if face_index is None:
+                raise ValueError("Could not retain a collinear polygon boundary vertex during triangulation.")
+            face = faces.pop(face_index)
+            opposite = next(index for index in face if index not in {edge_start, end_index})
+            orientation = np.sign(face_area(face))
+            first = (edge_start, middle, opposite)
+            second = (middle, end_index, opposite)
+            if np.sign(face_area(first)) != orientation:
+                first = (middle, edge_start, opposite)
+            if np.sign(face_area(second)) != orientation:
+                second = (end_index, middle, opposite)
+            faces.extend((first, second))
+            edge_start = middle
+    return np.asarray(faces, dtype=int)
+
+
+def _polygon_loft_body_terminal_mesh(node) -> Mesh:
+    if node.kind != "polygon_loft_body":
+        raise ValueError("polygon loft terminal extraction requires a polygon_loft_body node.")
+    cells = node.parameters.get("cells", ())
+    if not isinstance(cells, (tuple, list)) or not cells:
+        raise ValueError("polygon_loft_body.cells must be non-empty.")
+    cell_meshes = tuple(_polygon_loft_cell_terminal_mesh(cell) for cell in cells)
+    if len(cell_meshes) == 1:
+        return cell_meshes[0]
+    from .csg import _apply_boolean
+
+    return _apply_boolean(cell_meshes, "union")
+
+
+def _polygon_loft_boolean_terminal_mesh(patch: ImplicitSurfacePatch) -> Mesh | None:
+    root = patch.field
+    if root.kind != "difference" or len(root.children) < 2:
+        return None
+    if any(child.kind != "polygon_loft_body" for child in root.children):
+        return None
+    from .csg import _apply_boolean
+
+    operands = tuple(_polygon_loft_body_terminal_mesh(child) for child in root.children)
+    result = _apply_boolean(operands, "difference")
+    if not np.allclose(patch.transform_matrix, np.eye(4), atol=1e-12, rtol=0.0):
+        result = result.transformed(patch.transform_matrix)
+    return result
 
 
 @dataclass(frozen=True)

--- a/tests/test_surface_csg.py
+++ b/tests/test_surface_csg.py
@@ -11,7 +11,7 @@ import impression.modeling.csg as csg_module
 import numpy as np
 import pytest
 
-from impression.mesh import Mesh
+from impression.mesh import Mesh, analyze_mesh
 from impression.modeling.drawing2d import make_circle, make_rect
 from impression.modeling.tessellation import (
     export_tessellation_request,
@@ -46,6 +46,7 @@ from impression.modeling import (
     ImplicitCompositionOperandSignPolicy,
     ImplicitCompositionResult,
     ImplicitOperandFieldAdapterRecord,
+    ImplicitSurfacePatch,
     GeometryChangeWitness,
     NormalizedDifferenceEvidence,
     NURBSSurfacePatch,
@@ -59,6 +60,8 @@ from impression.modeling import (
     SurfaceBooleanOperands,
     SurfaceBooleanPatchRef,
     SurfaceBooleanResult,
+    Section,
+    Station,
     SurfaceDifferenceGateDecision,
     SurfaceBooleanSplitRecord,
     SurfaceBooleanTrimmedPatchFragment,
@@ -330,9 +333,12 @@ from impression.modeling import (
     make_box_mesh,
     make_cylinder,
     loft,
+    loft_sections,
     make_plane,
     make_sphere,
     make_surface_body,
+    as_section,
+    evaluate_implicit_field,
     make_surface_shell,
     normalize_surface_difference_evidence,
     normalize_surface_csg_operand_ordering,
@@ -2717,6 +2723,102 @@ def _offset_capped_loft_body() -> SurfaceBody:
     )
 
 
+def test_polygon_loft_difference_reconstructs_closed_rotated_result_shell() -> None:
+    base = loft(
+        [make_rect(size=(4.0, 4.0)), make_rect(size=(3.5, 3.5))],
+        path=[(0.0, 0.0, 0.0), (0.0, 0.0, 4.0)],
+        cap_ends=True,
+    )
+    cutter = loft(
+        [make_rect(size=(0.8, 5.0)), make_rect(size=(0.8, 5.0))],
+        path=[(0.0, 0.0, 0.5), (0.0, 0.0, 3.5)],
+        cap_ends=True,
+    )
+    angle = np.deg2rad(27.0)
+    cutter = cutter.with_transform(
+        np.asarray(
+            (
+                (np.cos(angle), -np.sin(angle), 0.0, 0.0),
+                (np.sin(angle), np.cos(angle), 0.0, 0.0),
+                (0.0, 0.0, 1.0, 0.0),
+                (0.0, 0.0, 0.0, 1.0),
+            )
+        )
+    )
+
+    result = boolean_difference(base, [cutter])
+
+    assert result.status == "succeeded"
+    assert result.classification == "closed"
+    assert result.body is not None
+    route = result.body.kernel_metadata()["polygon_loft_field_csg"]
+    assert route["solver_path"] == "declarative-polygon-loft-field-difference"
+    assert route["no_mesh_fallback"] is True
+    assert route["bounded_cell_limit"] == 256
+    assert route["bounded_points_per_cell_limit"] == 512
+    result_patch = result.body.iter_patches(world=True)[0]
+    assert isinstance(result_patch, ImplicitSurfacePatch)
+    assert evaluate_implicit_field(result_patch.field, (0.0, 0.0, 2.0)).value > 0.0
+    assert evaluate_implicit_field(result_patch.field, (1.5, 0.0, 2.0)).value < 0.0
+    tessellation = tessellate_surface_body(result.body, export_tessellation_request())
+    assert tessellation.analysis.is_watertight is True
+    assert tessellation.analysis.is_manifold is True
+    assert tessellation.analysis.degenerate_faces == 0
+
+
+def test_branching_polygon_loft_difference_executes_bounded_cells_and_recomposes() -> None:
+    def region(size: tuple[float, float], center: tuple[float, float]):
+        return as_section(make_rect(size=size, center=center)).regions[0]
+
+    source = Section(
+        (
+            region((0.85, 0.85), (-1.0, 0.0)),
+            region((0.85, 0.85), (1.0, 0.0)),
+        )
+    )
+    target = Section(
+        (
+            region((0.8, 0.8), (-1.0, 0.0)),
+            region((0.7, 0.7), (0.0, 0.0)),
+            region((0.8, 0.8), (1.0, 0.0)),
+        )
+    )
+    frame = {"u": (1.0, 0.0, 0.0), "v": (0.0, 1.0, 0.0), "n": (0.0, 0.0, 1.0)}
+    base = loft_sections(
+        (
+            Station(t=0.0, section=source, origin=(0.0, 0.0, 0.0), **frame),
+            Station(t=1.0, section=target, origin=(0.0, 0.0, 2.0), **frame),
+        ),
+        cap_ends=True,
+        split_merge_mode="resolve",
+        split_merge_steps=8,
+    )
+    cutter = loft(
+        [make_rect(size=(0.4, 3.0)), make_rect(size=(0.4, 3.0))],
+        path=[(0.0, 0.0, 0.5), (0.0, 0.0, 1.5)],
+        cap_ends=True,
+    )
+
+    result = boolean_difference(base, [cutter])
+
+    assert base.kernel_metadata()["branch_count"] > 1
+    assert result.status == "succeeded"
+    assert result.classification == "closed"
+    assert result.body is not None
+    route = result.body.kernel_metadata()["polygon_loft_field_csg"]
+    assert route["branching_base"] is True
+    assert route["no_mesh_fallback"] is True
+    assert len(route["decomposition"]) == 2
+    assert route["decomposition"][0]["cell_count"] > 1
+    assert route["decomposition"][0]["execution"] == "declarative-cell-field-union"
+    assert route["decomposition"][0]["recomposition"] == "implicit-min-union"
+    tessellation = tessellate_surface_body(result.body, export_tessellation_request())
+    analysis = analyze_mesh(tessellation.mesh)
+    assert analysis.is_watertight is True
+    assert analysis.is_manifold is True
+    assert analysis.degenerate_faces == 0
+
+
 def _assert_loft_primitive_result_metadata(result: SurfaceBooleanResult) -> None:
     assert result.body is not None
     metadata = result.body.kernel_metadata()["loft_primitive_csg"]
@@ -2796,12 +2898,15 @@ def test_surface_csg_executes_loft_pair_routes_without_mesh_fallback(operation: 
     assert route.loft_operand_indices == (0, 1)
     assert direct is not None
     assert direct.status == "succeeded"
-    assert result.status == ("invalid" if operation == "difference" else "succeeded")
+    assert result.status == "succeeded"
     if operation == "difference":
         assert result.difference_gate is not None
-        assert result.difference_gate.classification == "invalid"
-        assert result.classification is None
-        assert result.body is None
+        assert result.difference_gate.classification == "success"
+        assert result.classification == "closed"
+        assert result.body is not None
+        metadata = result.body.kernel_metadata()["polygon_loft_field_csg"]
+        assert metadata["solver_path"] == "declarative-polygon-loft-field-difference"
+        assert metadata["no_mesh_fallback"] is True
         return
     assert result.classification == "closed"
     assert result.body is not None


### PR DESCRIPTION
Completes the reopened Fix 08B/Fix 08C release gate for issue #248.

- executes bounded polygonal ruled-loft cells as declarative surface fields
- supports branching and world-transformed loft/loft difference through the public API
- confines manifold extraction to terminal preview/export tessellation
- repairs terminal collinear degeneracies only when topology is preserved
- corrects the external USB/acoustic fixtures to use uncut bases

Validation:
- 516 focused surface/CSG tests pass
- 1,783 full-suite tests pass at 82.9% coverage
- corrected external enclosure qualifier passes USB-C, acoustic, and rotated snap-pocket cases