### PR TITLE
Record v1.0.0a4 publication evidence

### DIFF
--- a/project/release-1.0.0a4/README.md
+++ b/project/release-1.0.0a4/README.md
@@ -1,7 +1,7 @@
 # Impression v1.0.0a4 Corrective Release Definition
 
 Date: 2026-08-04
-Status: Release Candidate Qualified Locally; Publication Pending
+Status: Published
 Issue set: [#242](https://github.com/kellyjanderson/Impression/issues/242) through [#248](https://github.com/kellyjanderson/Impression/issues/248)
 Base release: `v1.0.0a3`
 
@@ -113,3 +113,16 @@ built-artifact qualification.
 - Full configured coverage suite: 1,783 passed, 82.9% coverage.
 - Real visible preview smoke: transitive save reload and mtime-neutral `R`
   refresh both changed the rendered geometry; temporary fixtures were removed.
+- Published prerelease: [v1.0.0a4](https://github.com/kellyjanderson/Impression/releases/tag/v1.0.0a4).
+- Merged release commit: `3eed418c19640de40533f14ff3c3556d79406e49`.
+- Terminal release workflow:
+  [31342959431](https://github.com/kellyjanderson/Impression/actions/runs/31342959431);
+  test, exact-artifact qualification, publication, and published-metadata
+  verification passed.
+- Published artifact SHA-256 values:
+  - `impression-1.0.0a4-py3-none-any.whl`: `4559ab8dbe69ad1ad3d98d2b756ec28e69489ade504db616d66b8477c9b42ea3`
+  - `impression-1.0.0a4.tar.gz`: `763ed2239ecb26c84eecfd843643b94e19d76a45281254c10521aa3a560a472b`
+  - `impression-docs-v1.0.0a4.zip`: `c4094b5c422c16347fd2911eca3c6eb5ece4595f6839c2805343fbd67cf4fd81`
+- Independent post-publication download verification matched all three hashes;
+  the live wheel and sdist each passed fresh-environment version, STL export,
+  docs extraction, and `pip check` smoke tests.

--- a/project/release-1.0.0a4/planning/progression.md
+++ b/project/release-1.0.0a4/planning/progression.md
@@ -1,7 +1,7 @@
 # v1.0.0a4 Corrective Release Progression
 
 Date: 2026-08-04
-Status: Ready for implementation
+Status: Complete; v1.0.0a4 Published
 
 Only the 19 canonical implementation leaves and their paired canonical test
 specifications are executable anchors in this progression. Archived parents do
@@ -268,3 +268,19 @@ prerequisites are complete; the whole preceding wave need not finish first.
 - [x] Archive the eight superseded parent/intermediate specs.
 - [x] Update indexes and this progression to reference canonical children only.
 - [x] Record completed refinement in the request-scoped ledger and ACD conformance sections.
+
+## Release Evidence
+
+- Release: [v1.0.0a4](https://github.com/kellyjanderson/Impression/releases/tag/v1.0.0a4)
+- Merged release commit: `3eed418c19640de40533f14ff3c3556d79406e49`
+- Qualification run:
+  [31342959431](https://github.com/kellyjanderson/Impression/actions/runs/31342959431)
+  - test, qualify, publish, and published-metadata verification passed.
+- Published assets:
+  - `impression-1.0.0a4-py3-none-any.whl` - SHA-256 `4559ab8dbe69ad1ad3d98d2b756ec28e69489ade504db616d66b8477c9b42ea3`
+  - `impression-1.0.0a4.tar.gz` - SHA-256 `763ed2239ecb26c84eecfd843643b94e19d76a45281254c10521aa3a560a472b`
+  - `impression-docs-v1.0.0a4.zip` - SHA-256 `c4094b5c422c16347fd2911eca3c6eb5ece4595f6839c2805343fbd67cf4fd81`
+- Independent post-publication verification downloaded the three live assets,
+  matched their published digests, validated the docs ZIP, and passed separate
+  fresh-install wheel and sdist smokes with version, STL export, docs extraction,
+  and `pip check` coverage.


### PR DESCRIPTION
Closes the durable release record after successful publication of v1.0.0a4.

Records:
- live prerelease URL and exact merged commit
- successful test/qualify/publish/metadata workflow run
- SHA-256 digests for the three published assets
- independent downloads, docs ZIP validation, and separate fresh-install wheel/sdist smokes

Validation: `24 passed` (`tests/test_progression.py` and `tests/test_release_metadata.py`).